### PR TITLE
docs: CLAUDE.md — Execution Status follow-on PR #15 sprint summary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ the full workshop lifecycle from request through post-event follow-up.
 | **Live URL** | `scaling-up-platform-v2.vercel.app` |
 | **Client** | Jeff Verdun, CIO - Scaling Up |
 | **Operations** | Suzanne (handles manual approvals) |
-| **Last Updated** | May 5, 2026 — Jeff May 4 meeting bugs shipped (BUG-MAY4-1a+1b+2+3) |
+| **Last Updated** | May 6, 2026 — Execution Status follow-on PR #15 shipped (SEND_SURVEY_LINK msg + SEND_FILE_LINK false-SENT + Trigger Now midnight UTC) |
 | **Work Logs** | Session work logs at `~/.claude/worklogs/` — invoke `/log-session` to log or generate reports |
 
 ## Current Status
@@ -27,7 +27,11 @@ the full workshop lifecycle from request through post-event follow-up.
 - BUG-MAY4-1b (false-SENT): `EMAIL_ATTENDEES` always wrote `status="SENT"` even with 0 registrants. Fixed to `sentEmails.size > 0 ? "SENT" : "SKIPPED"` with `error: "No recipients at scheduled time"`. `SEND_SURVEY_LINK` already used `sentCount`-based status; `SEND_FILE_LINK` already had an early-exit guard.
 - BUG-MAY4-2 (duplicate email): `runAutoBuild` called concurrently from GET email-link + POST dashboard approval handlers, both calling `sendWorkshopBuiltEmail`. Fixed with atomic `db.workshop.updateMany({ where: { workshopBuiltEmailSentAt: null } })` claim — only the first concurrent caller wins. New `Workshop.workshopBuiltEmailSentAt DateTime?` column (migration `20260505100000_add_workshop_built_email_sent_at`). Also added `id: "workshop-approved-${workshopId}-${approvalId}"` to all 3 `inngest.send("workshop/approved")` calls for Inngest-level dedup keyed to approvalId.
 - BUG-MAY4-3 (misleading badges): Per-step SENT/SKIPPED/FAILED badges removed from workshop detail Workflow Status card and workflow editor Execution Status tab. A step fires per-recipient — a single badge across N attendees is meaningless.
-- 933 tests passing (up from 914) — 6 new `resolve-event-start-moment` tests + 3 BUG-MAY4-1b guards
+- **Follow-on PR #15 (May 6 2026, commit `07c58a8`):** three residual fixes surfaced during May 5 production manual test:
+  - SEND_SURVEY_LINK 0-recipients message: `execute-workflow.ts` now early-exits before the survey loop and writes `error: "No recipients at scheduled time"` (was misleading `"No survey link could be generated"`). Existing `sentCount === 0` fallback preserved for genuine link-gen failures (regression-guarded).
+  - SEND_FILE_LINK false-SENT: `execute-workflow.ts` SEND_FILE_LINK handler now tracks `fileEmailsSent` and writes `status: "SENT"` only if at least one email went out. With files attached AND 0 registrants the row was previously written as SENT — same shape as the EMAIL_ATTENDEES bug fixed in BUG-MAY4-1b.
+  - Trigger Now midnight-UTC body context: `trigger-workflow-step.ts:109` now feeds `resolveEventStartMoment({ eventDate, eventTime, timezone })` into the email body interpolation context. Was using raw `new Date(workshop.eventDate)` (midnight UTC) so `{{workshopDate}}` / `{{workshopTime}}` substitutions landed on the wrong day for workshops where the local-zone moment differs from midnight UTC. Same swap `execute-workflow.ts` got in BUG-MAY4-1a.
+- 936 tests passing (up from 933) — 3 new RED→GREEN guards (SEND_SURVEY_LINK error msg, SEND_FILE_LINK files-with-0-recipients, trigger-workflow-step `workshopDate` uses `resolveEventStartMoment`)
 
 **Jeff Apr 30 Sprint** — Complete (May 4 2026, all 12 items on main):
 - BUG-01 (commit b139380): password-reset welcome email link no longer 404s — dropped `/auth/` prefix from `api/coaches/route.ts:142` + `api/coaches/[id]/send-password-reset/route.ts:34`


### PR DESCRIPTION
## Summary
Updates CLAUDE.md to record the three follow-on fixes shipped in PR #15 (commit `07c58a8`) on May 6, 2026:

- SEND_SURVEY_LINK 0-recipients message corrected → "No recipients at scheduled time"
- SEND_FILE_LINK false-SENT eliminated via `fileEmailsSent` counter
- Trigger Now midnight-UTC body context fixed via `resolveEventStartMoment`

Adds these as a sub-bullet under the BUG-MAY4 entry. Bumps test count 933 → 936 and updates the Last Updated date.

## Test plan
- [x] Markdown renders cleanly
- [x] Information accurate to commit `07c58a8` (PR #15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)