### PR TITLE
fix: Execution Status truthfulness + Trigger Now timing (3 follow-ons)

### DIFF
--- a/src/src/__tests__/inngest/execute-workflow.test.ts
+++ b/src/src/__tests__/inngest/execute-workflow.test.ts
@@ -1353,6 +1353,36 @@ describe("execute-workflow Inngest function", () => {
         ([arg]: [{ data?: Record<string, unknown> }]) => arg?.data?.status === "SKIPPED"
       );
       expect(skippedCall).toBeDefined();
+      // BUG-MAY4 follow-on: error must say "no recipients", NOT "No survey link could be generated"
+      expect(skippedCall?.[0]?.data?.errorMessage).toBe("No recipients at scheduled time");
+    });
+
+    it("SEND_SURVEY_LINK with registrants but link generation fails: keeps 'No survey link could be generated' message", async () => {
+      const assignment = makeAssignment({
+        steps: [
+          makeStep({
+            id: "step-survey",
+            stepType: "SEND_SURVEY_LINK",
+            subject: "Survey",
+            body: "Take it",
+          }),
+        ],
+      });
+      findUnique.mockResolvedValue(assignment);
+      registrationFindMany.mockResolvedValue([
+        { id: "reg-1", email: "a@test.com", firstName: "A", lastName: "B", company: "" },
+      ]);
+      mockGetOrCreateSurveyLink.mockResolvedValue(null); // generation fails
+
+      await invoke();
+
+      expect(mockSendEmail).not.toHaveBeenCalled();
+      const skippedCall = executionCreate.mock.calls.find(
+        ([arg]: [{ data?: Record<string, unknown> }]) => arg?.data?.status === "SKIPPED"
+      );
+      expect(skippedCall).toBeDefined();
+      // Genuine link-gen failure path keeps its specific message — regression guard
+      expect(skippedCall?.[0]?.data?.errorMessage).toBe("No survey link could be generated");
     });
 
     it("SEND_FILE_LINK with 0 registrants: records SKIPPED, sends no emails", async () => {
@@ -1376,6 +1406,49 @@ describe("execute-workflow Inngest function", () => {
         ([arg]: [{ data?: Record<string, unknown> }]) => arg?.data?.status === "SKIPPED"
       );
       expect(skippedCall).toBeDefined();
+    });
+
+    it("SEND_FILE_LINK with files attached AND 0 registrants: records SKIPPED, NOT SENT", async () => {
+      // BUG-MAY4 follow-on: files attached but no recipients → must NOT record SENT
+      mockGetStepFiles.mockResolvedValue([
+        { id: "file-1", filename: "guide.pdf", contentType: "application/pdf" },
+      ]);
+      mockBuildAttachments.mockReturnValue([
+        {
+          filename: "guide.pdf",
+          path: "https://app.test/api/files/file-1/download?token=abc",
+          contentType: "application/pdf",
+        },
+      ]);
+
+      const assignment = makeAssignment({
+        steps: [
+          makeStep({
+            id: "step-files",
+            stepType: "SEND_FILE_LINK",
+            subject: "Files",
+            body: "{{fileLinks}}",
+          }),
+        ],
+      });
+      findUnique.mockResolvedValue(assignment);
+      registrationFindMany.mockResolvedValue([]); // 0 recipients
+
+      await invoke();
+
+      expect(mockSendEmail).not.toHaveBeenCalled();
+
+      // Must NOT have a SENT record — the previous false-SENT bug
+      const sentCall = executionCreate.mock.calls.find(
+        ([arg]: [{ data?: Record<string, unknown> }]) => arg?.data?.status === "SENT"
+      );
+      expect(sentCall).toBeUndefined();
+
+      const skippedCall = executionCreate.mock.calls.find(
+        ([arg]: [{ data?: Record<string, unknown> }]) => arg?.data?.status === "SKIPPED"
+      );
+      expect(skippedCall).toBeDefined();
+      expect(skippedCall?.[0]?.data?.errorMessage).toBe("No recipients at scheduled time");
     });
   });
 

--- a/src/src/__tests__/inngest/trigger-workflow-step.test.ts
+++ b/src/src/__tests__/inngest/trigger-workflow-step.test.ts
@@ -43,6 +43,10 @@ jest.mock("@/lib/workflows/workflow-service", () => ({
     interpolateTemplate: jest.fn((input: string) => input),
 }));
 
