### PR TITLE
fix: BUG-MAY4-1a+1b — workflow timing skew + 0-attendee false SENT

### DIFF
--- a/src/scripts/diagnose-workflow-step-execution.ts
+++ b/src/scripts/diagnose-workflow-step-execution.ts
@@ -1,0 +1,95 @@
+/* eslint-disable */
+import { PrismaClient } from "@prisma/client";
+
+const db = new PrismaClient();
+
+async function main() {
+  const workshopCode = process.argv[2] ?? "WS-2026-QN5H";
+
+  const workshop = await db.workshop.findFirst({
+    where: { workshopCode },
+  });
+
+  if (!workshop) {
+    console.log(`No workshop found for code ${workshopCode}`);
+    return;
+  }
+
+  console.log("=== WORKSHOP ===");
+  console.log(JSON.stringify(workshop, null, 2));
+
+  const assignments = await db.workflowAssignment.findMany({
+    where: { workshopId: workshop.id },
+    include: {
+      workflow: {
+        select: {
+          id: true,
+          name: true,
+          steps: {
+            select: {
+              id: true,
+              stepType: true,
+              triggerType: true,
+              offsetDays: true,
+              offsetHours: true,
+              sendTimeOfDay: true,
+              sortOrder: true,
+              surveyTemplateId: true,
+              subject: true,
+            },
+            orderBy: { sortOrder: "asc" },
+          },
+        },
+      },
+    },
+  });
+
+  console.log("\n=== WORKFLOW ASSIGNMENTS ===");
+  console.log(JSON.stringify(assignments, null, 2));
+
+  const executions = await db.workflowStepExecution.findMany({
+    where: { workshopId: workshop.id },
+    select: {
+      id: true,
+      stepId: true,
+      status: true,
+      scheduledFor: true,
+      executedAt: true,
+      errorMessage: true,
+      attempts: true,
+      inngestEventId: true,
+      registrationId: true,
+      createdAt: true,
+    },
+    orderBy: { scheduledFor: "asc" },
+  });
+
+  console.log("\n=== WORKFLOW STEP EXECUTIONS ===");
+  if (executions.length === 0) {
+    console.log("(none)");
+  } else {
+    for (const ex of executions) {
+      console.log(JSON.stringify(ex, null, 2));
+    }
+  }
+
+  const registrations = await db.registration.findMany({
+    where: { workshopId: workshop.id },
+    select: {
+      id: true,
+      email: true,
+      status: true,
+      createdAt: true,
+    },
+  });
+
+  console.log("\n=== REGISTRATIONS ===");
+  console.log(JSON.stringify(registrations, null, 2));
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(() => db.$disconnect());

--- a/src/src/__tests__/inngest/execute-workflow.test.ts
+++ b/src/src/__tests__/inngest/execute-workflow.test.ts
@@ -1302,6 +1302,84 @@ describe("execute-workflow Inngest function", () => {
   });
 
   // ------------------------------------------------------------------
+  // BUG-MAY4-1b: 0-attendees → SKIPPED (not false SENT)
+  // ------------------------------------------------------------------
+  describe("BUG-MAY4-1b: zero-registrant steps record SKIPPED, not SENT", () => {
+    it("EMAIL_ATTENDEES with 0 registrants: records SKIPPED, sends no emails", async () => {
+      const assignment = makeAssignment({
+        steps: [
+          makeStep({
+            stepType: "EMAIL_ATTENDEES",
+            subject: "Hi",
+            body: "Body",
+          }),
+        ],
+      });
+      findUnique.mockResolvedValue(assignment);
+      registrationFindMany.mockResolvedValue([]); // 0 registrants
+
+      await invoke();
+
+      expect(mockSendEmail).not.toHaveBeenCalled();
+      const sentCall = executionCreate.mock.calls.find(
+        ([arg]: [{ data?: Record<string, unknown> }]) => arg?.data?.status === "SENT"
+      );
+      expect(sentCall).toBeUndefined();
+      const skippedCall = executionCreate.mock.calls.find(
+        ([arg]: [{ data?: Record<string, unknown> }]) => arg?.data?.status === "SKIPPED"
+      );
+      expect(skippedCall).toBeDefined();
+    });
+
+    it("SEND_SURVEY_LINK with 0 registrants: records SKIPPED with 'no recipients' reason", async () => {
+      const assignment = makeAssignment({
+        steps: [
+          makeStep({
+            id: "step-survey",
+            stepType: "SEND_SURVEY_LINK",
+            subject: "Survey",
+            body: "Take it",
+          }),
+        ],
+      });
+      findUnique.mockResolvedValue(assignment);
+      registrationFindMany.mockResolvedValue([]);
+
+      await invoke();
+
+      expect(mockSendEmail).not.toHaveBeenCalled();
+      expect(mockGetOrCreateSurveyLink).not.toHaveBeenCalled();
+      const skippedCall = executionCreate.mock.calls.find(
+        ([arg]: [{ data?: Record<string, unknown> }]) => arg?.data?.status === "SKIPPED"
+      );
+      expect(skippedCall).toBeDefined();
+    });
+
+    it("SEND_FILE_LINK with 0 registrants: records SKIPPED, sends no emails", async () => {
+      const assignment = makeAssignment({
+        steps: [
+          makeStep({
+            id: "step-files",
+            stepType: "SEND_FILE_LINK",
+            subject: "Files",
+            body: "Get them",
+          }),
+        ],
+      });
+      findUnique.mockResolvedValue(assignment);
+      registrationFindMany.mockResolvedValue([]);
+
+      await invoke();
+
+      expect(mockSendEmail).not.toHaveBeenCalled();
+      const skippedCall = executionCreate.mock.calls.find(
+        ([arg]: [{ data?: Record<string, unknown> }]) => arg?.data?.status === "SKIPPED"
+      );
+      expect(skippedCall).toBeDefined();
+    });
+  });
+
+  // ------------------------------------------------------------------
   // BUG-09: scheduledFor preservation
   // ------------------------------------------------------------------
   describe("BUG-09 scheduledFor preservation", () => {

--- a/src/src/__tests__/lib/resolve-event-start-moment.test.ts
+++ b/src/src/__tests__/lib/resolve-event-start-moment.test.ts
@@ -1,0 +1,115 @@
+/**
+ * BUG-MAY4-1a: resolveEventStartMoment combines Workshop.eventDate (midnight UTC)
+ * with Workshop.eventTime (free-form string like "16:00 - 18:00") and
+ * Workshop.timezone (IANA like "America/New_York") into a real Date pointing
+ * at the actual moment the event starts.
+ *
+ * Without this, calculateSendDate(eventDate, offsetHours) computes scheduledFor
+ * from midnight UTC and lands ~20 hours before the actual event start time
+ * for a 4 PM EDT workshop.
+ */
+
+import { resolveEventStartMoment } from "@/lib/workflows/resolve-event-start-moment";
+import { calculateSendDate } from "@/lib/workflows/workflow-service";
+
+describe("resolveEventStartMoment — BUG-MAY4-1a", () => {
+  it("Jeff's exact failing case: midnight UTC + '16:00 - 18:00' + 'America/New_York' resolves to 4 PM EDT (May 4 20:00 UTC)", () => {
+    const workshop = {
+      eventDate: new Date("2026-05-04T00:00:00.000Z"),
+      eventTime: "16:00 - 18:00",
+      timezone: "America/New_York",
+    };
+
+    const result = resolveEventStartMoment(workshop);
+
+    // 4 PM EDT on May 4, 2026 = 20:00 UTC (EDT = UTC-4 in May)
+    expect(result.toISOString()).toBe("2026-05-04T20:00:00.000Z");
+  });
+
+  it("non-DST winter: '09:00' + 'America/Los_Angeles' on Dec 1 resolves to 17:00 UTC (PST = UTC-8)", () => {
+    const workshop = {
+      eventDate: new Date("2026-12-01T00:00:00.000Z"),
+      eventTime: "09:00",
+      timezone: "America/Los_Angeles",
+    };
+
+    const result = resolveEventStartMoment(workshop);
+
+    expect(result.toISOString()).toBe("2026-12-01T17:00:00.000Z");
+  });
+
+  it("missing eventTime → falls back to eventDate as stored (no time-of-day shift)", () => {
+    const eventDate = new Date("2026-05-04T00:00:00.000Z");
+    const workshop = {
+      eventDate,
+      eventTime: null,
+      timezone: "America/New_York",
+    };
+
+    const result = resolveEventStartMoment(workshop);
+
+    expect(result.toISOString()).toBe(eventDate.toISOString());
+  });
+
+  it("malformed eventTime ('TBD') → falls back to eventDate as stored", () => {
+    const eventDate = new Date("2026-05-04T00:00:00.000Z");
+    const workshop = {
+      eventDate,
+      eventTime: "TBD",
+      timezone: "America/New_York",
+    };
+
+    const result = resolveEventStartMoment(workshop);
+
+    expect(result.toISOString()).toBe(eventDate.toISOString());
+  });
+
+  it("missing timezone → treats wall-clock as UTC", () => {
+    const workshop = {
+      eventDate: new Date("2026-05-04T00:00:00.000Z"),
+      eventTime: "16:00",
+      timezone: null,
+    };
+
+    const result = resolveEventStartMoment(workshop);
+
+    // 16:00 UTC on the event day
+    expect(result.toISOString()).toBe("2026-05-04T16:00:00.000Z");
+  });
+
+  it("DST spring-forward day: 10:00 EDT on March 8 2026 resolves correctly (spring forward at 02:00 local)", () => {
+    // March 8 2026 in America/New_York: DST starts at 02:00 local. After 02:00 → EDT (UTC-4).
+    const workshop = {
+      eventDate: new Date("2026-03-08T00:00:00.000Z"),
+      eventTime: "10:00",
+      timezone: "America/New_York",
+    };
+
+    const result = resolveEventStartMoment(workshop);
+
+    // 10:00 EDT = 14:00 UTC (DST active)
+    expect(result.toISOString()).toBe("2026-03-08T14:00:00.000Z");
+  });
+
+  it("integration with calculateSendDate: Jeff's exact prod failure case now produces 3 PM EDT, not 23:00 UTC the day before", () => {
+    // Jeff's prod row from WS-2026-QN5H:
+    //   eventDate = 2026-05-04T00:00:00Z (midnight UTC May 4)
+    //   eventTime = "16:00 - 18:00"
+    //   timezone = "America/New_York"
+    //   step.offsetHours = -1 (1 hour before)
+    //
+    // BEFORE this fix: calculateSendDate(midnight UTC, 0, -1) → 2026-05-03T23:00:00Z
+    //                  (20 hours before actual event start)
+    // AFTER this fix:  resolveEventStartMoment first → 2026-05-04T20:00:00Z (4 PM EDT)
+    //                  then calculateSendDate(20:00 UTC, 0, -1) → 2026-05-04T19:00:00Z (3 PM EDT)
+    const startMoment = resolveEventStartMoment({
+      eventDate: new Date("2026-05-04T00:00:00.000Z"),
+      eventTime: "16:00 - 18:00",
+      timezone: "America/New_York",
+    });
+
+    const scheduledFor = calculateSendDate(startMoment, 0, -1, null, "America/New_York");
+
+    expect(scheduledFor.toISOString()).toBe("2026-05-04T19:00:00.000Z");
+  });
+});

--- a/src/src/inngest/functions/execute-workflow.ts
+++ b/src/src/inngest/functions/execute-workflow.ts
@@ -18,6 +18,7 @@ import {
   scheduleWorkflowExecution,
   recordWorkflowExecution,
 } from "@/lib/workflows/record-workflow-execution";
+import { resolveEventStartMoment } from "@/lib/workflows/resolve-event-start-moment";
 import { buildLocationString } from "@/lib/ics-generator";
 import {
   buildProtectedEmailAttachments,
@@ -94,8 +95,16 @@ export const executeWorkflow = inngest.createFunction(
     const { workflow, workshop } = assignment;
     const appUrl = process.env.APP_URL || "https://scaling-up-platform-v2.vercel.app";
 
-    // eventDate may be serialized to string through Inngest step.run
-    const eventDate = new Date(workshop.eventDate);
+    // BUG-MAY4-1a: Workshop.eventDate is stored as midnight UTC; the actual
+    // time-of-day lives in workshop.eventTime ("16:00 - 18:00") and the IANA
+    // zone in workshop.timezone. Combine them to the true start moment so
+    // calculateSendDate offsets land on real wall-clock times instead of
+    // ~20 hours before the event.
+    const eventDate = resolveEventStartMoment({
+      eventDate: new Date(workshop.eventDate),
+      eventTime: workshop.eventTime,
+      timezone: workshop.timezone,
+    });
 
     // Build context for variable interpolation
     const baseContext: WorkflowContext = {
@@ -349,14 +358,16 @@ export const executeWorkflow = inngest.createFunction(
                 });
               }
 
-              // Record execution (BUG-09: preserve scheduledFor + transition SCHEDULED row)
+              // BUG-MAY4-1b: 0 registrants → SKIPPED (not false SENT)
+              const emailsSent = sentEmails.size;
               await recordWorkflowExecution(db, {
                 executionId,
                 stepId: workflowStep.id,
                 workshopId: workshop.id,
-                status: "SENT",
+                status: emailsSent > 0 ? "SENT" : "SKIPPED",
                 scheduledFor: effectiveScheduledFor,
                 executedAt: new Date(),
+                ...(emailsSent === 0 ? { error: "No recipients at scheduled time" } : {}),
               });
 
               stepsExecuted++;

--- a/src/src/lib/workflows/resolve-event-start-moment.ts
+++ b/src/src/lib/workflows/resolve-event-start-moment.ts
@@ -1,0 +1,97 @@
+/**
+ * BUG-MAY4-1a: Resolve a Workshop's actual start moment by combining its
+ * stored eventDate (midnight UTC, date-only), eventTime (free-form string),
+ * and timezone (IANA, e.g. "America/New_York").
+ *
+ * Why: Workshop.eventDate is stored as 00:00 UTC of the event day, with the
+ * actual time-of-day kept separately as a string in eventTime ("16:00 - 18:00")
+ * and the IANA zone in timezone. calculateSendDate previously did naive
+ * arithmetic against midnight UTC, producing scheduledFor values 20+ hours
+ * before the real event. This helper produces the true start moment as a Date
+ * (UTC) so downstream code can offset against it correctly.
+ */
+
+export interface WorkshopStartMomentInput {
+  eventDate: Date;
+  eventTime?: string | null;
+  timezone?: string | null;
+}
+
+export function resolveEventStartMoment(workshop: WorkshopStartMomentInput): Date {
+  const startStr = parseStartTime(workshop.eventTime);
+  if (!startStr) return new Date(workshop.eventDate);
+
+  const { hour, minute } = startStr;
+
+  const year = workshop.eventDate.getUTCFullYear();
+  const month = workshop.eventDate.getUTCMonth() + 1; // 1-12
+  const day = workshop.eventDate.getUTCDate();
+
+  const tz = workshop.timezone || "UTC";
+
+  return zonedWallClockToUtc(year, month, day, hour, minute, tz);
+}
+
+function parseStartTime(raw: string | null | undefined): { hour: number; minute: number } | null {
+  if (!raw) return null;
+
+  // "16:00 - 18:00" → "16:00"; "16:00" → "16:00"
+  const startSegment = raw.split(/[-–—]/)[0]?.trim();
+  if (!startSegment) return null;
+
+  const match = startSegment.match(/^(\d{1,2}):(\d{2})$/);
+  if (!match) return null;
+
+  const hour = parseInt(match[1], 10);
+  const minute = parseInt(match[2], 10);
+  if (Number.isNaN(hour) || Number.isNaN(minute)) return null;
+  if (hour < 0 || hour > 23 || minute < 0 || minute > 59) return null;
+
+  return { hour, minute };
+}
+
+/**
+ * Given a wall-clock moment (year/month/day/hour/minute) in a specific IANA
+ * timezone, return the corresponding UTC Date. Handles DST transitions via
+ * Intl.DateTimeFormat (the platform's tzdata).
+ */
+function zonedWallClockToUtc(
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  timezone: string
+): Date {
+  // First guess: treat the wall-clock as UTC.
+  const guessUtc = Date.UTC(year, month - 1, day, hour, minute);
+
+  // Ask Intl what wall-clock that UTC moment shows in the target timezone.
+  const fmt = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+  const parts = Object.fromEntries(
+    fmt.formatToParts(new Date(guessUtc)).map((p) => [p.type, p.value])
+  );
+
+  const tzYear = parseInt(parts.year, 10);
+  const tzMonth = parseInt(parts.month, 10);
+  const tzDay = parseInt(parts.day, 10);
+  // Intl sometimes emits "24" for midnight; normalize.
+  const tzHour = parseInt(parts.hour, 10) % 24;
+  const tzMinute = parseInt(parts.minute, 10);
+
+  const tzAsUtc = Date.UTC(tzYear, tzMonth - 1, tzDay, tzHour, tzMinute);
+
+  // The difference is the timezone's offset for that moment.
+  // Adjusting the guess by the offset lands at the true UTC for the wall-clock.
+  const offset = guessUtc - tzAsUtc;
+  return new Date(guessUtc + offset);
+}


### PR DESCRIPTION
## Root cause (from prod DB, workshop WS-2026-QN5H)

Workshop.eventDate is stored as midnight UTC. eventTime ("16:00 - 18:00") and timezone ("America/New_York") were never factored into scheduling. calculateSendDate received midnight-UTC and computed scheduledFor ~20h in the past → Inngest fired all 3 steps immediately at assignment (1:52 PM), 4 minutes before Bilbo registered and 1h+ before any configured offset.

Second bug stacked on top: EMAIL_ATTENDEES always wrote status="SENT" even when 0 registrants looped → false success with no emails leaving the system.

## Changes

### BUG-MAY4-1a — timing fix
- New `src/lib/workflows/resolve-event-start-moment.ts`: combines eventDate + eventTime + IANA timezone into the true UTC start moment using `Intl.DateTimeFormat` offset math (no new dependencies, handles DST).
- `execute-workflow.ts`: feeds `resolveEventStartMoment(workshop)` into `calculateSendDate` instead of raw `new Date(workshop.eventDate)`.
- 6 new unit tests covering Jeff's exact case, PST winter, null/malformed eventTime fallbacks, DST spring-forward, and integration with calculateSendDate.

### BUG-MAY4-1b — false-SENT fix
- `execute-workflow.ts` EMAIL_ATTENDEES: status now `sentEmails.size > 0 ? "SENT" : "SKIPPED"` with `error: "No recipients at scheduled time"` when 0 registrants.
- 3 new regression guards: EMAIL_ATTENDEES, SEND_SURVEY_LINK, SEND_FILE_LINK all with 0 registrants.

## Test results
933/933 passing. Build verified (next build clean, migrate deploy skipped due to Neon cold-start; runs on Vercel).

## Verification plan
After merge: replicate Jeff's failure mode on prod — create workshop 10min out, assign Standard Test Event workflow, verify steps fire at correct offset (not immediately), verify 0-attendee shows SKIPPED in Execution Status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)