### PR TITLE
fix: post-QA fixes — trigger-now 409 + coach conversation history

### DIFF
--- a/src/src/app/(portal)/portal/workshops/[id]/page.tsx
+++ b/src/src/app/(portal)/portal/workshops/[id]/page.tsx
@@ -46,7 +46,7 @@ export default async function WorkshopDetailsPage({
   const { id } = await params;
   const { coach } = await requireCoach();
 
-  const [workshop, workflowAssignments, surveyCount, latestDenial, workshopFiles, registrationFinancials, infoRequestedApproval, fallbackLandingPage, pendingPriceChange] = await Promise.all([
+  const [workshop, workflowAssignments, surveyCount, latestDenial, workshopFiles, registrationFinancials, infoRequestedApproval, fallbackLandingPage, pendingPriceChange, approvalHistory] = await Promise.all([
     db.workshop.findFirst({
       where: { id, coachId: coach.id },
       select: {
@@ -142,6 +142,18 @@ export default async function WorkshopDetailsPage({
       where: { workshopId: id, type: "CUSTOM_PRICING", status: { in: ["PENDING", "COUNTER_OFFERED"] } },
       select: { id: true, requestData: true, requestedAt: true, status: true, counterOfferCents: true, counterOfferNote: true },
       orderBy: { requestedAt: "desc" },
+    }),
+    // BUG-05: Full approval conversation history for coach view
+    db.approvalQueue.findMany({
+      where: {
+        workshopId: id,
+        type: { in: ["WORKSHOP_REQUEST", "CUSTOM_PRICING"] },
+        status: { not: "INFO_REQUESTED" },
+      },
+      include: {
+        messages: { orderBy: { createdAt: "asc" } },
+      },
+      orderBy: { requestedAt: "asc" },
     }),
   ]);
 
@@ -330,6 +342,39 @@ export default async function WorkshopDetailsPage({
             </p>
           </div>
           <Badge variant="warning">Pending</Badge>
+        </div>
+      )}
+
+      {/* BUG-05: Full conversation history */}
+      {approvalHistory.some((r) => r.messages.length > 0) && (
+        <div className="rounded-xl border border-border bg-card p-5">
+          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+            Conversation History
+          </h2>
+          <div className="space-y-6">
+            {approvalHistory.map((record) => {
+              const msgs = record.messages.map((m) => ({
+                ...m,
+                createdAt: m.createdAt instanceof Date ? m.createdAt.toISOString() : m.createdAt,
+              }));
+              if (!msgs.length) return null;
+              return (
+                <div key={record.id}>
+                  <p className="text-xs text-muted-foreground mb-1">
+                    {record.requestedAt.toLocaleDateString("en-US", {
+                      month: "short",
+                      day: "numeric",
+                      year: "numeric",
+                    })}
+                    {record.type === "CUSTOM_PRICING" && (
+                      <span className="ml-2 font-medium">(Custom Pricing Request)</span>
+                    )}
+                  </p>
+                  <ApprovalThread messages={msgs} perspective="coach" />
+                </div>
+              );
+            })}
+          </div>
         </div>
       )}
 

--- a/src/src/app/api/workflow-steps/[stepId]/trigger-now/route.ts
+++ b/src/src/app/api/workflow-steps/[stepId]/trigger-now/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getApiActor, isPrivilegedRole } from "@/lib/auth/authorization";
 import { RateLimits, withRateLimit } from "@/lib/rate-limit";
 import { inngest } from "@/inngest/client";
+import { db } from "@/lib/db";
 
 /**
  * POST /api/workflow-steps/[stepId]/trigger-now
@@ -63,9 +64,32 @@ export async function POST(
         );
     }
 
+    const cleanWorkshopId = workshopId.trim();
+
+    const step = await db.workflowStep.findUnique({
+        where: { id: stepId },
+        select: { id: true },
+    });
+    if (!step) {
+        return NextResponse.json(
+            { error: "Workflow step not found" },
+            { status: 404, headers: rateLimit.headers }
+        );
+    }
+
+    const existing = await db.workflowStepExecution.findFirst({
+        where: { stepId, workshopId: cleanWorkshopId, status: "SENT" },
+    });
+    if (existing) {
+        return NextResponse.json(
+            { error: "This step has already been sent", alreadySent: true },
+            { status: 409, headers: rateLimit.headers }
+        );
+    }
+
     await inngest.send({
         name: "workflow/step.trigger",
-        data: { stepId, workshopId },
+        data: { stepId, workshopId: cleanWorkshopId },
     });
 
     return NextResponse.json({ success: true }, { headers: rateLimit.headers });

--- a/src/src/components/workflows/trigger-now-button.tsx
+++ b/src/src/components/workflows/trigger-now-button.tsx
@@ -27,6 +27,11 @@ export function TriggerNowButton({ stepId, workshopId }: TriggerNowButtonProps) 
                     title: "Step triggered",
                     description: "The workflow step will execute shortly.",
                 });
+            } else if (res.status === 409) {
+                toast({
+                    title: "Already sent",
+                    description: "This step was already executed. Check the workflow status card.",
+                });
             } else {
                 const data = await res.json().catch(() => ({}));
                 toast({


### PR DESCRIPTION
## Summary

- **Fix 2: Trigger Now idempotency** — `POST /api/workflow-steps/[stepId]/trigger-now` now returns 404 for unknown step IDs and 409 (with `alreadySent: true`) when the step was already executed (status=SENT). The button now shows a neutral "Already sent" info toast instead of a false "Step triggered" success on 409.
- **Fix 3: Coach conversation history** — Coach workshop detail page now fetches full approval conversation history and renders it above the reply form using the existing `ApprovalThread` component. Active `INFO_REQUESTED` approvals are excluded from history to avoid duplicate display.
- **Fix 1 (already in main)** — Registrations page null `eventDate` crash was fixed in prior commits (`62fdb4f`, `ff0c19b`); no new code needed.

## Test Plan

- [ ] **Fix 1**: Visit `/portal/registrations` as a coach — page loads without crash
- [ ] **Fix 2a**: Open admin workshop detail, find a step already marked SENT, click "Trigger Now" → toast shows "Already sent" (not "Step triggered")
- [ ] **Fix 2b**: Click "Trigger Now" on a step NOT yet sent → toast shows "Step triggered"
- [ ] **Fix 3**: Visit coach workshop detail for a workshop that had admin back-and-forth — "Conversation History" card appears above the reply form showing prior message threads

🤖 Generated with [Claude Code](https://claude.com/claude-code)