+jest.mock("@/lib/workflows/resolve-event-start-moment", () => ({
+    resolveEventStartMoment: jest.fn(),
+}));
+
 jest.mock("@/lib/workflows/workflow-types", () => ({
     STEP_TYPES: {
         EMAIL_ATTENDEES: "EMAIL_ATTENDEES",
@@ -95,6 +99,8 @@ jest.mock("@/lib/surveys/survey-automation", () => ({
 
 import { db } from "@/lib/db";
 import { sendEmailViaSMTP } from "@/lib/smtp-transport";
+import { interpolateTemplate } from "@/lib/workflows/workflow-service";
+import { resolveEventStartMoment } from "@/lib/workflows/resolve-event-start-moment";
 
 // Force the module to load so capturedHandler is assigned
 import "@/inngest/functions/trigger-workflow-step";
@@ -169,6 +175,10 @@ describe("triggerWorkflowStep Inngest function", () => {
         (db.workflowStep.findUnique as jest.Mock).mockResolvedValue(makeWorkflowStep());
         (db.workshop.findUnique as jest.Mock).mockResolvedValue(makeWorkshop());
         (db.registration.findMany as jest.Mock).mockResolvedValue([]);
+        // Default: pass through eventDate untouched. Specific tests override.
+        (resolveEventStartMoment as jest.Mock).mockImplementation(
+            (input: { eventDate: Date }) => input.eventDate
+        );
     });
 
     // ------------------------------------------
@@ -498,6 +508,52 @@ describe("triggerWorkflowStep Inngest function", () => {
                     data: expect.objectContaining({ status: "SENT" }),
                 })
             );
+        });
+    });
+
+    // ------------------------------------------
+    // BUG-MAY4 follow-on: workshopDate uses resolveEventStartMoment, not raw midnight UTC
+    // ------------------------------------------
+    describe("workshopDate context: uses resolveEventStartMoment", () => {
+        it("interpolates workshopDate from resolveEventStartMoment, NOT raw workshop.eventDate", async () => {
+            // Workshop eventDate is stored as midnight UTC of one day; the true
+            // local-zone start moment is on a different calendar day.
+            (db.workshop.findUnique as jest.Mock).mockResolvedValue(
+                makeWorkshop({
+                    eventDate: new Date("2026-06-01T00:00:00.000Z"), // Mon Jun 1 in UTC
+                    eventTime: "9:00 AM",
+                    timezone: "America/New_York",
+                })
+            );
+            // Force resolveEventStartMoment to return a clearly different date
+            // so the test can distinguish raw-eventDate vs resolved-moment paths.
+            (resolveEventStartMoment as jest.Mock).mockReturnValue(
+                new Date("2026-07-15T13:00:00.000Z") // Wed Jul 15 in UTC
+            );
+
+            await capturedHandler({ event: buildEvent(), step: mockStep });
+
+            // Verify resolveEventStartMoment was called with the workshop's date/time/zone
+            expect(resolveEventStartMoment).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    eventTime: "9:00 AM",
+                    timezone: "America/New_York",
+                })
+            );
+
+            // Verify interpolateTemplate received workshopDate from the RESOLVED moment,
+            // not from raw workshop.eventDate (Jun 1).
+            const interpolateCalls = (interpolateTemplate as jest.Mock).mock.calls;
+            const callsWithWorkshopDate = interpolateCalls.filter(
+                ([, ctx]: [unknown, { workshopDate?: string } | undefined]) =>
+                    ctx && typeof ctx.workshopDate === "string"
+            );
+            expect(callsWithWorkshopDate.length).toBeGreaterThan(0);
+            for (const [, ctx] of callsWithWorkshopDate) {
+                expect(ctx.workshopDate).toContain("July");
+                expect(ctx.workshopDate).toContain("15");
+                expect(ctx.workshopDate).not.toContain("June");
+            }
         });
     });
 });

--- a/src/src/inngest/functions/execute-workflow.ts
+++ b/src/src/inngest/functions/execute-workflow.ts
@@ -397,6 +397,19 @@ export const executeWorkflow = inngest.createFunction(
                 select: { id: true, email: true, firstName: true, lastName: true, company: true },
               });
 
+              if (registrations.length === 0) {
+                await recordWorkflowExecution(db, {
+                  executionId,
+                  stepId: workflowStep.id,
+                  workshopId: workshop.id,
+                  status: "SKIPPED",
+                  scheduledFor: effectiveScheduledFor,
+                  executedAt: new Date(),
+                  error: "No recipients at scheduled time",
+                });
+                return;
+              }
+
               const surveyType = resolveSurveyType(workflowStep);
               let sentCount = 0;
               for (const reg of registrations) {
@@ -550,6 +563,7 @@ export const executeWorkflow = inngest.createFunction(
               });
               const fileLinks = buildFileLinksHtml(protectedLinks);
 
+              let fileEmailsSent = 0;
               for (const reg of registrations) {
                 const personalContext: WorkflowContext = {
                   ...baseContext,
@@ -584,18 +598,20 @@ export const executeWorkflow = inngest.createFunction(
                     },
                   },
                 });
+                fileEmailsSent++;
               }
 
               await recordWorkflowExecution(db, {
                 executionId,
                 stepId: workflowStep.id,
                 workshopId: workshop.id,
-                status: "SENT",
+                status: fileEmailsSent > 0 ? "SENT" : "SKIPPED",
                 scheduledFor: effectiveScheduledFor,
                 executedAt: new Date(),
+                ...(fileEmailsSent === 0 ? { error: "No recipients at scheduled time" } : {}),
               });
 
