### PR TITLE
feat: Figma revisions batch (Mar 2026) — 11 revisions + template UX fixes

### DIFF
--- a/src/__tests__/inngest/auto-build-workshop.test.ts
+++ b/src/__tests__/inngest/auto-build-workshop.test.ts
@@ -17,7 +17,7 @@
 jest.mock("@/lib/db", () => ({
   db: {
     workshop: { findUnique: jest.fn(), update: jest.fn() },
-    landingPage: { findMany: jest.fn(), findUnique: jest.fn(), create: jest.fn() },
+    landingPage: { findMany: jest.fn(), findUnique: jest.fn(), create: jest.fn(), findFirst: jest.fn() },
     workflow: { findFirst: jest.fn() },
     workflowAssignment: { findUnique: jest.fn(), create: jest.fn() },
   },
@@ -137,6 +137,7 @@ function createStepRunForHappyPath(workshopOverrides: Record<string, unknown> = 
       (db.workflowAssignment.findUnique as jest.Mock).mockResolvedValueOnce(null);
       (db.workflowAssignment.create as jest.Mock).mockResolvedValueOnce({ id: "wa-post-001" });
     } else if (name === "update-status") {
+      (db.landingPage.findFirst as jest.Mock).mockResolvedValueOnce(null);
       (db.workshop.update as jest.Mock).mockResolvedValueOnce({ id: "ws-test-123" });
     }
     // "notify-coach" uses sendWorkshopBuiltEmail which is already mocked
@@ -269,6 +270,7 @@ describe("auto-build-workshop Inngest function", () => {
         } else if (name === "assign-post-event-workflow") {
           (db.workflow.findFirst as jest.Mock).mockResolvedValueOnce(null);
         } else if (name === "update-status") {
+          (db.landingPage.findFirst as jest.Mock).mockResolvedValueOnce(null);
           (db.workshop.update as jest.Mock).mockResolvedValueOnce({ id: "ws-test-123" });
         }
         return fn();
@@ -327,12 +329,15 @@ describe("auto-build-workshop Inngest function", () => {
         } else if (name === "fetch-workshop") {
           (db.workshop.findUnique as jest.Mock).mockResolvedValueOnce(createWorkshopRecord());
         } else if (name === "create-landing-pages") {
-          (db.landingPage.findMany as jest.Mock).mockResolvedValueOnce([]); // no templates
+          (db.landingPage.findMany as jest.Mock)
+            .mockResolvedValueOnce([]) // no category-matched templates
+            .mockResolvedValueOnce([]); // no global templates (fallback)
         } else if (name === "assign-pre-event-workflow") {
           (db.workflow.findFirst as jest.Mock).mockResolvedValueOnce(null);
         } else if (name === "assign-post-event-workflow") {
           (db.workflow.findFirst as jest.Mock).mockResolvedValueOnce(null);
         } else if (name === "update-status") {
+          (db.landingPage.findFirst as jest.Mock).mockResolvedValueOnce(null);
           (db.workshop.update as jest.Mock).mockResolvedValueOnce({ id: "ws-test-123" });
         }
         return fn();
@@ -369,6 +374,7 @@ describe("auto-build-workshop Inngest function", () => {
           (db.workflowAssignment.findUnique as jest.Mock).mockResolvedValueOnce(null);
           (db.workflowAssignment.create as jest.Mock).mockResolvedValueOnce({ id: "wa-002" });
         } else if (name === "update-status") {
+          (db.landingPage.findFirst as jest.Mock).mockResolvedValueOnce(null);
           (db.workshop.update as jest.Mock).mockResolvedValueOnce({ id: "ws-test-123" });
         }
         return fn();
@@ -403,6 +409,7 @@ describe("auto-build-workshop Inngest function", () => {
           (db.workflow.findFirst as jest.Mock).mockResolvedValueOnce(createPostEventWorkflow());
           (db.workflowAssignment.findUnique as jest.Mock).mockResolvedValueOnce({ id: "existing-wa-2" });
         } else if (name === "update-status") {
+          (db.landingPage.findFirst as jest.Mock).mockResolvedValueOnce(null);
           (db.workshop.update as jest.Mock).mockResolvedValueOnce({ id: "ws-test-123" });
         }
         return fn();
@@ -429,6 +436,7 @@ describe("auto-build-workshop Inngest function", () => {
         } else if (name === "assign-post-event-workflow") {
           (db.workflow.findFirst as jest.Mock).mockResolvedValueOnce(null);
         } else if (name === "update-status") {
+          (db.landingPage.findFirst as jest.Mock).mockResolvedValueOnce(null);
           (db.workshop.update as jest.Mock).mockResolvedValueOnce({ id: "ws-test-123" });
         }
         return fn();
@@ -470,6 +478,7 @@ describe("auto-build-workshop Inngest function", () => {
         } else if (name === "assign-post-event-workflow") {
           (db.workflow.findFirst as jest.Mock).mockResolvedValueOnce(null);
         } else if (name === "update-status") {
+          (db.landingPage.findFirst as jest.Mock).mockResolvedValueOnce(null);
           (db.workshop.update as jest.Mock).mockResolvedValueOnce({ id: "ws-test-123" });
         }
         return fn();

--- a/src/src/__tests__/api/landing-page-library.test.ts
+++ b/src/src/__tests__/api/landing-page-library.test.ts
@@ -1,0 +1,265 @@
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        status: init?.status || 200,
+        headers: init?.headers,
+      }),
+  },
+  NextRequest: class MockNextRequest extends Request {
+    nextUrl: URL;
+    constructor(input: string | URL, init?: RequestInit) {
+      super(input, init);
+      this.nextUrl = new URL(typeof input === "string" ? input : input.toString());
+    }
+  },
+}));
+
+jest.mock("@/lib/db", () => ({
+  db: {
+    landingPage: {
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      create: jest.fn(),
+    },
+    workshop: {
+      findUnique: jest.fn(),
+    },
+    coach: {
+      findUnique: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("@/lib/authorization", () => ({
+  getApiActor: jest.fn(),
+  isPrivilegedRole: (role: string) => role === "ADMIN" || role === "STAFF",
+  canManageCoachData: jest.fn(),
+}));
+
+jest.mock("@/lib/template-interpolation", () => ({
+  rewriteIdentityFields: jest.fn((content: string) => content),
+  buildWorkshopVariables: jest.fn().mockResolvedValue(null),
+}));
+
+import { GET } from "@/app/api/landing-pages/library/route";
+import { NextRequest } from "next/server";
+import { db } from "@/lib/db";
+import { getApiActor } from "@/lib/authorization";
+
+const adminActor = {
+  userId: "admin-1",
+  email: "admin@example.com",
+  role: "ADMIN",
+  coachId: null,
+};
+
+function buildRequest(url: string): Parameters<typeof GET>[0] {
+  return new NextRequest(url) as unknown as Parameters<typeof GET>[0];
+}
+
+function makeLibraryPage(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "lp-1",
+    template: "SOLO_LANDING",
+    status: "PUBLISHED",
+    slug: "test-workshop-solo-landing-abc123",
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-15T00:00:00.000Z"),
+    workshopId: "ws-1",
+    isActiveTemplate: false,
+    categoryId: null,
+    workshop: {
+      title: "Test Workshop",
+      workshopCode: "TWS-001",
+    },
+    ...overrides,
+  };
+}
+
+describe("Landing Page Library API - GET /api/landing-pages/library", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (db.landingPage.findMany as jest.Mock).mockResolvedValue([]);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    (getApiActor as jest.Mock).mockResolvedValue(null);
+
+    const response = await GET(buildRequest("http://localhost/api/landing-pages/library"));
+
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body.success).toBe(false);
+  });
+
+  it("returns 400 for an invalid template param", async () => {
+    (getApiActor as jest.Mock).mockResolvedValue(adminActor);
+
+    const response = await GET(
+      buildRequest("http://localhost/api/landing-pages/library?template=INVALID_TEMPLATE")
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe("Invalid template");
+  });
+
+  it("accepts THANK_YOU as a valid template (does not reject it)", async () => {
+    (getApiActor as jest.Mock).mockResolvedValue(adminActor);
+    (db.landingPage.findMany as jest.Mock).mockResolvedValue([]);
+
+    const response = await GET(
+      buildRequest("http://localhost/api/landing-pages/library?template=THANK_YOU")
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+  });
+
+  describe("activeOnly behavior", () => {
+    it("does NOT filter by isActiveTemplate when activeOnly=true (default)", async () => {
+      (getApiActor as jest.Mock).mockResolvedValue(adminActor);
+      (db.landingPage.findMany as jest.Mock).mockResolvedValue([makeLibraryPage()]);
+
+      await GET(buildRequest("http://localhost/api/landing-pages/library"));
+
+      const callArgs = (db.landingPage.findMany as jest.Mock).mock.calls[0][0];
+      expect(callArgs.where).not.toHaveProperty("isActiveTemplate");
+    });
+
+    it("does NOT filter by isActiveTemplate when activeOnly param is omitted", async () => {
+      (getApiActor as jest.Mock).mockResolvedValue(adminActor);
+      (db.landingPage.findMany as jest.Mock).mockResolvedValue([]);
+
+      await GET(buildRequest("http://localhost/api/landing-pages/library?template=SOLO_LANDING"));
+
+      const callArgs = (db.landingPage.findMany as jest.Mock).mock.calls[0][0];
+      expect(callArgs.where).not.toHaveProperty("isActiveTemplate");
+    });
+
+    it("filters isActiveTemplate=false when activeOnly=false", async () => {
+      (getApiActor as jest.Mock).mockResolvedValue(adminActor);
+      (db.landingPage.findMany as jest.Mock).mockResolvedValue([makeLibraryPage()]);
+
+      await GET(
+        buildRequest("http://localhost/api/landing-pages/library?activeOnly=false")
+      );
+
+      const callArgs = (db.landingPage.findMany as jest.Mock).mock.calls[0][0];
+      expect(callArgs.where).toHaveProperty("isActiveTemplate", false);
+    });
+
+    it("returns mapped data including new fields", async () => {
+      (getApiActor as jest.Mock).mockResolvedValue(adminActor);
+      (db.landingPage.findMany as jest.Mock).mockResolvedValue([
+        makeLibraryPage({ isActiveTemplate: false, categoryId: "cat-1" }),
+      ]);
+
+      const response = await GET(
+        buildRequest("http://localhost/api/landing-pages/library?activeOnly=false")
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.success).toBe(true);
+      expect(body.data[0]).toMatchObject({
+        id: "lp-1",
+        isActiveTemplate: false,
+        categoryId: "cat-1",
+        workshopCode: "TWS-001",
+        updatedAt: "2026-01-15T00:00:00.000Z",
+        editPath: "/workshops/ws-1/landing-pages/solo-landing",
+      });
+    });
+  });
+
+  describe("categoryId filter", () => {
+    it("does NOT add OR filter when activeOnly=true and categoryId provided", async () => {
+      (getApiActor as jest.Mock).mockResolvedValue(adminActor);
+      (db.landingPage.findMany as jest.Mock).mockResolvedValue([]);
+
+      await GET(
+        buildRequest(
+          "http://localhost/api/landing-pages/library?categoryId=cat-99"
+        )
+      );
+
+      const callArgs = (db.landingPage.findMany as jest.Mock).mock.calls[0][0];
+      expect(callArgs.where).not.toHaveProperty("OR");
+    });
+
+    it("adds OR filter for categoryId OR null when activeOnly=false and categoryId provided", async () => {
+      (getApiActor as jest.Mock).mockResolvedValue(adminActor);
+      (db.landingPage.findMany as jest.Mock).mockResolvedValue([]);
+
+      await GET(
+        buildRequest(
+          "http://localhost/api/landing-pages/library?activeOnly=false&categoryId=cat-42"
+        )
+      );
+
+      const callArgs = (db.landingPage.findMany as jest.Mock).mock.calls[0][0];
+      expect(callArgs.where.OR).toEqual([{ categoryId: "cat-42" }, { categoryId: null }]);
+    });
+
+    it("does NOT add OR filter when activeOnly=false but no categoryId", async () => {
+      (getApiActor as jest.Mock).mockResolvedValue(adminActor);
+      (db.landingPage.findMany as jest.Mock).mockResolvedValue([]);
+
+      await GET(
+        buildRequest("http://localhost/api/landing-pages/library?activeOnly=false")
+      );
+
+      const callArgs = (db.landingPage.findMany as jest.Mock).mock.calls[0][0];
+      expect(callArgs.where).not.toHaveProperty("OR");
+    });
+  });
+
+  describe("toTemplateEditorPath fix (THANK_YOU → thank-you)", () => {
+    it("generates correct editPath for THANK_YOU template", async () => {
+      (getApiActor as jest.Mock).mockResolvedValue(adminActor);
+      (db.landingPage.findMany as jest.Mock).mockResolvedValue([
+        makeLibraryPage({ template: "THANK_YOU" }),
+      ]);
+
+      const response = await GET(
+        buildRequest("http://localhost/api/landing-pages/library?template=THANK_YOU")
+      );
+
+      const body = await response.json();
+      expect(body.data[0].editPath).toBe("/workshops/ws-1/landing-pages/thank-you");
+    });
+
+    it("generates correct editPath for SOLO_LANDING template", async () => {
+      (getApiActor as jest.Mock).mockResolvedValue(adminActor);
+      (db.landingPage.findMany as jest.Mock).mockResolvedValue([
+        makeLibraryPage({ template: "SOLO_LANDING" }),
+      ]);
+
+      const response = await GET(
+        buildRequest("http://localhost/api/landing-pages/library?template=SOLO_LANDING")
+      );
+
+      const body = await response.json();
+      expect(body.data[0].editPath).toBe("/workshops/ws-1/landing-pages/solo-landing");
+    });
+  });
+
+  it("returns empty data for non-privileged actors without coachId", async () => {
+    (getApiActor as jest.Mock).mockResolvedValue({
+      userId: "user-1",
+      email: "user@example.com",
+      role: "VIEWER",
+      coachId: null,
+    });
+
+    const response = await GET(buildRequest("http://localhost/api/landing-pages/library"));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data).toEqual([]);
+  });
+});

--- a/src/src/__tests__/api/landing-pages-id-route.test.ts
+++ b/src/src/__tests__/api/landing-pages-id-route.test.ts
@@ -289,6 +289,95 @@ describe("PATCH /api/landing-pages/[id]", () => {
     });
   });
 
+  it("categoryId-only PATCH on currently-active page triggers deactivation transaction", async () => {
+    // An already-active page being re-scoped to a new category should atomically deactivate
+    // any competing active template in the new slot — even when isActiveTemplate is not in the payload.
+    (getApiActor as jest.Mock).mockResolvedValue(adminActor);
+    (db.landingPage.findUnique as jest.Mock).mockResolvedValue({
+      id: "page-4",
+      template: "WORKSHOP",
+      categoryId: "cat-old",
+      isActiveTemplate: true, // page is currently active
+    });
+
+    const rescoped = {
+      id: "page-4",
+      template: "WORKSHOP",
+      categoryId: "cat-new",
+      isActiveTemplate: true,
+    };
+    (db.$transaction as jest.Mock).mockResolvedValue([{ count: 1 }, rescoped]);
+
+    const response = await PATCH(
+      buildPatchRequest({ categoryId: "cat-new" }), // no isActiveTemplate in payload
+      routeParams("page-4")
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.page.categoryId).toBe("cat-new");
+
+    // Must use transaction (not a plain update) to deactivate competitors in the new slot
+    expect(db.$transaction).toHaveBeenCalledTimes(1);
+
+    // updateMany should target the NEW category slot to clear competitors
+    expect(db.landingPage.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          categoryId: "cat-new",
+          template: "WORKSHOP",
+          isActiveTemplate: true,
+          id: { not: "page-4" },
+        }),
+      })
+    );
+
+    // update should persist the new categoryId
+    expect(db.landingPage.update).toHaveBeenCalledWith({
+      where: { id: "page-4" },
+      data: { categoryId: "cat-new" },
+    });
+
+    // No direct (non-transaction) update call
+    expect(db.landingPage.update).toHaveBeenCalledTimes(1);
+  });
+
+  it("categoryId-only PATCH on inactive page does NOT trigger transaction", async () => {
+    // An inactive page being re-scoped should not run the deactivation transaction.
+    (getApiActor as jest.Mock).mockResolvedValue(adminActor);
+    (db.landingPage.findUnique as jest.Mock).mockResolvedValue({
+      id: "page-5",
+      template: "WORKSHOP",
+      categoryId: "cat-old",
+      isActiveTemplate: false, // page is currently inactive
+    });
+
+    const updated = {
+      id: "page-5",
+      template: "WORKSHOP",
+      categoryId: "cat-new",
+      isActiveTemplate: false,
+    };
+    (db.landingPage.update as jest.Mock).mockResolvedValue(updated);
+
+    const response = await PATCH(
+      buildPatchRequest({ categoryId: "cat-new" }), // no isActiveTemplate in payload
+      routeParams("page-5")
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.page.categoryId).toBe("cat-new");
+
+    // No transaction needed for an inactive page re-scope
+    expect(db.$transaction).not.toHaveBeenCalled();
+    expect(db.landingPage.update).toHaveBeenCalledWith({
+      where: { id: "page-5" },
+      data: { categoryId: "cat-new" },
+    });
+  });
+
   it("returns 400 for invalid payload", async () => {
     (getApiActor as jest.Mock).mockResolvedValue(adminActor);
 

--- a/src/src/__tests__/api/landing-pages-id-route.test.ts
+++ b/src/src/__tests__/api/landing-pages-id-route.test.ts
@@ -12,8 +12,11 @@ jest.mock("@/lib/db", () => ({
   db: {
     landingPage: {
       findUnique: jest.fn(),
+      update: jest.fn(),
+      updateMany: jest.fn(),
       delete: jest.fn(),
     },
+    $transaction: jest.fn(),
   },
 }));
 
@@ -22,7 +25,7 @@ jest.mock("@/lib/authorization", () => ({
   isPrivilegedRole: (role: string) => role === "ADMIN" || role === "STAFF",
 }));
 
-import { DELETE } from "@/app/api/landing-pages/[id]/route";
+import { DELETE, PATCH } from "@/app/api/landing-pages/[id]/route";
 import { db } from "@/lib/db";
 import { getApiActor } from "@/lib/authorization";
 
@@ -35,6 +38,24 @@ function buildDeleteRequest(): Parameters<typeof DELETE>[0] {
     method: "DELETE",
   }) as unknown as Parameters<typeof DELETE>[0];
 }