-              stepsExecuted++;
+              if (fileEmailsSent > 0) stepsExecuted++;
               return;
             }
 

--- a/src/src/inngest/functions/trigger-workflow-step.ts
+++ b/src/src/inngest/functions/trigger-workflow-step.ts
@@ -15,6 +15,7 @@ import {
     type WorkflowContext,
 } from "@/lib/workflows/workflow-service";
 import { STEP_TYPES, TRIGGER_TYPES } from "@/lib/workflows/workflow-types";
+import { resolveEventStartMoment } from "@/lib/workflows/resolve-event-start-moment";
 import { buildLocationString } from "@/lib/ics-generator";
 import {
     buildProtectedEmailAttachments,
@@ -106,7 +107,15 @@ export const triggerWorkflowStep = inngest.createFunction(
 
         const appUrl =
             process.env.APP_URL || "https://scaling-up-platform-v2.vercel.app";
-        const eventDate = new Date(workshop.eventDate);
+        // BUG-MAY4 follow-on: workshop.eventDate is midnight UTC; the actual event
+        // start is in eventTime + timezone. Resolve to the true UTC moment so the
+        // workshopDate / workshopTime context vars match what users actually see
+        // in their inbox — same swap execute-workflow.ts already got in BUG-MAY4-1a.
+        const eventDate = resolveEventStartMoment({
+            eventDate: new Date(workshop.eventDate),
+            eventTime: workshop.eventTime,
+            timezone: workshop.timezone,
+        });
 
         const baseContext: WorkflowContext = {
             workshopTitle: workshop.title,


### PR DESCRIPTION
## Summary

Three follow-on fixes after BUG-MAY4-1a+1b+2+3 production verification surfaced remaining gaps in the same files we just touched. All bundled into one PR — same file area, same `resolveEventStartMoment` helper for fix #3, same shape for fixes #1 + #2.

## Fixes

### 1. SEND_SURVEY_LINK error message — [execute-workflow.ts](src/src/inngest/functions/execute-workflow.ts)
With 0 registrants, the row showed "No survey link could be generated" — misleading, implies a template lookup problem when the real reason is just no recipients. Added early-exit before the registrations loop: 0 recipients → SKIPPED with `"No recipients at scheduled time"`. The existing `sentCount === 0` fallback after the loop is preserved (regression-guarded by a new test) so the genuine link-gen failure path keeps its specific message.

### 2. SEND_FILE_LINK false-SENT — [execute-workflow.ts](src/src/inngest/functions/execute-workflow.ts)
Loop ran 0 times with 0 registrants but the terminal `recordWorkflowExecution` still wrote `status: "SENT"` unconditionally. Identical shape to the EMAIL_ATTENDEES false-SENT bug fixed in BUG-MAY4-1b. Added a `fileEmailsSent` counter, terminal status now reflects actual sends (`SENT` if any went out, `SKIPPED` with the same "no recipients" reason otherwise).

### 3. Trigger Now midnight UTC — [trigger-workflow-step.ts](src/src/inngest/functions/trigger-workflow-step.ts)
Used raw `new Date(workshop.eventDate)` (midnight UTC) when building the email body context, so `{{workshopDate}}` / `{{workshopTime}}` substitutions landed on the wrong day for any workshop where the local-zone moment differs from midnight UTC. Same swap [execute-workflow.ts](src/src/inngest/functions/execute-workflow.ts) got in BUG-MAY4-1a — feeds `resolveEventStartMoment({ eventDate, eventTime, timezone })` into the context.

## Tests

3 new RED → GREEN tests via TDD; each one watched fail before implementation:

- `SEND_SURVEY_LINK with 0 registrants: records SKIPPED with 'no recipients' reason` — asserts errorMessage is "No recipients at scheduled time"
- `SEND_SURVEY_LINK with registrants but link generation fails: keeps 'No survey link could be generated' message` — regression guard for the genuine failure path
- `SEND_FILE_LINK with files attached AND 0 registrants: records SKIPPED, NOT SENT` — asserts no SENT call when 0 recipients even with files attached
- `triggerWorkflowStep workshopDate context: uses resolveEventStartMoment` — mocks helper to a clearly-different date and asserts interpolateTemplate receives that resolved date in workshopDate

52/52 tests in execute-workflow + trigger-workflow-step suites pass. 936 total tests across the codebase pass.

## Test plan
- [x] `npx jest --testPathPatterns "execute-workflow|trigger-workflow-step"` — 52/52 pass
- [x] `npx jest` (full suite) — 936/936 pass
- [x] `npx next build` — compiles clean
- [ ] Manual: Trigger workflow with 0 registrants → all 3 rows show "No recipients at scheduled time" in Execution Status tab (rows 1 and 2 already do post-BUG-MAY4-1b; this PR makes row 3 match)
- [ ] Manual: Click Trigger Now on a per-attendee step → email body shows correct workshop date in workshop's timezone, not yesterday-UTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)