+
+function buildPatchRequest(
+  body: Record<string, unknown>,
+  id = "page-1"
+): Parameters<typeof PATCH>[0] {
+  return new Request(`http://localhost/api/landing-pages/${id}`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  }) as unknown as Parameters<typeof PATCH>[0];
+}
+
+const adminActor = {
+  userId: "admin-user",
+  email: "admin@example.com",
+  role: "ADMIN",
+  coachId: null,
+};
 
 describe("DELETE /api/landing-pages/[id]", () => {
   beforeEach(() => {
@@ -59,12 +80,7 @@ describe("DELETE /api/landing-pages/[id]", () => {
   });
 
   it("blocks deletion of active template pages", async () => {
-    (getApiActor as jest.Mock).mockResolvedValue({
-      userId: "admin-user",
-      email: "admin@example.com",
-      role: "ADMIN",
-      coachId: null,
-    });
+    (getApiActor as jest.Mock).mockResolvedValue(adminActor);
     (db.landingPage.findUnique as jest.Mock).mockResolvedValue({
       id: "page-1",
       isActiveTemplate: true,
@@ -79,12 +95,7 @@ describe("DELETE /api/landing-pages/[id]", () => {
   });
 
   it("deletes non-active pages for admins", async () => {
-    (getApiActor as jest.Mock).mockResolvedValue({
-      userId: "admin-user",
-      email: "admin@example.com",
-      role: "ADMIN",
-      coachId: null,
-    });
+    (getApiActor as jest.Mock).mockResolvedValue(adminActor);
     (db.landingPage.findUnique as jest.Mock).mockResolvedValue({
       id: "page-1",
       isActiveTemplate: false,
@@ -99,5 +110,195 @@ describe("DELETE /api/landing-pages/[id]", () => {
     expect(db.landingPage.delete).toHaveBeenCalledWith({
       where: { id: "page-1" },
     });
+  });
+});
+
+describe("PATCH /api/landing-pages/[id]", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    (getApiActor as jest.Mock).mockResolvedValue(null);
+
+    const response = await PATCH(
+      buildPatchRequest({ isActiveTemplate: true }),
+      routeParams("page-1")
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe("Authentication required");
+  });
+
+  it("returns 403 for non-admin users", async () => {
+    (getApiActor as jest.Mock).mockResolvedValue({
+      userId: "coach-user",
+      email: "coach@example.com",
+      role: "COACH",
+      coachId: "coach-1",
+    });
+
+    const response = await PATCH(
+      buildPatchRequest({ isActiveTemplate: true }),
+      routeParams("page-1")
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error).toBe("Forbidden");
+  });
+
+  it("returns 404 when page does not exist", async () => {
+    (getApiActor as jest.Mock).mockResolvedValue(adminActor);
+    (db.landingPage.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const response = await PATCH(
+      buildPatchRequest({ isActiveTemplate: true }),
+      routeParams("nonexistent")
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.error).toBe("Landing page not found");
+  });
+
+  it("uses $transaction to deactivate competing template when activating", async () => {
+    (getApiActor as jest.Mock).mockResolvedValue(adminActor);
+    (db.landingPage.findUnique as jest.Mock).mockResolvedValue({
+      id: "page-1",
+      template: "WORKSHOP",
+      categoryId: null,
+      isActiveTemplate: false,
+    });
+
+    const activatedPage = {
+      id: "page-1",
+      template: "WORKSHOP",
+      categoryId: null,
+      isActiveTemplate: true,
+    };
+
+    // $transaction receives an array and returns an array; we return [{count:1}, activatedPage]
+    (db.$transaction as jest.Mock).mockResolvedValue([{ count: 1 }, activatedPage]);
+
+    const response = await PATCH(
+      buildPatchRequest({ isActiveTemplate: true }),
+      routeParams("page-1")
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.page).toEqual(activatedPage);
+
+    // $transaction should have been called with the array of operations
+    expect(db.$transaction).toHaveBeenCalledTimes(1);
+
+    // Building the transaction array invokes both db methods to construct their promise arguments
+    // The updateMany call inside the transaction should target the same slot
+    expect(db.landingPage.updateMany).toHaveBeenCalledWith({
+      where: {
+        template: "WORKSHOP",
+        categoryId: null,
+        isActiveTemplate: true,
+        id: { not: "page-1" },
+      },
+      data: { isActiveTemplate: false },
+    });
+
+    // The update call should activate the target page (no categoryId change since none provided)
+    expect(db.landingPage.update).toHaveBeenCalledWith({
+      where: { id: "page-1" },
+      data: { isActiveTemplate: true },
+    });
+  });
+
+  it("re-scopes page to a new categoryId when provided with isActiveTemplate: true", async () => {
+    (getApiActor as jest.Mock).mockResolvedValue(adminActor);
+    (db.landingPage.findUnique as jest.Mock).mockResolvedValue({
+      id: "page-2",
+      template: "WORKSHOP",
+      categoryId: null, // currently global
+      isActiveTemplate: false,
+    });
+
+    const activatedPage = {
+      id: "page-2",
+      template: "WORKSHOP",
+      categoryId: "cat-abc",
+      isActiveTemplate: true,
+    };
+    (db.$transaction as jest.Mock).mockResolvedValue([{ count: 0 }, activatedPage]);
+
+    const response = await PATCH(
+      buildPatchRequest({ isActiveTemplate: true, categoryId: "cat-abc" }),
+      routeParams("page-2")
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.page.categoryId).toBe("cat-abc");
+
+    // The updateMany should use the NEW categoryId as the slot filter
+    expect(db.landingPage.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ categoryId: "cat-abc" }),
+      })
+    );
+
+    // The update should persist the new categoryId
+    expect(db.landingPage.update).toHaveBeenCalledWith({
+      where: { id: "page-2" },
+      data: { isActiveTemplate: true, categoryId: "cat-abc" },
+    });
+  });
+
+  it("performs simple update (no transaction) when isActiveTemplate is false", async () => {
+    (getApiActor as jest.Mock).mockResolvedValue(adminActor);
+    (db.landingPage.findUnique as jest.Mock).mockResolvedValue({
+      id: "page-3",
+      template: "WORKSHOP",
+      categoryId: null,
+      isActiveTemplate: true,
+    });
+
+    const deactivatedPage = {
+      id: "page-3",
+      template: "WORKSHOP",
+      categoryId: null,
+      isActiveTemplate: false,
+    };
+    (db.landingPage.update as jest.Mock).mockResolvedValue(deactivatedPage);
+
+    const response = await PATCH(
+      buildPatchRequest({ isActiveTemplate: false }),
+      routeParams("page-3")
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.page.isActiveTemplate).toBe(false);
+
+    // No transaction — direct update
+    expect(db.$transaction).not.toHaveBeenCalled();
+    expect(db.landingPage.update).toHaveBeenCalledWith({
+      where: { id: "page-3" },
+      data: { isActiveTemplate: false },
+    });
+  });
+
+  it("returns 400 for invalid payload", async () => {
+    (getApiActor as jest.Mock).mockResolvedValue(adminActor);
+
+    const response = await PATCH(
+      buildPatchRequest({ isActiveTemplate: "yes" }), // should be boolean
+      routeParams("page-1")
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("Validation error");
   });
 });

--- a/src/src/__tests__/api/landing-pages-id-route.test.ts
+++ b/src/src/__tests__/api/landing-pages-id-route.test.ts
@@ -179,8 +179,12 @@ describe("PATCH /api/landing-pages/[id]", () => {
       isActiveTemplate: true,
     };
 
-    // $transaction receives an array and returns an array; we return [{count:1}, activatedPage]
-    (db.$transaction as jest.Mock).mockResolvedValue([{ count: 1 }, activatedPage]);
+    // Interactive transaction: invoke the callback with the db mock as the tx proxy
+    (db.$transaction as jest.Mock).mockImplementation(async (fn: (tx: typeof db) => Promise<unknown>) => {
+      (db.landingPage.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+      (db.landingPage.update as jest.Mock).mockResolvedValue(activatedPage);
+      return fn(db);
+    });
 
     const response = await PATCH(
       buildPatchRequest({ isActiveTemplate: true }),
@@ -192,10 +196,9 @@ describe("PATCH /api/landing-pages/[id]", () => {
     expect(body.success).toBe(true);
     expect(body.page).toEqual(activatedPage);
 
-    // $transaction should have been called with the array of operations
+    // $transaction should have been called once with a callback
     expect(db.$transaction).toHaveBeenCalledTimes(1);
 
-    // Building the transaction array invokes both db methods to construct their promise arguments
     // The updateMany call inside the transaction should target the same slot
     expect(db.landingPage.updateMany).toHaveBeenCalledWith({
       where: {
@@ -229,7 +232,11 @@ describe("PATCH /api/landing-pages/[id]", () => {
       categoryId: "cat-abc",
       isActiveTemplate: true,
     };
-    (db.$transaction as jest.Mock).mockResolvedValue([{ count: 0 }, activatedPage]);
+    (db.$transaction as jest.Mock).mockImplementation(async (fn: (tx: typeof db) => Promise<unknown>) => {
+      (db.landingPage.updateMany as jest.Mock).mockResolvedValue({ count: 0 });
+      (db.landingPage.update as jest.Mock).mockResolvedValue(activatedPage);
+      return fn(db);
+    });
 
     const response = await PATCH(
       buildPatchRequest({ isActiveTemplate: true, categoryId: "cat-abc" }),
@@ -306,7 +313,11 @@ describe("PATCH /api/landing-pages/[id]", () => {
       categoryId: "cat-new",
       isActiveTemplate: true,
     };
-    (db.$transaction as jest.Mock).mockResolvedValue([{ count: 1 }, rescoped]);
+    (db.$transaction as jest.Mock).mockImplementation(async (fn: (tx: typeof db) => Promise<unknown>) => {
+      (db.landingPage.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+      (db.landingPage.update as jest.Mock).mockResolvedValue(rescoped);
+      return fn(db);
+    });
 
     const response = await PATCH(
       buildPatchRequest({ categoryId: "cat-new" }), // no isActiveTemplate in payload

--- a/src/src/__tests__/api/registrations-route.test.ts
+++ b/src/src/__tests__/api/registrations-route.test.ts
@@ -108,7 +108,10 @@ describe("DELETE /api/registrations/[id]", () => {
       stripePaymentId: "pi_123",
     });
 
-    const response = await DELETE({} as Parameters<typeof DELETE>[0], routeParams());
+    const mockRequest = {
+      nextUrl: { searchParams: new URLSearchParams() },
+    } as unknown as Parameters<typeof DELETE>[0];
+    const response = await DELETE(mockRequest, routeParams());
     const body = await response.json();
 
     expect(response.status).toBe(200);

--- a/src/src/__tests__/inngest/auto-build-workshop.test.ts
+++ b/src/src/__tests__/inngest/auto-build-workshop.test.ts
@@ -826,4 +826,38 @@ describe("autoBuildWorkshop Inngest function", () => {
     expect(db.landingPage.create).toHaveBeenCalledTimes(2);
     expect(result.pagesCreated).toBe(2);
   });
+
+  // ---- 22. Deduplication is order-independent ----
+  it("deduplication correctly selects category-specific template regardless of array order", async () => {
+    // Reverse order from test 19: category-specific first, then global
+    const catSolo = { id: "tpl-cat-solo-rev", template: "SOLO_LANDING", content: '{"title":"Cat Solo Rev"}', slug: "cat-solo-rev", categoryId: "cat-1" };
+    const globalSolo = { id: "tpl-global-solo-rev", template: "SOLO_LANDING", content: '{"title":"Global Solo Rev"}', slug: "global-solo-rev", categoryId: null };
+
+    (db.landingPage.findMany as jest.Mock)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([catSolo, globalSolo]); // category-specific FIRST
+
+    (db.workshop.findUnique as jest.Mock)
+      .mockResolvedValueOnce({ status: "AWAITING_APPROVAL" })
+      .mockResolvedValueOnce(mockWorkshop);
+
+    (db.landingPage.findUnique as jest.Mock).mockResolvedValue(null);
+    (db.landingPage.create as jest.Mock).mockResolvedValue({});
+    (db.workflow.findFirst as jest.Mock)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+    (db.landingPage.findFirst as jest.Mock).mockResolvedValue(null);
+    (db.workshop.update as jest.Mock).mockResolvedValue({});
+    (sendWorkshopBuiltEmail as jest.Mock).mockResolvedValue(undefined);
+
+    await capturedHandler({ event: makeEvent(), step: mockStep });
+
+    // Still only 1 page created (dedup removes global), using category-specific content
+    expect(db.landingPage.create).toHaveBeenCalledTimes(1);
+    expect(db.landingPage.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ content: '{"title":"Cat Solo Rev"}' }),
+      })
+    );
+  });
 });

--- a/src/src/__tests__/inngest/auto-build-workshop.test.ts
+++ b/src/src/__tests__/inngest/auto-build-workshop.test.ts
@@ -736,4 +736,94 @@ describe("autoBuildWorkshop Inngest function", () => {
       })
     );
   });
+
+  // ---- 19. Category-specific template wins over global for same template type ----
+  it("prefers category-specific template over global when both exist for the same template type", async () => {
+    const globalSolo = { id: "tpl-global-solo", template: "SOLO_LANDING", content: '{"title":"Global Solo"}', slug: "global-solo", categoryId: null };
+    const catSolo = { id: "tpl-cat-solo", template: "SOLO_LANDING", content: '{"title":"Cat Solo"}', slug: "cat-solo", categoryId: "cat-1" };
+
+    (db.landingPage.findMany as jest.Mock)
+      .mockResolvedValueOnce([])  // idempotency
+      .mockResolvedValueOnce([globalSolo, catSolo]); // findMany returns both
+
+    (db.workshop.findUnique as jest.Mock)
+      .mockResolvedValueOnce({ status: "AWAITING_APPROVAL" })
+      .mockResolvedValueOnce(mockWorkshop); // has categoryId: "cat-1"
+
+    (db.landingPage.findUnique as jest.Mock).mockResolvedValue(null);
+    (db.landingPage.create as jest.Mock).mockResolvedValue({});
+    (db.workflow.findFirst as jest.Mock)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+    (db.landingPage.findFirst as jest.Mock).mockResolvedValue(null);
+    (db.workshop.update as jest.Mock).mockResolvedValue({});
+    (sendWorkshopBuiltEmail as jest.Mock).mockResolvedValue(undefined);
+
+    await capturedHandler({ event: makeEvent(), step: mockStep });
+
+    // Only 1 page created (deduplication removed the duplicate), from the category-specific template
+    expect(db.landingPage.create).toHaveBeenCalledTimes(1);
+    expect(db.landingPage.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ content: '{"title":"Cat Solo"}' }),
+      })
+    );
+  });
+
+  // ---- 20. Global template used as fallback when no category-specific exists ----
+  it("uses global template as fallback when no category-specific template exists", async () => {
+    const globalReg = { id: "tpl-global-reg", template: "REGISTRATION", content: '{"form":"global"}', slug: "global-reg", categoryId: null };
+
+    (db.landingPage.findMany as jest.Mock)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([globalReg]);
+
+    (db.workshop.findUnique as jest.Mock)
+      .mockResolvedValueOnce({ status: "AWAITING_APPROVAL" })
+      .mockResolvedValueOnce(mockWorkshop);
+
+    (db.landingPage.findUnique as jest.Mock).mockResolvedValue(null);
+    (db.landingPage.create as jest.Mock).mockResolvedValue({});
+    (db.workflow.findFirst as jest.Mock)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+    (db.landingPage.findFirst as jest.Mock).mockResolvedValue(null);
+    (db.workshop.update as jest.Mock).mockResolvedValue({});
+    (sendWorkshopBuiltEmail as jest.Mock).mockResolvedValue(undefined);
+
+    const result = await capturedHandler({ event: makeEvent(), step: mockStep });
+
+    expect(db.landingPage.create).toHaveBeenCalledTimes(1);
+    expect(result.pagesCreated).toBe(1);
+    expect(result.status).toBe("PRE_EVENT");
+  });
+
+  // ---- 21. Different template types from different scopes both used ----
+  it("uses both category-specific and global templates when they are for different template types", async () => {
+    const catSolo = { id: "tpl-cat-solo", template: "SOLO_LANDING", content: '{"c":"cat"}', slug: "cat-solo", categoryId: "cat-1" };
+    const globalReg = { id: "tpl-global-reg", template: "REGISTRATION", content: '{"f":"global"}', slug: "global-reg", categoryId: null };
+
+    (db.landingPage.findMany as jest.Mock)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([catSolo, globalReg]);
+
+    (db.workshop.findUnique as jest.Mock)
+      .mockResolvedValueOnce({ status: "AWAITING_APPROVAL" })
+      .mockResolvedValueOnce(mockWorkshop);
+
+    (db.landingPage.findUnique as jest.Mock).mockResolvedValue(null);
+    (db.landingPage.create as jest.Mock).mockResolvedValue({});
+    (db.workflow.findFirst as jest.Mock)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+    (db.landingPage.findFirst as jest.Mock).mockResolvedValue(null);
+    (db.workshop.update as jest.Mock).mockResolvedValue({});
+    (sendWorkshopBuiltEmail as jest.Mock).mockResolvedValue(undefined);
+
+    const result = await capturedHandler({ event: makeEvent(), step: mockStep });
+
+    // Both pages created (different types, no dedup needed)
+    expect(db.landingPage.create).toHaveBeenCalledTimes(2);
+    expect(result.pagesCreated).toBe(2);
+  });
 });

--- a/src/src/__tests__/inngest/auto-build-workshop.test.ts
+++ b/src/src/__tests__/inngest/auto-build-workshop.test.ts
@@ -26,6 +26,7 @@ jest.mock("@/lib/db", () => ({
     landingPage: {
       findMany: jest.fn(),
       findUnique: jest.fn(),
+      findFirst: jest.fn(),
       create: jest.fn(),
     },
     workflow: {
@@ -160,6 +161,9 @@ function setupHappyPath() {
     .mockResolvedValueOnce({ id: "assign-pre-1" })
     .mockResolvedValueOnce({ id: "assign-post-1" });
 
+  // SOLO_LANDING slug lookup (update-status step)
+  (db.landingPage.findFirst as jest.Mock).mockResolvedValue(null);
+
   // Status update
   (db.workshop.update as jest.Mock).mockResolvedValue({});
 
@@ -261,6 +265,7 @@ describe("autoBuildWorkshop Inngest function", () => {
     (db.workflowAssignment.create as jest.Mock)
       .mockResolvedValueOnce({ id: "assign-pre-1" })
       .mockResolvedValueOnce({ id: "assign-post-1" });
+    (db.landingPage.findFirst as jest.Mock).mockResolvedValue(null);
     (db.workshop.update as jest.Mock).mockResolvedValue({});
     (sendWorkshopBuiltEmail as jest.Mock).mockResolvedValue(undefined);
     (inngest.send as jest.Mock).mockResolvedValue(undefined);
@@ -385,6 +390,7 @@ describe("autoBuildWorkshop Inngest function", () => {
     (db.workflowAssignment.create as jest.Mock)
       .mockResolvedValueOnce({ id: "assign-pre-1" })
       .mockResolvedValueOnce({ id: "assign-post-1" });
+    (db.landingPage.findFirst as jest.Mock).mockResolvedValue(null);
     (db.workshop.update as jest.Mock).mockResolvedValue({});
     (sendWorkshopBuiltEmail as jest.Mock).mockResolvedValue(undefined);
     (inngest.send as jest.Mock).mockResolvedValue(undefined);
@@ -505,6 +511,7 @@ describe("autoBuildWorkshop Inngest function", () => {
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(null);
 
+    (db.landingPage.findFirst as jest.Mock).mockResolvedValue(null);
     (db.workshop.update as jest.Mock).mockResolvedValue({});
     (sendWorkshopBuiltEmail as jest.Mock).mockResolvedValue(undefined);
 
@@ -656,6 +663,7 @@ describe("autoBuildWorkshop Inngest function", () => {
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(null);
 
+    (db.landingPage.findFirst as jest.Mock).mockResolvedValue(null);
     (db.workshop.update as jest.Mock).mockResolvedValue({});
     (sendWorkshopBuiltEmail as jest.Mock).mockResolvedValue(undefined);
 

--- a/src/src/app/(dashboard)/templates/page.tsx
+++ b/src/src/app/(dashboard)/templates/page.tsx
@@ -229,7 +229,7 @@ export default async function TemplatesPage({ searchParams }: TemplatesPageProps
                         </p>
                       ) : (
                         // State 3: No template at all (or on All tab with nothing)
-                        <p className="mt-2 text-xs text-amber-600 dark:text-amber-500">
+                        <p className="mt-2 text-xs text-warning">
                           No template set{selectedCategory ? ` for ${selectedCategory.name}` : ""} — mark a landing page as Auto-Build to promote it here.
                         </p>
                       )}

--- a/src/src/app/(dashboard)/templates/page.tsx
+++ b/src/src/app/(dashboard)/templates/page.tsx
@@ -9,6 +9,7 @@ import { db } from "@/lib/db";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { DeleteLandingPageButton } from "@/components/templates/delete-landing-page-button";
+import { ActivateTemplateModal } from "@/components/templates/activate-template-modal";
 
 const TEMPLATE_OPTIONS = [
   {
@@ -80,6 +81,34 @@ async function getMasterTemplates(categoryId: string | null) {
   return masterByType;
 }
 
+async function getGlobalMasterTemplates() {
+  const pages = await db.landingPage.findMany({
+    where: {
+      isActiveTemplate: true,
+      categoryId: null,
+      template: { in: ["SOLO_LANDING", "DUO_LANDING", "REGISTRATION", "THANK_YOU"] },
+    },
+    select: {
+      id: true,
+      template: true,
+      status: true,
+      slug: true,
+      isActiveTemplate: true,
+      createdAt: true,
+      workshopId: true,
+      categoryId: true,
+      workshop: { select: { title: true } },
+      category: { select: { id: true, name: true } },
+    },
+    orderBy: { updatedAt: "desc" },
+  });
+  const globalByType = new Map<string, typeof pages[number]>();
+  for (const p of pages) {
+    if (!globalByType.has(p.template)) globalByType.set(p.template, p);
+  }
+  return globalByType;
+}
+
 async function getCategories() {
   return db.category.findMany({
     where: { isActive: true },
@@ -102,9 +131,10 @@ export default async function TemplatesPage({ searchParams }: TemplatesPageProps
   const params = await searchParams;
   const selectedCategoryId = params.category ?? null;
 
-  const [masterByType, categories] = await Promise.all([
+  const [masterByType, categories, globalByType] = await Promise.all([
     getMasterTemplates(selectedCategoryId),
     getCategories(),
+    selectedCategoryId ? getGlobalMasterTemplates() : Promise.resolve(new Map() as Awaited<ReturnType<typeof getGlobalMasterTemplates>>),
   ]);
 
   const selectedCategory = categories.find((c) => c.id === selectedCategoryId) ?? null;
@@ -152,13 +182,14 @@ export default async function TemplatesPage({ searchParams }: TemplatesPageProps
       {selectedCategory && (
         <div className="rounded-md border border-border bg-muted/40 px-4 py-2 text-sm text-muted-foreground">
           Showing templates for <span className="font-semibold text-foreground">{selectedCategory.name}</span>.
-          Templates with no category (global) are <span className="font-semibold">not</span> shown — use &quot;All&quot; to see them.
+          Category overrides take priority. Slots showing &quot;Using Global&quot; will use the global template for auto-build.
         </div>
       )}
 
       <div className="grid gap-4">
         {TEMPLATE_OPTIONS.map((option) => {
           const master = masterByType.get(option.value as TemplateValue);
+          const globalFallback = globalByType.get(option.value as TemplateValue);
           const editHref = master
             ? `/workshops/${master.workshopId}/landing-pages/${option.route}`
             : null;
@@ -186,20 +217,27 @@ export default async function TemplatesPage({ searchParams }: TemplatesPageProps
                       </div>
                       <p className="text-sm text-muted-foreground">{option.description}</p>
                       {master ? (
+                        // State 1: Has category override (or on All tab with a master set)
                         <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
                           <Badge variant={statusVariant(master.status)}>{master.status}</Badge>
                           <span>Based on: {master.workshop.title}</span>
                         </div>
+                      ) : selectedCategoryId && globalFallback ? (
+                        // State 2: No category override, but global fallback exists
+                        <p className="mt-2 text-xs text-muted-foreground">
+                          Using Global: {globalFallback.workshop.title}
+                        </p>
                       ) : (
-                        <p className="mt-2 text-xs text-warning">
-                          No master template set{selectedCategory ? ` for ${selectedCategory.name}` : ""} — mark a landing page as Auto-Build to promote it here.
+                        // State 3: No template at all (or on All tab with nothing)
+                        <p className="mt-2 text-xs text-amber-600 dark:text-amber-500">
+                          No template set{selectedCategory ? ` for ${selectedCategory.name}` : ""} — mark a landing page as Auto-Build to promote it here.
                         </p>
                       )}
                     </div>
                   </div>
 
                   <div className="flex items-center gap-2 shrink-0">
-                    {master && editHref && (
+                    {master && editHref ? (
                       <>
                         {previewHref && (
                           <Link
@@ -218,7 +256,16 @@ export default async function TemplatesPage({ searchParams }: TemplatesPageProps
                         </Link>
                         <DeleteLandingPageButton pageId={master.id} templateLabel={option.label} />
                       </>
-                    )}
+                    ) : selectedCategoryId ? (
+                      // Show Set Override or Set Template button when on a category tab
+                      <ActivateTemplateModal
+                        template={option.value as TemplateValue}
+                        categoryId={selectedCategoryId}
+                        categoryName={selectedCategory?.name ?? "Global"}
+                        templateLabel={option.label}
+                        hasGlobalFallback={!!globalFallback}
+                      />
+                    ) : null}
                   </div>
                 </div>
               </CardContent>

--- a/src/src/app/(dashboard)/templates/page.tsx
+++ b/src/src/app/(dashboard)/templates/page.tsx
@@ -48,7 +48,7 @@ async function getMasterTemplates(categoryId: string | null) {
   // FIG-005: Filter templates by category. "null" means global (no categoryId filter).
   const categoryWhere = categoryId
     ? { categoryId }
-    : {}; // no filter → show all active templates (original behaviour when "All" is selected)
+    : { categoryId: null }; // All tab = global templates only (categoryId: null)
 
   const pages = await db.landingPage.findMany({
     where: {
@@ -230,7 +230,7 @@ export default async function TemplatesPage({ searchParams }: TemplatesPageProps
                       ) : (
                         // State 3: No template at all (or on All tab with nothing)
                         <p className="mt-2 text-xs text-warning">
-                          No template set{selectedCategory ? ` for ${selectedCategory.name}` : ""} — mark a landing page as Auto-Build to promote it here.
+                          No template set{selectedCategory ? ` for ${selectedCategory.name}` : ""} — use the Set Template button to promote a landing page.
                         </p>
                       )}
                     </div>
@@ -265,7 +265,16 @@ export default async function TemplatesPage({ searchParams }: TemplatesPageProps
                         templateLabel={option.label}
                         hasGlobalFallback={!!globalFallback}
                       />
-                    ) : null}
+                    ) : (
+                      // Show Set Global Template button on the All tab
+                      <ActivateTemplateModal
+                        template={option.value as TemplateValue}
+                        categoryId={null}
+                        categoryName="Global"
+                        templateLabel={option.label}
+                        hasGlobalFallback={false}
+                      />
+                    )}
                   </div>
                 </div>
               </CardContent>
@@ -280,17 +289,21 @@ export default async function TemplatesPage({ searchParams }: TemplatesPageProps
         </CardHeader>
         <CardContent className="text-sm text-muted-foreground space-y-2">
           <p>
-            Each workshop has its own set of landing pages. To promote a workshop page as the
-            master template, open the workshop landing page editor and toggle &quot;Auto-Build&quot; on.
+            To set a global template, use the <strong>Set Template</strong> button on the{" "}
+            <strong>All</strong> tab. To set a category-specific override, switch to that
+            category tab and use <strong>Set Override</strong> or <strong>Set Template</strong>.
+            In both cases the system will show you a list of existing workshop landing pages to
+            promote as the master.
           </p>
           <p>
             Templates can be scoped to a category (AI or Exit &amp; Valuation). When auto-build runs,
-            it picks templates matching the workshop&apos;s category first. Templates with no category
-            are &quot;global&quot; and apply to all workshops as a fallback.
+            it picks the category-specific template first and falls back to the global template if
+            no override exists. Templates on the <strong>All</strong> tab have no category and
+            apply to all workshops as a fallback.
           </p>
           <p>
             <strong>Important:</strong> Exit &amp; Valuation templates are seeded but inactive by default.
-            Activate them from the workshop landing page editor only after verifying their content.
+            Activate them from this page only after verifying their content.
           </p>
         </CardContent>
       </Card>

--- a/src/src/app/api/landing-pages/[id]/route.ts
+++ b/src/src/app/api/landing-pages/[id]/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
-import { Prisma } from "@prisma/client";
 import type { LandingPage } from "@prisma/client";
 import { db } from "@/lib/db";
 import { getApiActor, isPrivilegedRole } from "@/lib/authorization";
@@ -50,7 +49,8 @@ export async function PATCH(
             const effectiveCategoryId = data.categoryId !== undefined ? data.categoryId : page.categoryId;
 
             // Atomic: deactivate any competing active template for this slot, then activate this one
-            const txResult = await db.$transaction<[Prisma.BatchPayload, LandingPage]>([
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const txResult = await (db.$transaction as (ops: any[]) => Promise<any[]>)([
                 db.landingPage.updateMany({
                     where: {
                         template: page.template,

--- a/src/src/app/api/landing-pages/[id]/route.ts
+++ b/src/src/app/api/landing-pages/[id]/route.ts
@@ -49,9 +49,8 @@ export async function PATCH(
             const effectiveCategoryId = data.categoryId !== undefined ? data.categoryId : page.categoryId;
 
             // Atomic: deactivate any competing active template for this slot, then activate this one
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const txResult = await (db.$transaction as (ops: any[]) => Promise<any[]>)([
-                db.landingPage.updateMany({
+            const txResult = await db.$transaction(async (tx) => {
+                await tx.landingPage.updateMany({
                     where: {
                         template: page.template,
                         categoryId: effectiveCategoryId,  // null = global slot
@@ -59,16 +58,16 @@ export async function PATCH(
                         id: { not: id },
                     },
                     data: { isActiveTemplate: false },
-                }),
-                db.landingPage.update({
+                });
+                return tx.landingPage.update({
                     where: { id },
                     data: {
                         ...(data.isActiveTemplate !== undefined && { isActiveTemplate: data.isActiveTemplate }),
                         ...(data.categoryId !== undefined && { categoryId: data.categoryId }),
                     },
-                }),
-            ]);
-            updated = txResult[1];
+                });
+            });
+            updated = txResult;
         } else {
             updated = await db.landingPage.update({
                 where: { id },

--- a/src/src/app/api/landing-pages/[id]/route.ts
+++ b/src/src/app/api/landing-pages/[id]/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
+import { Prisma } from "@prisma/client";
+import type { LandingPage } from "@prisma/client";
 import { db } from "@/lib/db";
 import { getApiActor, isPrivilegedRole } from "@/lib/authorization";
 
@@ -34,14 +36,21 @@ export async function PATCH(
             return NextResponse.json({ error: "Landing page not found" }, { status: 404 });
         }
 
-        let updated;
-        if (data.isActiveTemplate === true) {
+        // Should we run the deactivation transaction?
+        // Yes if: we're activating this page, OR we're re-scoping an already-active page to a new slot.
+        const needsTransaction =
+            data.isActiveTemplate === true ||
+            (data.categoryId !== undefined && page.isActiveTemplate && data.isActiveTemplate !== false);
+
+        let updated: LandingPage;
+
+        if (needsTransaction) {
             // Determine the effective categoryId for the slot
             // (use data.categoryId if explicitly provided, otherwise use the page's existing categoryId)
             const effectiveCategoryId = data.categoryId !== undefined ? data.categoryId : page.categoryId;
 
             // Atomic: deactivate any competing active template for this slot, then activate this one
-            const [, activatedPage] = await db.$transaction([
+            const txResult = await db.$transaction<[Prisma.BatchPayload, LandingPage]>([
                 db.landingPage.updateMany({
                     where: {
                         template: page.template,
@@ -54,12 +63,12 @@ export async function PATCH(
                 db.landingPage.update({
                     where: { id },
                     data: {
-                        isActiveTemplate: true,
+                        ...(data.isActiveTemplate !== undefined && { isActiveTemplate: data.isActiveTemplate }),
                         ...(data.categoryId !== undefined && { categoryId: data.categoryId }),
                     },
                 }),
             ]);
-            updated = activatedPage;
+            updated = txResult[1];
         } else {
             updated = await db.landingPage.update({
                 where: { id },

--- a/src/src/app/api/landing-pages/[id]/route.ts
+++ b/src/src/app/api/landing-pages/[id]/route.ts
@@ -5,6 +5,7 @@ import { getApiActor, isPrivilegedRole } from "@/lib/authorization";
 
 const UpdateSchema = z.object({
     isActiveTemplate: z.boolean().optional(),
+    categoryId: z.string().nullable().optional(),  // allow re-scoping page to a specific category
 });
 
 /**
@@ -33,12 +34,41 @@ export async function PATCH(
             return NextResponse.json({ error: "Landing page not found" }, { status: 404 });
         }
 
-        const updated = await db.landingPage.update({
-            where: { id },
-            data: {
-                ...(data.isActiveTemplate !== undefined && { isActiveTemplate: data.isActiveTemplate }),
-            },
-        });
+        let updated;
+        if (data.isActiveTemplate === true) {
+            // Determine the effective categoryId for the slot
+            // (use data.categoryId if explicitly provided, otherwise use the page's existing categoryId)
+            const effectiveCategoryId = data.categoryId !== undefined ? data.categoryId : page.categoryId;
+
+            // Atomic: deactivate any competing active template for this slot, then activate this one
+            const [, activatedPage] = await db.$transaction([
+                db.landingPage.updateMany({
+                    where: {
+                        template: page.template,
+                        categoryId: effectiveCategoryId,  // null = global slot
+                        isActiveTemplate: true,
+                        id: { not: id },
+                    },
+                    data: { isActiveTemplate: false },
+                }),
+                db.landingPage.update({
+                    where: { id },
+                    data: {
+                        isActiveTemplate: true,
+                        ...(data.categoryId !== undefined && { categoryId: data.categoryId }),
+                    },
+                }),
+            ]);
+            updated = activatedPage;
+        } else {
+            updated = await db.landingPage.update({
+                where: { id },
+                data: {
+                    ...(data.isActiveTemplate !== undefined && { isActiveTemplate: data.isActiveTemplate }),
+                    ...(data.categoryId !== undefined && { categoryId: data.categoryId }),
+                },
+            });
+        }
 
         return NextResponse.json({ success: true, page: updated });
     } catch (error) {

--- a/src/src/app/api/landing-pages/library/route.ts
+++ b/src/src/app/api/landing-pages/library/route.ts
@@ -58,6 +58,8 @@ export async function GET(request: NextRequest) {
 
     const templateParam = queryValidation.data.template || "";
     const normalizedTemplate = templateParam.toUpperCase();
+    // activeOnly defaults to true (no isActiveTemplate filter = return all pages, backward compatible).
+    // Pass activeOnly=false to retrieve only inactive templates (candidates for activation).
     const activeOnly = queryValidation.data.activeOnly !== "false";
     const categoryId = queryValidation.data.categoryId;
 
@@ -78,6 +80,7 @@ export async function GET(request: NextRequest) {
         : { in: [...TEMPLATE_OPTIONS] },
       ...(!activeOnly && { isActiveTemplate: false }),
       ...(!activeOnly && categoryId && {
+        // Include both category-specific templates AND global templates (categoryId: null = applies to all categories)
         OR: [{ categoryId }, { categoryId: null }],
       }),
       ...(isPrivilegedRole(actor.role)

--- a/src/src/app/api/landing-pages/library/route.ts
+++ b/src/src/app/api/landing-pages/library/route.ts
@@ -5,11 +5,13 @@ import { canManageCoachData, getApiActor, isPrivilegedRole } from "@/lib/authori
 import { rewriteIdentityFields, buildWorkshopVariables } from "@/lib/template-interpolation";
 import { z } from "zod";
 
-const TEMPLATE_OPTIONS = ["SOLO_LANDING", "DUO_LANDING", "REGISTRATION"] as const;
+const TEMPLATE_OPTIONS = ["SOLO_LANDING", "DUO_LANDING", "REGISTRATION", "THANK_YOU"] as const;
 type TemplateType = (typeof TEMPLATE_OPTIONS)[number];
 
 const landingPageLibraryQuerySchema = z.object({
   template: z.string().trim().optional(),
+  activeOnly: z.string().optional(),
+  categoryId: z.string().trim().optional(),
 });
 
 const applyLandingPageTemplateSchema = z.object({
@@ -23,7 +25,7 @@ function isTemplateType(value: string): value is TemplateType {
 }
 
 function toTemplateEditorPath(template: TemplateType): string {
-  return template.toLowerCase().replace("_", "-");
+  return template.toLowerCase().replace(/_/g, "-");
 }
 
 function generateSlug(workshopTitle: string, template: TemplateType): string {
@@ -56,6 +58,8 @@ export async function GET(request: NextRequest) {
 
     const templateParam = queryValidation.data.template || "";
     const normalizedTemplate = templateParam.toUpperCase();
+    const activeOnly = queryValidation.data.activeOnly !== "false";
+    const categoryId = queryValidation.data.categoryId;
 
     if (templateParam && !isTemplateType(normalizedTemplate)) {
       return NextResponse.json(
@@ -72,6 +76,10 @@ export async function GET(request: NextRequest) {
       template: isTemplateType(normalizedTemplate)
         ? normalizedTemplate
         : { in: [...TEMPLATE_OPTIONS] },
+      ...(!activeOnly && { isActiveTemplate: false }),
+      ...(!activeOnly && categoryId && {
+        OR: [{ categoryId }, { categoryId: null }],
+      }),
       ...(isPrivilegedRole(actor.role)
         ? {}
         : {
@@ -89,10 +97,14 @@ export async function GET(request: NextRequest) {
         status: true,
         slug: true,
         createdAt: true,
+        updatedAt: true,
         workshopId: true,
+        isActiveTemplate: true,
+        categoryId: true,
         workshop: {
           select: {
             title: true,
+            workshopCode: true,
           },
         },
       },
@@ -108,8 +120,12 @@ export async function GET(request: NextRequest) {
       status: page.status,
       slug: page.slug,
       createdAt: page.createdAt.toISOString(),
+      updatedAt: page.updatedAt.toISOString(),
       workshopId: page.workshopId,
+      isActiveTemplate: page.isActiveTemplate,
+      categoryId: page.categoryId,
       workshopTitle: page.workshop.title,
+      workshopCode: page.workshop.workshopCode,
       editPath: `/workshops/${page.workshopId}/landing-pages/${toTemplateEditorPath(
         page.template as TemplateType
       )}`,

--- a/src/src/components/templates/activate-template-modal.tsx
+++ b/src/src/components/templates/activate-template-modal.tsx
@@ -143,7 +143,7 @@ export function ActivateTemplateModal({
         <button className={triggerClassName}>{triggerLabel}</button>
       </DialogTrigger>
 
-      <DialogContent className="max-w-xl">
+      <DialogContent aria-describedby={undefined} className="max-w-xl">
         <DialogHeader>
           <DialogTitle>
             {hasGlobalFallback ? "Set Category Override" : "Set Template"} — {templateLabel}
@@ -168,7 +168,15 @@ export function ActivateTemplateModal({
 
           {/* Fetch error */}
           {!loading && fetchError && (
-            <p className="text-sm text-destructive">{fetchError}</p>
+            <div className="py-4 text-center space-y-3">
+              <p className="text-sm text-destructive">{fetchError}</p>
+              <button
+                onClick={fetchCandidates}
+                className="text-sm text-primary underline hover:no-underline"
+              >
+                Try again
+              </button>
+            </div>
           )}
 
           {/* Empty state */}

--- a/src/src/components/templates/activate-template-modal.tsx
+++ b/src/src/components/templates/activate-template-modal.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+
+type TemplateValue = "SOLO_LANDING" | "DUO_LANDING" | "REGISTRATION" | "THANK_YOU";
+
+interface Candidate {
+  id: string;
+  template: TemplateValue;
+  status: string;
+  slug: string;
+  workshopId: string;
+  workshopTitle: string;
+  workshopCode: string;
+  categoryId: string | null;
+  isActiveTemplate: boolean;
+  updatedAt: string;
+}
+
+interface ActivateTemplateModalProps {
+  template: TemplateValue;
+  categoryId: string | null;
+  categoryName: string;
+  templateLabel: string;
+  hasGlobalFallback: boolean;
+}
+
+export function ActivateTemplateModal({
+  template,
+  categoryId,
+  categoryName,
+  templateLabel,
+  hasGlobalFallback,
+}: ActivateTemplateModalProps) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [candidates, setCandidates] = useState<Candidate[] | null>(null);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [activatingId, setActivatingId] = useState<string | null>(null);
+  const [activateErrors, setActivateErrors] = useState<Record<string, string>>({});
+
+  async function fetchCandidates() {
+    setLoading(true);
+    setFetchError(null);
+    setCandidates(null);
+    try {
+      const url =
+        `/api/landing-pages/library?template=${template}&activeOnly=false` +
+        (categoryId ? `&categoryId=${categoryId}` : "");
+      const res = await fetch(url);
+      const json = await res.json();
+      if (!res.ok || !json.success) {
+        setFetchError(json.error ?? "Failed to load candidates.");
+      } else {
+        setCandidates(json.data as Candidate[]);
+      }
+    } catch {
+      setFetchError("Network error — please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleOpenChange(next: boolean) {
+    setOpen(next);
+    if (next) {
+      fetchCandidates();
+    } else {
+      // Reset state on close
+      setCandidates(null);
+      setFetchError(null);
+      setActivatingId(null);
+      setActivateErrors({});
+    }
+  }
+
+  async function handleActivate(page: Candidate) {
+    setActivatingId(page.id);
+    setActivateErrors((prev) => {
+      const next = { ...prev };
+      delete next[page.id];
+      return next;
+    });
+
+    try {
+      const body: { isActiveTemplate: boolean; categoryId?: string | null } = {
+        isActiveTemplate: true,
+      };
+
+      // If the page is global and we're activating it for a specific category,
+      // re-scope it to that category.
+      if (page.categoryId === null && categoryId !== null) {
+        body.categoryId = categoryId;
+      }
+
+      const res = await fetch(`/api/landing-pages/${page.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+
+      const json = await res.json();
+
+      if (!res.ok || !json.success) {
+        setActivateErrors((prev) => ({
+          ...prev,
+          [page.id]: json.error ?? "Activation failed.",
+        }));
+      } else {
+        setOpen(false);
+        router.refresh();
+      }
+    } catch {
+      setActivateErrors((prev) => ({
+        ...prev,
+        [page.id]: "Network error — please try again.",
+      }));
+    } finally {
+      setActivatingId(null);
+    }
+  }
+
+  const triggerClassName = hasGlobalFallback
+    ? "inline-flex items-center justify-center gap-1 rounded-md border border-border px-2.5 py-1 text-xs font-medium text-muted-foreground hover:bg-accent transition-colors cursor-pointer"
+    : "inline-flex items-center justify-center gap-1 rounded-md px-2.5 py-1 text-xs font-medium bg-amber-500 hover:bg-amber-600 text-white transition-colors cursor-pointer";
+
+  const triggerLabel = hasGlobalFallback ? "Set Override" : "Set Template";
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <button className={triggerClassName}>{triggerLabel}</button>
+      </DialogTrigger>
+
+      <DialogContent className="max-w-xl">
+        <DialogHeader>
+          <DialogTitle>
+            {hasGlobalFallback ? "Set Category Override" : "Set Template"} — {templateLabel}
+          </DialogTitle>
+        </DialogHeader>
+
+        {categoryId && (
+          <p className="text-sm text-muted-foreground -mt-2">
+            Activating for category: <span className="font-semibold text-foreground">{categoryName}</span>
+          </p>
+        )}
+
+        <div className="mt-1">
+          {/* Loading state */}
+          {loading && (
+            <div className="space-y-3">
+              <Skeleton className="h-16 w-full" />
+              <Skeleton className="h-16 w-full" />
+              <Skeleton className="h-16 w-full" />
+            </div>
+          )}
+
+          {/* Fetch error */}
+          {!loading && fetchError && (
+            <p className="text-sm text-destructive">{fetchError}</p>
+          )}
+
+          {/* Empty state */}
+          {!loading && !fetchError && candidates !== null && candidates.length === 0 && (
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              No inactive landing pages available for this template type. Go to a workshop&apos;s
+              landing page editor and toggle &quot;Auto-Build&quot; off to make a page available
+              here.
+            </p>
+          )}
+
+          {/* Candidates list */}
+          {!loading && !fetchError && candidates !== null && candidates.length > 0 && (
+            <div className="max-h-96 overflow-y-auto space-y-2 pr-1">
+              {candidates.map((page) => (
+                <div
+                  key={page.id}
+                  className="flex items-start justify-between gap-3 rounded-lg border border-border bg-muted/30 p-3"
+                >
+                  <div className="flex-1 min-w-0 space-y-1">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="font-semibold text-sm text-foreground truncate">
+                        {page.workshopTitle}
+                      </span>
+                      <span className="text-xs text-muted-foreground">{page.workshopCode}</span>
+                    </div>
+
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <Badge variant={page.categoryId === null ? "secondary" : "outline"} className="text-xs">
+                        {page.categoryId === null ? "Global" : "Category"}
+                      </Badge>
+                      <Badge
+                        variant={page.status === "PUBLISHED" ? "default" : "secondary"}
+                        className="text-xs"
+                      >
+                        {page.status}
+                      </Badge>
+                      <span className="text-xs text-muted-foreground">
+                        {new Date(page.updatedAt).toLocaleDateString()}
+                      </span>
+                    </div>
+
+                    {page.categoryId === null && categoryId !== null && (
+                      <p className="text-xs text-muted-foreground italic">
+                        Will be scoped to {categoryName}
+                      </p>
+                    )}
+
+                    {activateErrors[page.id] && (
+                      <p className="text-xs text-destructive">{activateErrors[page.id]}</p>
+                    )}
+                  </div>
+
+                  <button
+                    onClick={() => handleActivate(page)}
+                    disabled={activatingId === page.id}
+                    className="shrink-0 inline-flex items-center justify-center rounded-md bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:pointer-events-none transition-colors cursor-pointer"
+                  >
+                    {activatingId === page.id ? "Activating…" : "Activate"}
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/src/components/templates/active-template-toggle.tsx
+++ b/src/src/components/templates/active-template-toggle.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useToast } from "@/components/ui/use-toast";
 
 interface ActiveTemplateToggleProps {
     pageId: string;
@@ -10,6 +11,7 @@ interface ActiveTemplateToggleProps {
 export function ActiveTemplateToggle({ pageId, isActive }: ActiveTemplateToggleProps) {
     const [active, setActive] = useState(isActive);
     const [loading, setLoading] = useState(false);
+    const { toast } = useToast();
 
     const handleToggle = async () => {
         setLoading(true);
@@ -22,7 +24,7 @@ export function ActiveTemplateToggle({ pageId, isActive }: ActiveTemplateToggleP
             if (!res.ok) throw new Error("Failed to update");
             setActive(!active);
         } catch {
-            alert("Failed to update template status");
+            toast({ title: "Error", description: "Failed to update template status", variant: "destructive" });
         } finally {
             setLoading(false);
         }

--- a/src/src/components/templates/delete-landing-page-button.tsx
+++ b/src/src/components/templates/delete-landing-page-button.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { ConfirmationModal } from "@/components/ui/confirmation-modal";
+import { useToast } from "@/components/ui/use-toast";
 
 interface Props {
   pageId: string;
@@ -9,34 +11,58 @@ interface Props {
 }
 
 export function DeleteLandingPageButton({ pageId, templateLabel }: Props) {
+  const [open, setOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const router = useRouter();
+  const { toast } = useToast();
 
   async function handleDelete() {
-    if (!confirm(`Delete the master template for "${templateLabel}"? This cannot be undone.`)) return;
     setDeleting(true);
     try {
       const res = await fetch(`/api/landing-pages/${pageId}`, { method: "DELETE" });
-      if (res.ok) {
+      const json = await res.json();
+      if (res.ok && json.success) {
+        // Modal intentionally stays open on error so the user can retry with context
+        setOpen(false);
         router.refresh();
       } else {
-        const json = await res.json();
-        alert(json.error || "Delete failed");
+        toast({
+          title: "Delete failed",
+          description: json.error || "Delete failed — please try again.",
+          variant: "destructive",
+        });
       }
     } catch {
-      alert("Delete failed");
+      toast({
+        title: "Delete failed",
+        description: "Network error — please try again.",
+        variant: "destructive",
+      });
     } finally {
       setDeleting(false);
     }
   }
 
   return (
-    <button
-      onClick={handleDelete}
-      disabled={deleting}
-      className="rounded-md border border-destructive/50 px-3 py-1.5 text-sm font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
-    >
-      {deleting ? "Deleting…" : "Delete"}
-    </button>
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        disabled={deleting}
+        className="rounded-md border border-destructive/50 px-3 py-1.5 text-sm font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
+      >
+        Delete
+      </button>
+      <ConfirmationModal
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        onConfirm={handleDelete}
+        title={`Delete master template`}
+        description={`Remove "${templateLabel}" as the active master template?`}
+        warningText="This cannot be undone. Auto-build will fall back to the global template or skip this template type until a new one is promoted."
+        confirmLabel="Delete Template"
+        variant="destructive"
+        isLoading={deleting}
+      />
+    </>
   );
 }

--- a/src/src/components/ui/dialog.tsx
+++ b/src/src/components/ui/dialog.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const Dialog = DialogPrimitive.Root;
+const DialogTrigger = DialogPrimitive.Trigger;
+const DialogPortal = DialogPrimitive.Portal;
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/50 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-card p-6 shadow-xl duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-2xl",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)} {...props} />
+);
+DialogHeader.displayName = "DialogHeader";
+
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
+    {...props}
+  />
+);
+DialogFooter.displayName = "DialogFooter";
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold leading-none tracking-tight text-foreground", className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+};

--- a/src/src/inngest/functions/auto-build-workshop.ts
+++ b/src/src/inngest/functions/auto-build-workshop.ts
@@ -177,6 +177,16 @@ export const autoBuildWorkshop = inngest.createFunction(
                 select: { id: true, template: true, content: true, slug: true, categoryId: true },
             });
 
+            // FIG-005: Deduplicate — prefer category-scoped over global for same template type
+            const deduped = new Map<string, typeof activeTemplates[number]>();
+            for (const tpl of activeTemplates) {
+                const existing = deduped.get(tpl.template);
+                if (!existing || (tpl.categoryId !== null && existing.categoryId === null)) {
+                    deduped.set(tpl.template, tpl);
+                }
+            }
+            activeTemplates = Array.from(deduped.values());
+
             // FIG-005: If category-filtered query returns nothing, fall back to ALL active templates
             // (graceful degradation so existing global templates still work)
             if (activeTemplates.length === 0 && workshop.categoryId) {


### PR DESCRIPTION
## Summary

- **11 Figma-board revisions** (FIG-001 through FIG-011): auto-title reactive fix, isFree bug, pricing tier dropdown, View Public Page button, workshop inline edit expansion, CUSTOM_PRICING approval flow, custom pricing notes in email, INFO_REQUESTED coach edit/resubmit, virtualLink required, per-category landing page templates
- **Template promotion UX** (today): All-tab global template query fix, Set Template button on All tab, corrected help text, DeleteLandingPageButton → ConfirmationModal + toast
- **52 test suites / 514 tests passing**

## Test plan

- [ ] Verify workshop creation wizard: auto-title fires, isFree resolves correctly, virtualLink required for VIRTUAL workshops
- [ ] Verify CUSTOM_PRICING flow: coach submits pricing change → approval created → admin approves → priceCents updated
- [ ] Verify INFO_REQUESTED: admin requests info → coach edits/resubmits → approval advances
- [ ] Verify Templates page: All tab shows Set Template buttons, category tabs show Set Override, help text is accurate
- [ ] Verify Vercel deployment succeeds (check build logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)