### PR TITLE
feat(assessment): setup-first flip — Slice 1 (Members + wizard)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,6 +1,6 @@
 # Plan — Issue #10: Assessment Tool with Team Hierarchies & Longitudinal Reporting
 
-> **Status (May 17 2026)**: v7.6 spec locked across 7 spec files in `docs/specs/v7.6/`. v1 foundation Tasks 0–4 shipped May 14; deployment to prod pending env-mismatch resolution (Task 9). v7.6 spec amendments (Tasks 5–9 next) wait for the user before any subagent dispatch.
+> **Status (May 27 2026)**: v7.6 spec locked (specs 01–08). **Current priority — the setup-first "flip"** (May 26 Jeff redirect): coaches manage Company→Team→Users *first*, then campaigns pick existing members. See [08 Members & Teams lane](docs/specs/v7.6/08-members-teams-lane.md) — contract-first Slices 1–5 on branch `feat/assessment-setup-first` (subagent-driven dev). Engine + seeds (Rockefeller / QSP v1+v2 / Scaling Up Full / LVA) already in prod. Prior Tasks 5–9 (May 17) are parked behind the flip.
 
 ## Spec library (v7.6 — canonical, locked May 15-16)
 
@@ -13,6 +13,7 @@
 | [05 Wireframes Wave 5](docs/specs/v7.6/05-wireframes-wave5.md) | Wave 2 revisions + Wave 5 deliverables (markdown + HTML acceptance criteria) |
 | [06 Observability](docs/specs/v7.6/06-observability.md) | 7 metrics, 6 alert gates, /admin/observability deploy-time dashboard |
 | [07 Bootstrap runbook](docs/specs/v7.6/07-bootstrap-runbook.md) | Admin first-time setup (bulk-add certified coaches to default group) |
+| [08 Members & Teams lane](docs/specs/v7.6/08-members-teams-lane.md) | **Setup-first flip (current priority)**: (A+) Company=Organization as a unified team tree, 12 locked decisions, contract-first Slices 1–5, Esperto UX parity |
 
 ## Locked-decisions ledger (one line each)
 
@@ -27,6 +28,7 @@
 | 7 | Self-signed coach lands with zero assessment access until admin adds to a group | 02-service-layer-rules, 07-bootstrap-runbook |
 | 8 | Admin aggregate dashboard MVP shape: template selector + version selector, no filters on day 1 | 06-observability |
 | 9 | Deploy via .env.production.local + dotenv-cli (one-shot injection); local .env NEVER overwritten | 04-deploy-runbook |
+| 10 | Setup-first flip (May 26): user structure before campaigns; wizard picks existing members (not inline-create); (A+) Company=Organization presented Esperto-style as a unified tree | 08-members-teams-lane |
 
 ## Active Notion tasks (May 14 + May 17)
 

--- a/docs/specs/v7.6/08-members-teams-lane.md
+++ b/docs/specs/v7.6/08-members-teams-lane.md
@@ -1,0 +1,62 @@
+# 08 — Members & Teams Lane (Setup-First "Flip")
+
+> **Status (May 27 2026)**: Current priority. Supersedes the pre-flip campaign-creation flow. Implementation on branch `feat/assessment-setup-first` via subagent-driven development. Engine + seeds (Rockefeller / QSP v1+v2 / Scaling Up Full / LVA) already in prod and unaffected.
+
+## Context
+
+May 26 2026 Zoom — Jeff stopped feature work: the assessment module's order of operations is wrong. Today a coach creates a campaign and types people in *while* building it. Flip it: set up **Company → Team → Users first**, as their own lane, then a campaign just **picks an existing company + a subset of its users**.
+
+Why: **reuse** (set people up once; future modules — e.g. one-page strategic plan — point at the same structure), **targeting** (send to *some* people, not all), **tracking** (coach sees companies they support + per-campaign who's done vs. who to nag).
+
+**Reference = Esperto Assessments** (esperto.one), white-labeled "Scaling Up Toolkit" at scalinguptoolkit.com — the **incumbent we're replacing** (contract expires July 1 2026). Walked live May 27: nav Home/Members/Campaigns/Reports; **no separate Organization object** (a Company is a Team with `type=Company` at the root of one unified tree); members carry a **Level**; Add Campaign wizard = Variant → Details → **Participants (check members from the team tree)** → Overview. Screenshot workbook: `From Jeff/APP_scaling up assessemnt/navigation.xlsx`.
+
+This is mostly **new UI on existing APIs** + a **wizard rewire**. No schema migration (`OrgRespondent.roleType` is an existing nullable column) — but a **legacy-data compatibility pass** is required.
+
+## Relationship to the v7.6 roadmap
+
+Consistent with the destination (replace Esperto by July 1) and contradicts none of the 9 locked v7.6 decisions — it **operationalizes decision #1** (coaches manage orgs + participants) with a UI the wireframe waves never specified, and relies on decision #3 (`Organization.ownerCoachId`). It changes the near-term *course*: priority shift, campaign-creation contract rewired to pick-existing, v1.5 "coach My Clients overview" pulled forward (Slice 5), and `navigation.xlsx`/Esperto UX added as a spec source. Access Groups (decisions #2/#6/#7) are orthogonal and untouched.
+
+## Locked decisions (grilled + Codex/self review, May 27)
+
+1. **(A+) Company = our `Organization`** (zero migration; campaigns keep `organizationId` FK), *presented* Esperto-style as a unified team tree with the company as the root node. Diverge from Esperto only where it allows cross-company campaigns / a single all-companies workspace — neither asked for.
+2. **Single unified Members screen** `/portal/members`: companies as root nodes; expand → lazy-load that company's `OrgTeam` tree; select node → members panel; "not associated with any team" bucket per company. **Typed node contract** `{ kind: "organization" | "team" | "unassigned" }` so edits/deletes/breadcrumbs/imports branch cleanly.
+3. **One "Add Team" modal** (Type = Company/Department/Team/Folder). Type=Company at root → `POST /api/organizations`; other types → `POST /api/organizations/[id]/teams`. **Guards:** Company is root-only; an existing `OrgTeam`'s type may NOT change to Company; a sub-team may NOT be reparented to root (schema can't convert a team into an Organization).
+4. **Levels = Esperto's 6 exactly** (Leadership team member / Employee / Guest / CEO/Founder with team / CEO/Founder alone / CEO/Founder) on `roleType`; **exact slugs pulled from Esperto's member CSV export** (don't guess). Sequenced after the vertical slice (metadata, not contract-critical).
+5. **Level *suggests* the campaign CEO; never silently sets it.** Pre-suggest a CEO/Founder-Level member; **require explicit single-CEO confirmation before save** (0 or >1 in selection → force a pick). The partial unique index is a guardrail, not product logic. (Same slice as #4.)
+6. **Wizard picks an existing company only** (CTA to Members lane if none); no inline org creation.
+7. **Member Import + single Add + CSV export**; defer xlsx/json/deactivate-all. **CSV idempotency explicit**: dedupe `(organizationId, normalizedEmail)` case/whitespace-insensitive, preserve campaign history, never duplicate by casing — verify existing bulk route enforces this; document.
+8. **Post-creation participant add (CampaignDetail) = add-existing ONLY in v1** (no quick-add — avoids polluting the roster while the coach thinks they're adding "just to this campaign"). Persistent quick-add lives in the **wizard** with explicit "adds to {Company}'s roster" labeling.
+9. **Nav "Members", heading "Members & Teams"** (Esperto-verbatim). Don't otherwise touch the sidebar.
+10. **Coach landing augmentation only** (companies + per-campaign metrics total/new/invited/started/completed); defer Esperto Home chart/clock/calendar.
+11. **Keep current wizard email handling**; defer Esperto Mail-timing controls.
+12. **Coach lane first; visual = our brand components** (presentable by default); pixel-faithful Esperto layout deferred to Slice 2.
+
+**Staged-progress mapping** (`AssessmentInvitation.status`): new = PENDING & `sentAt` null · invited = SENT · started = VIEWED · completed = SUBMITTED · REVOKED excluded.
+
+## Reused backend (do NOT rebuild)
+
+- Models (`src/prisma/schema.prisma`): `Organization(ownerCoachId)`, `OrgTeam`(hierarchical `parentTeamId`, `type`, `name`, `description`), `OrgRespondent`(`email`, `firstName`, `lastName`, `jobTitle`, `roleType` nullable, `teamId`), `AssessmentCampaign(organizationId` NOT NULL`)`, `AssessmentCampaignParticipant(isCEO`, partial-unique one CEO/campaign`)`.
+- APIs (tested, `src/src/__tests__/api/organizations/`): `/api/organizations` CRUD; `/api/organizations/[id]/teams` CRUD + tree-build + cycle-detection + soft-delete cascade; `/api/organizations/[id]/respondents` CRUD; `/api/organizations/[id]/respondents/bulk` (CSV, team-path auto-create, skip/merge, 500 cap).
+- Zod `src/src/lib/validations.ts` (team/respondent/campaign; `bulkRespondents` deprecated). CSV parser `src/src/lib/assessments/respondent-csv.ts`.
+- Nav `src/src/components/nav/assessments-sidebar.tsx` (coach "My Organizations" placeholder L73-74 → repoint `/portal/members`).
+- `CampaignWizard.tsx` (Step2 inline-create → removed; server helper `processBulkRespondentsForCreate` kept for BC). `CampaignDetail.tsx`. Coach landing `src/src/app/(portal)/portal/assessments/page.tsx`.
+
+## Implementation — contract-first vertical slice
+
+Prove the flip end-to-end first (de-risks the wizard rewire + legacy data); presentable brand components; pixel-faithful polish after. Each slice = shippable, gated by `CI=true npx next build --turbopack` + tests; TDD; subagent-driven development.
+
+- **Slice 1 (THE FLIP, demoable):** `/portal/members` (list companies, Add Team dual-create + guards, Add Member single, members list, typed node contract, sidebar repoint) + wizard Step0 pick-existing-company / Step2 pick-existing-members (no quick-add yet; manual CEO) / `saveCampaign` drops `bulkRespondents` + CampaignDetail add-existing-only + **regression & legacy-data tests**.
+- **Slice 2:** Members & Teams UX polish — unified lazy-load tree (company-as-root, unassigned bucket), pixel-faithful layout + brand colors, edit modals.
+- **Slice 3:** Levels + CEO suggestion — `src/src/lib/assessments/respondent-levels.ts` (6 + Esperto slugs), respondent Zod `roleType`, Level column/form, suggested-CEO with explicit confirm.
+- **Slice 4:** Bulk import (reuse route; idempotency) + CSV export + persistent quick-add (wizard, roster labeling).
+- **Slice 5:** Coach landing companies + per-campaign metrics; CampaignDetail Team column + staged-progress icons.
+
+## Risks
+1. Wizard rewire (Slice 1) = breakage hot-spot; keep `processBulkRespondentsForCreate`/`bulkRespondents` (optional, deprecated); update tests, don't delete.
+2. Legacy-data compat: existing inline-created campaigns, null `roleType`, orphan/no-team respondents, soft-deleted teams, existing participants must render + be selectable. Verify in Slice 1.
+3. Add Team dual-create branch (#3): one modal → two endpoints; unit-test both paths + edit/move guards.
+4. Heterogeneous tree (#2): typed node contract.
+5. CEO designation (#5): never silent; explicit confirm.
+
+## Out of scope (v1)
+Add Team Signup/registration tab; top-level Reports lane + Summary Reports wizard; Edit-Campaign advanced tabs (Notifications/Relations/Mail-Log/Access); Esperto Home chart/clock/calendar; xlsx/json export + deactivate-all; Esperto wizard Mail-timing controls; admin-lane mirror.

--- a/src/src/__tests__/components/assessments/campaign-detail-add-existing.test.tsx
+++ b/src/src/__tests__/components/assessments/campaign-detail-add-existing.test.tsx
@@ -176,6 +176,70 @@ function findCall(predicate: (c: FetchCall) => boolean): FetchCall | undefined {
   return fetchCalls.find(predicate);
 }
 
+function findAllCalls(predicate: (c: FetchCall) => boolean): FetchCall[] {
+  return fetchCalls.filter(predicate);
+}
+
+/**
+ * Like installFetch but lets the first add-POST succeed and all subsequent
+ * add-POSTs fail — for testing the partial-failure path.
+ */
+function installFetchPartialFailure({
+  orgMembers = [BOB_ORG, CAROL_ORG],
+}: { orgMembers?: typeof BOB_ORG[] } = {}) {
+  fetchCalls = [];
+  let addPostCallCount = 0;
+  global.fetch = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : String(input);
+    const method = (init?.method ?? "GET").toUpperCase();
+    let body: unknown = undefined;
+    if (init?.body && typeof init.body === "string") {
+      try {
+        body = JSON.parse(init.body);
+      } catch {
+        body = init.body;
+      }
+    }
+    fetchCalls.push({ url, method, body });
+
+    // Org respondents list.
+    if (
+      url.includes(`/api/organizations/${ORG_ID}/respondents`) &&
+      method === "GET"
+    ) {
+      return jsonResponse({ success: true, data: orgMembers });
+    }
+
+    // Add respondent POST — first call succeeds, subsequent calls fail.
+    if (
+      url.includes(`/api/assessment-campaigns/${CAMPAIGN_ID}/respondents`) &&
+      method === "POST"
+    ) {
+      addPostCallCount++;
+      if (addPostCallCount === 1) {
+        return jsonResponse({ success: true, data: { invitation: null } });
+      }
+      return jsonResponse(
+        { success: false, error: "Server error adding respondent" },
+        false,
+      );
+    }
+
+    // Campaign respondents re-fetch (refresh after add).
+    if (
+      url.includes(`/api/assessment-campaigns/${CAMPAIGN_ID}/respondents`) &&
+      method === "GET"
+    ) {
+      return jsonResponse({
+        success: true,
+        data: { overview: BASE_OVERVIEW, respondents: [ALICE_ROW] },
+      });
+    }
+
+    return jsonResponse({ success: false, error: "unhandled" }, false);
+  }) as unknown as typeof fetch;
+}
+
 // ─── Render helper ──────────────────────────────────────────────────────────
 
 function renderDetail(
@@ -444,5 +508,66 @@ describe("CampaignDetail — Add Respondent dialog (pick-existing)", () => {
 
     // toast should have been called (error notification).
     await waitFor(() => expect(toastFn).toHaveBeenCalled());
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // (8) Partial failure — 2 selected, first succeeds, second fails
+  // ────────────────────────────────────────────────────────────────────────
+  it("partial failure: reports '1 added, 1 couldn't be added', refreshes table, keeps dialog open", async () => {
+    installFetchPartialFailure();
+    const toastFn = jest.fn();
+    jest
+      .spyOn(
+        require("@/components/ui/use-toast"),
+        "useToast",
+      )
+      .mockReturnValue({ toast: toastFn });
+
+    renderDetail();
+
+    // Open dialog and wait for members to load.
+    fireEvent.click(screen.getByTestId("add-respondent-btn"));
+    const bobCheckbox = await screen.findByRole("checkbox", {
+      name: /bob jones/i,
+    });
+    const carolCheckbox = await screen.findByRole("checkbox", {
+      name: /carol danvers/i,
+    });
+
+    // Select both Bob (first POST → success) and Carol (second POST → fail).
+    fireEvent.click(bobCheckbox);
+    fireEvent.click(carolCheckbox);
+    fireEvent.click(screen.getByTestId("add-respondent-confirm"));
+
+    // Wait for both add-POSTs to fire.
+    await waitFor(() => {
+      const addPosts = findAllCalls(
+        (c) =>
+          c.url.includes(`/api/assessment-campaigns/${CAMPAIGN_ID}/respondents`) &&
+          c.method === "POST",
+      );
+      expect(addPosts).toHaveLength(2);
+    });
+
+    // (a) refreshRespondents was triggered — the GET re-fetch for the campaign respondents fires.
+    await waitFor(() =>
+      expect(
+        findCall(
+          (c) =>
+            c.url.includes(`/api/assessment-campaigns/${CAMPAIGN_ID}/respondents`) &&
+            c.method === "GET",
+        ),
+      ).toBeTruthy(),
+    );
+
+    // (b) Toast reflects "1 added, 1 couldn't be added" — NOT "2 added".
+    await waitFor(() => expect(toastFn).toHaveBeenCalled());
+    const toastArgs = toastFn.mock.calls[0][0] as { title: string; description: string; variant?: string };
+    expect(toastArgs.title).toMatch(/1 added.*1 couldn't be added/i);
+    expect(toastArgs.variant).toBe("destructive");
+    expect(toastArgs.title).not.toMatch(/^2 respondents added/i);
+
+    // (c) Dialog stays open (partial failure keeps it open for retry).
+    expect(screen.getByTestId("add-respondent-dialog")).toBeInTheDocument();
   });
 });

--- a/src/src/__tests__/components/assessments/campaign-detail-add-existing.test.tsx
+++ b/src/src/__tests__/components/assessments/campaign-detail-add-existing.test.tsx
@@ -1,0 +1,448 @@
+/**
+ * CampaignDetail — "add existing member" picker tests (Slice 1).
+ *
+ * Verifies the post-creation Add Respondent dialog:
+ *  (1) Lists the company's members EXCLUDING current participants (picker present).
+ *  (2) Selecting members + confirming POSTs existing respondentId(s) to the add route.
+ *  (3) No inline-create form / no bulk-CSV panel present (negative assertions).
+ *  (4) Empty state (all members are already participants) shows /portal/members CTA.
+ *  (5) A failed add surfaces an inline error toast.
+ */
+
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { CampaignDetail } from "@/components/assessments/CampaignDetail";
+import type {
+  CampaignOverview,
+  CampaignRespondentRow,
+} from "@/lib/assessments/campaign-detail";
+
+// ─── next/navigation and useToast mocked globally via jest.setup.js ───────
+
+jest.mock("@/components/ui/use-toast", () => ({
+  useToast: () => ({ toast: jest.fn() }),
+}));
+
+// AssessmentResultView is not exercised by these tests.
+jest.mock("@/components/assessments/AssessmentResultView", () => ({
+  AssessmentResultView: () => <div data-testid="mock-result-view" />,
+}));
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────
+
+const ORG_ID = "org-abc";
+const CAMPAIGN_ID = "camp-xyz";
+
+const BASE_OVERVIEW: CampaignOverview = {
+  campaign: {
+    id: CAMPAIGN_ID,
+    name: "Q3 Leadership",
+    alias: "q3-leadership",
+    status: "ACTIVE",
+    organizationId: ORG_ID,
+    organizationName: "Acme Corp",
+    templateId: "tpl-1",
+    templateName: "Rockefeller Habits",
+    openAt: new Date("2026-06-01T00:00:00Z"),
+    closeAt: null,
+    createdAt: new Date("2026-05-01T00:00:00Z"),
+    invitationSubject: null,
+    invitationBodyMarkdown: null,
+  },
+  stats: {
+    totalParticipants: 1,
+    invited: 1,
+    viewed: 0,
+    submitted: 0,
+    completionPct: 0,
+  },
+};
+
+// Alice is already a participant in the campaign.
+const ALICE_ROW: CampaignRespondentRow = {
+  participantId: "part-1",
+  respondent: {
+    id: "resp-alice",
+    firstName: "Alice",
+    lastName: "Smith",
+    email: "alice@acme.com",
+    jobTitle: "CEO",
+  },
+  invitation: null,
+  hasSubmission: false,
+  submissionId: null,
+  submittedAt: null,
+  isCEO: false,
+};
+
+// Bob and Carol are org members NOT yet in the campaign.
+const BOB_ORG = {
+  id: "resp-bob",
+  firstName: "Bob",
+  lastName: "Jones",
+  email: "bob@acme.com",
+  jobTitle: null as string | null,
+};
+const CAROL_ORG = {
+  id: "resp-carol",
+  firstName: "Carol",
+  lastName: "Danvers",
+  email: "carol@acme.com",
+  jobTitle: "Engineer" as string | null,
+};
+
+// ─── fetch mock helper ──────────────────────────────────────────────────────
+
+interface FetchCall {
+  url: string;
+  method: string;
+  body: unknown;
+}
+
+let fetchCalls: FetchCall[];
+
+function jsonResponse(payload: unknown, ok = true) {
+  return {
+    ok,
+    status: ok ? 200 : 400,
+    json: async () => payload,
+  } as unknown as Response;
+}
+
+/**
+ * Install a fetch mock. By default returns Bob+Carol as org members, Alice as
+ * the only current participant (already excluded).
+ * Pass `orgMembers` to override. Pass `addOk=false` to make the add POST fail.
+ */
+function installFetch({
+  orgMembers = [BOB_ORG, CAROL_ORG],
+  addOk = true,
+}: {
+  orgMembers?: typeof BOB_ORG[];
+  addOk?: boolean;
+} = {}) {
+  fetchCalls = [];
+  global.fetch = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : String(input);
+    const method = (init?.method ?? "GET").toUpperCase();
+    let body: unknown = undefined;
+    if (init?.body && typeof init.body === "string") {
+      try {
+        body = JSON.parse(init.body);
+      } catch {
+        body = init.body;
+      }
+    }
+    fetchCalls.push({ url, method, body });
+
+    // Org respondents list.
+    if (
+      url.includes(`/api/organizations/${ORG_ID}/respondents`) &&
+      method === "GET"
+    ) {
+      return jsonResponse({ success: true, data: orgMembers });
+    }
+
+    // Add respondent POST.
+    if (
+      url.includes(`/api/assessment-campaigns/${CAMPAIGN_ID}/respondents`) &&
+      method === "POST"
+    ) {
+      if (!addOk) {
+        return jsonResponse(
+          { success: false, error: "Failed to add respondent" },
+          false,
+        );
+      }
+      return jsonResponse({ success: true, data: { invitation: null } });
+    }
+
+    // Campaign respondents re-fetch (refresh after add).
+    if (
+      url.includes(`/api/assessment-campaigns/${CAMPAIGN_ID}/respondents`) &&
+      method === "GET"
+    ) {
+      return jsonResponse({
+        success: true,
+        data: { overview: BASE_OVERVIEW, respondents: [ALICE_ROW] },
+      });
+    }
+
+    return jsonResponse({ success: false, error: "unhandled" }, false);
+  }) as unknown as typeof fetch;
+}
+
+function findCall(predicate: (c: FetchCall) => boolean): FetchCall | undefined {
+  return fetchCalls.find(predicate);
+}
+
+// ─── Render helper ──────────────────────────────────────────────────────────
+
+function renderDetail(
+  respondents: CampaignRespondentRow[] = [ALICE_ROW],
+  overview: CampaignOverview = BASE_OVERVIEW,
+) {
+  return render(
+    <CampaignDetail
+      initialOverview={overview}
+      initialRespondents={respondents}
+    />,
+  );
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+// ─── Test suite ─────────────────────────────────────────────────────────────
+
+describe("CampaignDetail — Add Respondent dialog (pick-existing)", () => {
+  // ────────────────────────────────────────────────────────────────────────
+  // (1) Dialog lists org members EXCLUDING current participants
+  // ────────────────────────────────────────────────────────────────────────
+  it("shows org members excluding current participants in a checkbox list", async () => {
+    installFetch();
+    renderDetail();
+
+    // Open the dialog.
+    fireEvent.click(screen.getByTestId("add-respondent-btn"));
+
+    // Wait for the org-respondents fetch to settle.
+    await waitFor(() =>
+      expect(
+        findCall(
+          (c) =>
+            c.url.includes(`/api/organizations/${ORG_ID}/respondents`) &&
+            c.method === "GET",
+        ),
+      ).toBeTruthy(),
+    );
+
+    // Bob and Carol are present in the dialog picker.
+    await screen.findByText(/bob jones/i);
+    expect(screen.getByText(/carol danvers/i)).toBeInTheDocument();
+
+    // Alice is already a participant — she must NOT have a checkbox in the picker.
+    // (She does appear in the respondent table, so we check role=checkbox, not text.)
+    const aliceCheckbox = screen.queryByRole("checkbox", { name: /alice smith/i });
+    expect(aliceCheckbox).not.toBeInTheDocument();
+
+    // Members are rendered as checkboxes (not a single select-dropdown).
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes.length).toBeGreaterThanOrEqual(2);
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // (2) Selecting member(s) + confirming POSTs existing respondentId(s)
+  // ────────────────────────────────────────────────────────────────────────
+  it("POSTs selected orgRespondentId(s) to the add route on confirm", async () => {
+    installFetch();
+    renderDetail();
+
+    fireEvent.click(screen.getByTestId("add-respondent-btn"));
+
+    // Wait for members to load.
+    const bobCheckbox = await screen.findByRole("checkbox", {
+      name: /bob jones/i,
+    });
+    fireEvent.click(bobCheckbox);
+    expect(bobCheckbox).toBeChecked();
+
+    // Confirm the add.
+    fireEvent.click(screen.getByTestId("add-respondent-confirm"));
+
+    await waitFor(() =>
+      expect(
+        findCall(
+          (c) =>
+            c.url.includes(
+              `/api/assessment-campaigns/${CAMPAIGN_ID}/respondents`,
+            ) && c.method === "POST",
+        ),
+      ).toBeTruthy(),
+    );
+
+    const addCall = findCall(
+      (c) =>
+        c.url.includes(
+          `/api/assessment-campaigns/${CAMPAIGN_ID}/respondents`,
+        ) && c.method === "POST",
+    )!;
+    // Must use the existing respondentId path — NOT a create-inline payload.
+    const body = addCall.body as Record<string, unknown>;
+    expect(body.orgRespondentId).toBe("resp-bob");
+    // Confirm no inline-create fields leak through.
+    expect(body).not.toHaveProperty("firstName");
+    expect(body).not.toHaveProperty("lastName");
+    expect(body).not.toHaveProperty("email");
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // (3) No inline-create / no bulk-CSV UI present (negative assertions)
+  // ────────────────────────────────────────────────────────────────────────
+  it("has NO inline-create form and NO bulk-CSV panel", async () => {
+    installFetch();
+    renderDetail();
+
+    fireEvent.click(screen.getByTestId("add-respondent-btn"));
+
+    // Allow dialog to settle / org fetch to fire.
+    await waitFor(() =>
+      expect(screen.getByTestId("add-respondent-dialog")).toBeInTheDocument(),
+    );
+
+    // Inline-create fields must not be present.
+    expect(
+      screen.queryByTestId("new-respondent-firstName"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("new-respondent-lastName"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("new-respondent-email"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("create-new-respondent-btn"),
+    ).not.toBeInTheDocument();
+
+    // Bulk-CSV tab / panel must not be present.
+    expect(
+      screen.queryByTestId("add-respondent-tab-bulk"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("add-respondent-tab-single"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("add-respondent-bulk-panel"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("add-respondent-bulk-textarea"),
+    ).not.toBeInTheDocument();
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // (4) Empty state — all org members already participants → /portal/members CTA
+  // ────────────────────────────────────────────────────────────────────────
+  it("shows /portal/members CTA when no members are available to add", async () => {
+    // Org returns Alice — who is already a participant.
+    installFetch({
+      orgMembers: [
+        {
+          id: "resp-alice",
+          firstName: "Alice",
+          lastName: "Smith",
+          email: "alice@acme.com",
+          jobTitle: "CEO" as string | null,
+        },
+      ],
+    });
+    renderDetail();
+
+    fireEvent.click(screen.getByTestId("add-respondent-btn"));
+
+    // Wait for the fetch.
+    await waitFor(() =>
+      expect(
+        findCall(
+          (c) =>
+            c.url.includes(`/api/organizations/${ORG_ID}/respondents`) &&
+            c.method === "GET",
+        ),
+      ).toBeTruthy(),
+    );
+
+    // Empty state CTA link must be present.
+    const cta = await screen.findByRole("link", { name: /add members/i });
+    expect(cta).toHaveAttribute("href", "/portal/members");
+
+    // No checkboxes should be rendered.
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+  });
+
+  it("shows /portal/members CTA when the org has zero members at all", async () => {
+    installFetch({ orgMembers: [] });
+    renderDetail([]);
+
+    fireEvent.click(screen.getByTestId("add-respondent-btn"));
+
+    await waitFor(() =>
+      expect(
+        findCall(
+          (c) =>
+            c.url.includes(`/api/organizations/${ORG_ID}/respondents`) &&
+            c.method === "GET",
+        ),
+      ).toBeTruthy(),
+    );
+
+    const cta = await screen.findByRole("link", { name: /add members/i });
+    expect(cta).toHaveAttribute("href", "/portal/members");
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // (5) Failed add surfaces an error (via toast or inline)
+  // ────────────────────────────────────────────────────────────────────────
+  it("does not crash and closes gracefully when add succeeds", async () => {
+    installFetch({ addOk: true });
+    renderDetail();
+
+    fireEvent.click(screen.getByTestId("add-respondent-btn"));
+    const carolCheckbox = await screen.findByRole("checkbox", {
+      name: /carol danvers/i,
+    });
+    fireEvent.click(carolCheckbox);
+    fireEvent.click(screen.getByTestId("add-respondent-confirm"));
+
+    await waitFor(() =>
+      expect(
+        findCall(
+          (c) =>
+            c.url.includes(
+              `/api/assessment-campaigns/${CAMPAIGN_ID}/respondents`,
+            ) && c.method === "POST",
+        ),
+      ).toBeTruthy(),
+    );
+
+    // Dialog should close after a successful add.
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId("add-respondent-dialog"),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
+  it("keeps dialog open on a failed add and does not crash", async () => {
+    installFetch({ addOk: false });
+    const toastFn = jest.fn();
+    jest
+      .spyOn(
+        require("@/components/ui/use-toast"),
+        "useToast",
+      )
+      .mockReturnValue({ toast: toastFn });
+
+    renderDetail();
+
+    fireEvent.click(screen.getByTestId("add-respondent-btn"));
+    const bobCheckbox = await screen.findByRole("checkbox", {
+      name: /bob jones/i,
+    });
+    fireEvent.click(bobCheckbox);
+    fireEvent.click(screen.getByTestId("add-respondent-confirm"));
+
+    await waitFor(() =>
+      expect(
+        findCall(
+          (c) =>
+            c.url.includes(
+              `/api/assessment-campaigns/${CAMPAIGN_ID}/respondents`,
+            ) && c.method === "POST",
+        ),
+      ).toBeTruthy(),
+    );
+
+    // toast should have been called (error notification).
+    await waitFor(() => expect(toastFn).toHaveBeenCalled());
+  });
+});

--- a/src/src/__tests__/components/assessments/campaign-wizard-pick-existing.test.tsx
+++ b/src/src/__tests__/components/assessments/campaign-wizard-pick-existing.test.tsx
@@ -1,0 +1,300 @@
+/**
+ * Assessment "setup-first" flip — CampaignWizard pick-existing tests.
+ *
+ * Slice 1 flips the wizard from inline-create to pick-existing:
+ *  (a) Step 0 (Organization) with zero orgs shows a CTA linking to
+ *      /portal/members and NO inline-create form.
+ *  (b) Step 0 picks an EXISTING org only — no "+ New organization" button.
+ *  (c) Step 2 (Participants) picks existing members (grouped by team) — no
+ *      inline single-respondent form and no bulk-CSV panel.
+ *  (d) saveCampaign() POSTs the selected participants and does NOT send a
+ *      `bulkRespondents` array in the create body.
+ */
+
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { CampaignWizard } from "@/components/assessments/CampaignWizard";
+
+// next/navigation is globally mocked in jest.setup.js.
+// useToast carries internal state; stub it to a no-op.
+jest.mock("@/components/ui/use-toast", () => ({
+  useToast: () => ({ toast: jest.fn() }),
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const ORG = { id: "org-1", name: "Acme Corp", externalId: null };
+const TEMPLATE = {
+  id: "tpl-1",
+  name: "Rockefeller Habits",
+  alias: "rockefeller",
+  description: null,
+  aggregationMode: "FULL_VISIBILITY" as const,
+};
+const TEAM_ENG = {
+  id: "team-eng",
+  organizationId: "org-1",
+  parentTeamId: null,
+  name: "Engineering",
+  type: null,
+  description: null,
+  children: [],
+};
+const ALICE = {
+  id: "resp-1",
+  firstName: "Alice",
+  lastName: "Smith",
+  email: "alice@acme.com",
+  jobTitle: "CEO",
+  teamId: "team-eng",
+  organizationId: "org-1",
+};
+const BOB = {
+  id: "resp-2",
+  firstName: "Bob",
+  lastName: "Jones",
+  email: "bob@acme.com",
+  jobTitle: null,
+  teamId: null,
+  organizationId: "org-1",
+};
+
+// ---------------------------------------------------------------------------
+// fetch routing helper — match by URL + method so step order doesn't matter.
+// ---------------------------------------------------------------------------
+
+interface FetchCall {
+  url: string;
+  method: string;
+  body: unknown;
+}
+
+let fetchCalls: FetchCall[];
+
+function jsonResponse(payload: unknown, ok = true) {
+  return {
+    ok,
+    status: ok ? 200 : 400,
+    json: async () => payload,
+  } as unknown as Response;
+}
+
+function installFetch({ orgs }: { orgs: typeof ORG[] }) {
+  fetchCalls = [];
+  global.fetch = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : String(input);
+    const method = (init?.method ?? "GET").toUpperCase();
+    let body: unknown = undefined;
+    if (init?.body && typeof init.body === "string") {
+      try {
+        body = JSON.parse(init.body);
+      } catch {
+        body = init.body;
+      }
+    }
+    fetchCalls.push({ url, method, body });
+
+    // Draft endpoint — no resumable draft.
+    if (url.includes("/api/assessment-campaign-drafts")) {
+      if (method === "GET") return jsonResponse({ success: true, data: null });
+      return jsonResponse({ success: true });
+    }
+    // Organizations list.
+    if (url.endsWith("/api/organizations") && method === "GET") {
+      return jsonResponse({ success: true, data: orgs });
+    }
+    // Single organization (Review step).
+    if (url.match(/\/api\/organizations\/org-1$/) && method === "GET") {
+      return jsonResponse({ success: true, data: ORG });
+    }
+    // Templates list.
+    if (url.endsWith("/api/assessment-templates") && method === "GET") {
+      return jsonResponse({ success: true, data: [TEMPLATE] });
+    }
+    // Teams tree for the org.
+    if (url.includes("/api/organizations/org-1/teams") && method === "GET") {
+      return jsonResponse({ success: true, data: [TEAM_ENG] });
+    }
+    // Respondents for the org.
+    if (
+      url.includes("/api/organizations/org-1/respondents") &&
+      method === "GET"
+    ) {
+      return jsonResponse({ success: true, data: [ALICE, BOB] });
+    }
+    // Campaign create.
+    if (url.endsWith("/api/assessment-campaigns") && method === "POST") {
+      return jsonResponse({
+        success: true,
+        data: { id: "camp-1" },
+      });
+    }
+    // Participants add.
+    if (url.includes("/api/assessment-campaigns/camp-1/participants")) {
+      return jsonResponse({ success: true, data: { added: 1 } });
+    }
+    // Activate.
+    if (url.includes("/api/assessment-campaigns/camp-1/activate")) {
+      return jsonResponse({ success: true, data: { status: "ACTIVE" } });
+    }
+    return jsonResponse({ success: false, error: "unhandled" }, false);
+  }) as unknown as typeof fetch;
+}
+
+function findCall(predicate: (c: FetchCall) => boolean): FetchCall | undefined {
+  return fetchCalls.find(predicate);
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Step 0 — Organization
+// ---------------------------------------------------------------------------
+
+describe("CampaignWizard — Step 0 (Organization)", () => {
+  it("zero orgs shows a setup CTA linking to /portal/members and NO inline-create", async () => {
+    installFetch({ orgs: [] });
+    render(<CampaignWizard />);
+
+    // Wait for the org fetch to settle.
+    await waitFor(() =>
+      expect(
+        findCall((c) => c.url.endsWith("/api/organizations") && c.method === "GET"),
+      ).toBeTruthy(),
+    );
+
+    // CTA link to the Members lane.
+    const cta = await screen.findByRole("link", { name: /set up a company/i });
+    expect(cta).toHaveAttribute("href", "/portal/members");
+
+    // No inline-create affordances.
+    expect(
+      screen.queryByRole("button", { name: /new organization/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /^create one$/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText(/organization name/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("with orgs present, picks an existing org and shows NO create button", async () => {
+    installFetch({ orgs: [ORG] });
+    render(<CampaignWizard />);
+
+    const radio = await screen.findByRole("radio", { name: /acme corp/i });
+    expect(radio).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /new organization/i }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Full flow — saveCampaign posts participants WITHOUT bulkRespondents
+// ---------------------------------------------------------------------------
+
+describe("CampaignWizard — pick-existing flow", () => {
+  async function advanceToParticipants() {
+    // Step 0 — pick org.
+    const orgRadio = await screen.findByRole("radio", { name: /acme corp/i });
+    fireEvent.click(orgRadio);
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+
+    // Step 1 — pick template.
+    const tplRadio = await screen.findByRole("radio", {
+      name: /rockefeller habits/i,
+    });
+    fireEvent.click(tplRadio);
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+  }
+
+  it("Step 2 picks existing members (no inline-create, no bulk CSV)", async () => {
+    installFetch({ orgs: [ORG] });
+    render(<CampaignWizard />);
+    await advanceToParticipants();
+
+    // Members list rendered from the respondents endpoint.
+    await screen.findByText("Alice Smith");
+    expect(screen.getByText("Bob Jones")).toBeInTheDocument();
+
+    // Inline-create + bulk-CSV affordances are gone.
+    expect(
+      screen.queryByRole("button", { name: /new respondent/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("wizard-toggle-bulk-csv"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("wizard-bulk-csv-panel"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("saveCampaign posts participants and does NOT send a bulkRespondents array", async () => {
+    installFetch({ orgs: [ORG] });
+    render(<CampaignWizard />);
+    await advanceToParticipants();
+
+    // Select Alice as participant + CEO.
+    const aliceCheckbox = await screen.findByRole("checkbox", {
+      name: /alice smith/i,
+    });
+    fireEvent.click(aliceCheckbox);
+    const aliceCeo = screen.getByRole("radio", {
+      name: /mark alice smith as ceo/i,
+    });
+    fireEvent.click(aliceCeo);
+
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+
+    // Step 3 — schedule (name + default open-ended).
+    const nameInput = await screen.findByLabelText(/campaign name/i);
+    fireEvent.change(nameInput, { target: { value: "Q3 Assessment" } });
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+
+    // Step 4 — review → Save as Draft.
+    const saveBtn = await screen.findByRole("button", {
+      name: /save as draft/i,
+    });
+    fireEvent.click(saveBtn);
+
+    await waitFor(() =>
+      expect(
+        findCall(
+          (c) =>
+            c.url.endsWith("/api/assessment-campaigns") && c.method === "POST",
+        ),
+      ).toBeTruthy(),
+    );
+
+    const createCall = findCall(
+      (c) => c.url.endsWith("/api/assessment-campaigns") && c.method === "POST",
+    )!;
+    const createBody = createCall.body as Record<string, unknown>;
+    // The flip: no bulkRespondents key in the create payload.
+    expect(createBody).not.toHaveProperty("bulkRespondents");
+    expect(createBody.organizationId).toBe("org-1");
+    expect(createBody.templateId).toBe("tpl-1");
+    expect(createBody.name).toBe("Q3 Assessment");
+
+    // Participants posted with the selected respondent + CEO.
+    await waitFor(() =>
+      expect(
+        findCall((c) =>
+          c.url.includes("/api/assessment-campaigns/camp-1/participants"),
+        ),
+      ).toBeTruthy(),
+    );
+    const partCall = findCall((c) =>
+      c.url.includes("/api/assessment-campaigns/camp-1/participants"),
+    )!;
+    const partBody = partCall.body as Record<string, unknown>;
+    expect(partBody.respondentIds).toEqual(["resp-1"]);
+    expect(partBody.ceoRespondentId).toBe("resp-1");
+  });
+});

--- a/src/src/__tests__/components/assessments/campaign-wizard-pick-existing.test.tsx
+++ b/src/src/__tests__/components/assessments/campaign-wizard-pick-existing.test.tsx
@@ -147,6 +147,103 @@ function findCall(predicate: (c: FetchCall) => boolean): FetchCall | undefined {
   return fetchCalls.find(predicate);
 }
 
+// ---------------------------------------------------------------------------
+// Second org for the cross-company regression (C1). ORG_B has its own member
+// (Carol) on its own team — none of org-1's ids appear here.
+// ---------------------------------------------------------------------------
+
+const ORG_B = { id: "org-2", name: "Globex Inc", externalId: null };
+const TEAM_SALES_B = {
+  id: "team-sales-b",
+  organizationId: "org-2",
+  parentTeamId: null,
+  name: "Sales",
+  type: null,
+  description: null,
+  children: [],
+};
+const CAROL = {
+  id: "resp-9",
+  firstName: "Carol",
+  lastName: "Danvers",
+  email: "carol@globex.com",
+  jobTitle: null,
+  teamId: "team-sales-b",
+  organizationId: "org-2",
+};
+
+/**
+ * Multi-org fetch installer. Routes teams/respondents per org id so a
+ * cross-company switch (org-1 → org-2) returns DIFFERENT members. Optionally
+ * fails the teams fetch (for the I2 teams-failure regression) — for which org
+ * the failure applies is controlled by `failTeamsForOrg`.
+ */
+function installMultiOrgFetch(opts?: { failTeamsForOrg?: string }) {
+  const failTeamsForOrg = opts?.failTeamsForOrg;
+  fetchCalls = [];
+  const teamsByOrg: Record<string, unknown[]> = {
+    "org-1": [TEAM_ENG],
+    "org-2": [TEAM_SALES_B],
+  };
+  const respByOrg: Record<string, unknown[]> = {
+    "org-1": [ALICE, BOB],
+    "org-2": [CAROL],
+  };
+  global.fetch = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : String(input);
+    const method = (init?.method ?? "GET").toUpperCase();
+    let body: unknown = undefined;
+    if (init?.body && typeof init.body === "string") {
+      try {
+        body = JSON.parse(init.body);
+      } catch {
+        body = init.body;
+      }
+    }
+    fetchCalls.push({ url, method, body });
+
+    if (url.includes("/api/assessment-campaign-drafts")) {
+      if (method === "GET") return jsonResponse({ success: true, data: null });
+      return jsonResponse({ success: true });
+    }
+    if (url.endsWith("/api/organizations") && method === "GET") {
+      return jsonResponse({ success: true, data: [ORG, ORG_B] });
+    }
+    const orgDetailMatch = url.match(/\/api\/organizations\/(org-1|org-2)$/);
+    if (orgDetailMatch && method === "GET") {
+      const o = orgDetailMatch[1] === "org-1" ? ORG : ORG_B;
+      return jsonResponse({ success: true, data: o });
+    }
+    if (url.endsWith("/api/assessment-templates") && method === "GET") {
+      return jsonResponse({ success: true, data: [TEMPLATE] });
+    }
+    const teamsMatch = url.match(/\/api\/organizations\/(org-1|org-2)\/teams/);
+    if (teamsMatch && method === "GET") {
+      const orgId = teamsMatch[1];
+      if (failTeamsForOrg && orgId === failTeamsForOrg) {
+        return jsonResponse({ success: false, error: "teams boom" }, false);
+      }
+      return jsonResponse({ success: true, data: teamsByOrg[orgId] ?? [] });
+    }
+    const respMatch = url.match(
+      /\/api\/organizations\/(org-1|org-2)\/respondents/,
+    );
+    if (respMatch && method === "GET") {
+      return jsonResponse({ success: true, data: respByOrg[respMatch[1]] ?? [] });
+    }
+    if (url.endsWith("/api/assessment-campaigns") && method === "POST") {
+      return jsonResponse({ success: true, data: { id: "camp-1" } });
+    }
+    if (url.includes("/api/assessment-campaigns/camp-1/participants")) {
+      return jsonResponse({ success: true, data: { added: 1 } });
+    }
+    if (url.includes("/api/assessment-campaigns/camp-1/activate")) {
+      return jsonResponse({ success: true, data: { status: "ACTIVE" } });
+    }
+    return jsonResponse({ success: false, error: "unhandled" }, false);
+  }) as unknown as typeof fetch;
+}
+
 afterEach(() => {
   jest.restoreAllMocks();
 });
@@ -296,5 +393,141 @@ describe("CampaignWizard — pick-existing flow", () => {
     const partBody = partCall.body as Record<string, unknown>;
     expect(partBody.respondentIds).toEqual(["resp-1"]);
     expect(partBody.ceoRespondentId).toBe("resp-1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// C1 — stale cross-company selection is cleared when the org changes.
+// ---------------------------------------------------------------------------
+
+describe("CampaignWizard — C1 cross-company selection reset", () => {
+  it("clears member selection (and CEO) when the picked company changes", async () => {
+    installMultiOrgFetch();
+    render(<CampaignWizard />);
+
+    // Step 0 — pick org A (Acme / org-1).
+    const orgA = await screen.findByRole("radio", { name: /acme corp/i });
+    fireEvent.click(orgA);
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+
+    // Step 1 — template.
+    const tpl = await screen.findByRole("radio", {
+      name: /rockefeller habits/i,
+    });
+    fireEvent.click(tpl);
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+
+    // Step 2 — select Alice (org A member) + mark her CEO.
+    const alice = await screen.findByRole("checkbox", { name: /alice smith/i });
+    fireEvent.click(alice);
+    expect(alice).toBeChecked();
+    const aliceCeo = screen.getByRole("radio", {
+      name: /mark alice smith as ceo/i,
+    });
+    fireEvent.click(aliceCeo);
+    expect(aliceCeo).toBeChecked();
+
+    // Back to template, Back to org.
+    fireEvent.click(screen.getByRole("button", { name: /back/i }));
+    await screen.findByRole("radio", { name: /rockefeller habits/i });
+    fireEvent.click(screen.getByRole("button", { name: /back/i }));
+
+    // Switch to org B (Globex / org-2).
+    const orgB = await screen.findByRole("radio", { name: /globex inc/i });
+    fireEvent.click(orgB);
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+
+    // Step 1 again — template still picked, advance.
+    const tpl2 = await screen.findByRole("radio", {
+      name: /rockefeller habits/i,
+    });
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+    expect(tpl2).toBeChecked();
+
+    // Step 2 for org B — Carol is the only member; she is NOT checked, and
+    // org-1's Alice is not even rendered. The Next button is disabled
+    // because the prior (org A) selection was wiped on the company switch.
+    const carol = await screen.findByRole("checkbox", { name: /carol danvers/i });
+    expect(carol).not.toBeChecked();
+    expect(
+      screen.queryByRole("checkbox", { name: /alice smith/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /next/i })).toBeDisabled();
+  });
+
+  it("re-selecting the SAME org does not wipe a valid selection", async () => {
+    installMultiOrgFetch();
+    render(<CampaignWizard />);
+
+    const orgA = await screen.findByRole("radio", { name: /acme corp/i });
+    fireEvent.click(orgA);
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+
+    const tpl = await screen.findByRole("radio", {
+      name: /rockefeller habits/i,
+    });
+    fireEvent.click(tpl);
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+
+    const alice = await screen.findByRole("checkbox", { name: /alice smith/i });
+    fireEvent.click(alice);
+    expect(alice).toBeChecked();
+
+    // Back to org, click the SAME org A again.
+    fireEvent.click(screen.getByRole("button", { name: /back/i }));
+    await screen.findByRole("radio", { name: /rockefeller habits/i });
+    fireEvent.click(screen.getByRole("button", { name: /back/i }));
+    const orgAagain = await screen.findByRole("radio", { name: /acme corp/i });
+    fireEvent.click(orgAagain);
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+    const tplAgain = await screen.findByRole("radio", {
+      name: /rockefeller habits/i,
+    });
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+    expect(tplAgain).toBeChecked();
+
+    // Selection preserved — Alice still checked.
+    const aliceAgain = await screen.findByRole("checkbox", {
+      name: /alice smith/i,
+    });
+    expect(aliceAgain).toBeChecked();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// I2 — a teams-fetch failure is surfaced (not silently swallowed) even when
+// the respondents fetch succeeds.
+// ---------------------------------------------------------------------------
+
+describe("CampaignWizard — I2 teams-fetch failure", () => {
+  it("shows an error + Retry when teams fails but respondents succeed", async () => {
+    installMultiOrgFetch({ failTeamsForOrg: "org-1" });
+    render(<CampaignWizard />);
+
+    // Step 0 — org A (whose teams fetch is rigged to fail).
+    const orgA = await screen.findByRole("radio", { name: /acme corp/i });
+    fireEvent.click(orgA);
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+
+    // Step 1 — template.
+    const tpl = await screen.findByRole("radio", {
+      name: /rockefeller habits/i,
+    });
+    fireEvent.click(tpl);
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+
+    // Step 2 — the teams failure must surface as an error with Retry, and the
+    // members must NOT be rendered (no silent all-unassigned fallback).
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/failed to load members/i);
+    expect(
+      screen.getByRole("button", { name: /retry/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("checkbox", { name: /alice smith/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/not associated with any team/i),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/src/__tests__/components/nav/assessments-sidebar.test.tsx
+++ b/src/src/__tests__/components/nav/assessments-sidebar.test.tsx
@@ -65,7 +65,7 @@ describe("AssessmentsSidebar", () => {
     render(<AssessmentsSidebar session={makeSession("COACH")} />);
     // Admin-only labels disappear (Organizations / Access Groups / Templates /
     // Campaigns / Public Quizzes / Aggregate Report). The "Dashboard" label
-    // is admin-only as well — coaches see "My Campaigns" / "My Organizations".
+    // is admin-only as well — coaches see "My Campaigns" / "Members".
     expect(screen.queryByText("Organizations")).not.toBeInTheDocument();
     expect(screen.queryByText("Access Groups")).not.toBeInTheDocument();
     expect(screen.queryByText("Templates")).not.toBeInTheDocument();
@@ -77,20 +77,20 @@ describe("AssessmentsSidebar", () => {
   it("renders the coach-lane section ONLY when role is COACH", () => {
     render(<AssessmentsSidebar session={makeSession("COACH")} />);
     expect(screen.getByText("My Campaigns")).toBeInTheDocument();
-    expect(screen.getByText("My Organizations")).toBeInTheDocument();
+    expect(screen.getByText("Members")).toBeInTheDocument();
     expect(screen.getByText(/coach lane/i)).toBeInTheDocument();
   });
 
   it("does NOT render the coach-lane section for ADMIN", () => {
     render(<AssessmentsSidebar session={makeSession("ADMIN")} />);
     expect(screen.queryByText("My Campaigns")).not.toBeInTheDocument();
-    expect(screen.queryByText("My Organizations")).not.toBeInTheDocument();
+    expect(screen.queryByText("Members")).not.toBeInTheDocument();
   });
 
   it("does NOT render the coach-lane section for STAFF", () => {
     render(<AssessmentsSidebar session={makeSession("STAFF")} />);
     expect(screen.queryByText("My Campaigns")).not.toBeInTheDocument();
-    expect(screen.queryByText("My Organizations")).not.toBeInTheDocument();
+    expect(screen.queryByText("Members")).not.toBeInTheDocument();
   });
 
   it("renders 7 admin entries for STAFF role too", () => {
@@ -145,20 +145,19 @@ describe("AssessmentsSidebar", () => {
       }
     });
 
-    it("marks My Organizations as a placeholder for COACH (but NOT My Campaigns)", () => {
+    it("marks neither coach-lane entry as a placeholder (both are real routes)", () => {
       render(<AssessmentsSidebar session={makeSession("COACH")} />);
 
-      const orgAnchor = anchorFor("My Organizations");
-      expect(orgAnchor).toHaveAttribute("aria-disabled", "true");
-      expect(orgAnchor.className).toMatch(/opacity-60/);
+      const membersAnchor = anchorFor("Members");
+      expect(membersAnchor).not.toHaveAttribute("aria-disabled");
+      expect(membersAnchor.className).not.toMatch(/opacity-60/);
 
       const campaignsAnchor = anchorFor("My Campaigns");
       expect(campaignsAnchor).not.toHaveAttribute("aria-disabled");
       expect(campaignsAnchor.className).not.toMatch(/opacity-60/);
 
-      // Exactly one "(coming soon)" marker on the coach lane.
-      const comingSoon = screen.getAllByText(/coming soon/i);
-      expect(comingSoon.length).toBe(1);
+      // No "(coming soon)" markers on the coach lane (both entries are live).
+      expect(screen.queryAllByText(/coming soon/i).length).toBe(0);
     });
   });
 });

--- a/src/src/__tests__/components/organizations/add-member-modal.test.tsx
+++ b/src/src/__tests__/components/organizations/add-member-modal.test.tsx
@@ -1,0 +1,326 @@
+/**
+ * TDD Red Phase — AddMemberModal tests.
+ *
+ * Test matrix:
+ *  (1) valid submit POSTs /api/organizations/{orgId}/respondents with exact body incl. selected teamId
+ *  (2) "— no team —" omits/nulls teamId from the POST body
+ *  (3) blank required field (firstName) blocks submit — no fetch, alert shown
+ *  (4) invalid email is blocked client-side — no fetch, alert shown
+ *  (5) 400 { success:false, error:[{message}] } surfaces that message and keeps modal open
+ *  (6) success triggers the refresh callback (onCreated) + closes the modal
+ *
+ * Uses fireEvent + data-testid following the AddTeamModal pattern.
+ * No @testing-library/user-event needed.
+ */
+
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { AddMemberModal } from "@/components/organizations/add-member-modal";
+import type { ApiTeamNode } from "@/components/organizations/members-teams-view";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const ORG_ID = "org-abc";
+
+const TEAM_ENG: ApiTeamNode = {
+  id: "team-eng",
+  organizationId: ORG_ID,
+  parentTeamId: null,
+  name: "Engineering",
+  type: null,
+  description: null,
+  children: [],
+};
+
+const TEAM_DESIGN: ApiTeamNode = {
+  id: "team-design",
+  organizationId: ORG_ID,
+  parentTeamId: null,
+  name: "Design",
+  type: null,
+  description: null,
+  children: [],
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderModal(
+  overrides: Partial<React.ComponentProps<typeof AddMemberModal>> = {}
+) {
+  const onClose = jest.fn();
+  const onCreated = jest.fn();
+  const defaults: React.ComponentProps<typeof AddMemberModal> = {
+    open: true,
+    onClose,
+    onCreated,
+    orgId: ORG_ID,
+    teams: [TEAM_ENG, TEAM_DESIGN],
+    defaultTeamId: null,
+  };
+  const props = { ...defaults, ...overrides };
+  render(<AddMemberModal {...props} />);
+  return { onClose: props.onClose as jest.Mock, onCreated: props.onCreated as jest.Mock };
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  global.fetch = jest.fn();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AddMemberModal", () => {
+  /**
+   * (1) Valid submit POSTs to the correct endpoint with exact body including teamId
+   */
+  test("(1) valid submit POSTs /api/organizations/{orgId}/respondents with correct body incl. teamId", async () => {
+    const mockRespondent = {
+      id: "r-1",
+      organizationId: ORG_ID,
+      firstName: "Alice",
+      lastName: "Smith",
+      email: "alice@example.com",
+      jobTitle: "Engineer",
+      teamId: "team-eng",
+    };
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({ success: true, data: mockRespondent }),
+    });
+
+    renderModal();
+
+    fireEvent.change(screen.getByLabelText(/first name/i), {
+      target: { value: "Alice" },
+    });
+    fireEvent.change(screen.getByLabelText(/last name/i), {
+      target: { value: "Smith" },
+    });
+    fireEvent.change(screen.getByLabelText(/e-?mail/i), {
+      target: { value: "alice@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText(/job title/i), {
+      target: { value: "Engineer" },
+    });
+    fireEvent.change(screen.getByTestId("select-team"), {
+      target: { value: "team-eng" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /add member/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        `/api/organizations/${ORG_ID}/respondents`,
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            firstName: "Alice",
+            lastName: "Smith",
+            email: "alice@example.com",
+            jobTitle: "Engineer",
+            teamId: "team-eng",
+          }),
+        })
+      );
+    });
+  });
+
+  /**
+   * (2) "— no team —" option omits/nulls teamId from the POST body
+   */
+  test('(2) "— no team —" selection omits teamId from the POST body', async () => {
+    const mockRespondent = {
+      id: "r-2",
+      organizationId: ORG_ID,
+      firstName: "Bob",
+      lastName: "Jones",
+      email: "bob@example.com",
+      teamId: null,
+    };
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({ success: true, data: mockRespondent }),
+    });
+
+    renderModal();
+
+    fireEvent.change(screen.getByLabelText(/first name/i), {
+      target: { value: "Bob" },
+    });
+    fireEvent.change(screen.getByLabelText(/last name/i), {
+      target: { value: "Jones" },
+    });
+    fireEvent.change(screen.getByLabelText(/e-?mail/i), {
+      target: { value: "bob@example.com" },
+    });
+
+    // Explicitly pick "— no team —"
+    fireEvent.change(screen.getByTestId("select-team"), {
+      target: { value: "" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /add member/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    const body = JSON.parse(init.body as string);
+    // teamId must NOT appear in the body (or be null) when no team selected
+    expect(body.teamId == null).toBe(true);
+    // jobTitle must NOT appear when blank
+    expect(body.jobTitle).toBeUndefined();
+  });
+
+  /**
+   * (3) Blank required field (firstName) blocks submit — no fetch, alert shown
+   */
+  test("(3) blank firstName blocks submit — no fetch, alert shown", async () => {
+    renderModal();
+
+    // Leave firstName empty; fill the rest
+    fireEvent.change(screen.getByLabelText(/last name/i), {
+      target: { value: "Smith" },
+    });
+    fireEvent.change(screen.getByLabelText(/e-?mail/i), {
+      target: { value: "alice@example.com" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /add member/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  /**
+   * (4) Invalid email format blocked client-side — no fetch, alert shown
+   */
+  test("(4) invalid email format blocks submit — no fetch, alert shown", async () => {
+    renderModal();
+
+    fireEvent.change(screen.getByLabelText(/first name/i), {
+      target: { value: "Alice" },
+    });
+    fireEvent.change(screen.getByLabelText(/last name/i), {
+      target: { value: "Smith" },
+    });
+    fireEvent.change(screen.getByLabelText(/e-?mail/i), {
+      target: { value: "not-an-email" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /add member/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  /**
+   * (5) 400 { success:false, error:[{message}] } surfaces that message and keeps modal open
+   */
+  test("(5) 400 Zod array error surfaces specific message and keeps modal open", async () => {
+    const zodMessage = "Valid email is required";
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: async () => ({
+        success: false,
+        error: [{ message: zodMessage, path: ["email"], code: "invalid_string" }],
+      }),
+    });
+
+    const { onClose, onCreated } = renderModal();
+
+    fireEvent.change(screen.getByLabelText(/first name/i), {
+      target: { value: "Alice" },
+    });
+    fireEvent.change(screen.getByLabelText(/last name/i), {
+      target: { value: "Smith" },
+    });
+    fireEvent.change(screen.getByLabelText(/e-?mail/i), {
+      target: { value: "alice@example.com" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /add member/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(zodMessage);
+    });
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(onCreated).not.toHaveBeenCalled();
+  });
+
+  /**
+   * (6) Successful create calls onCreated and closes the modal
+   */
+  test("(6) success triggers onCreated callback and closes the modal", async () => {
+    const mockRespondent = {
+      id: "r-3",
+      organizationId: ORG_ID,
+      firstName: "Carol",
+      lastName: "White",
+      email: "carol@example.com",
+      teamId: null,
+    };
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({ success: true, data: mockRespondent }),
+    });
+
+    const { onClose, onCreated } = renderModal();
+
+    fireEvent.change(screen.getByLabelText(/first name/i), {
+      target: { value: "Carol" },
+    });
+    fireEvent.change(screen.getByLabelText(/last name/i), {
+      target: { value: "White" },
+    });
+    fireEvent.change(screen.getByLabelText(/e-?mail/i), {
+      target: { value: "carol@example.com" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /add member/i }));
+
+    await waitFor(() => {
+      expect(onCreated).toHaveBeenCalledWith({ respondent: mockRespondent });
+    });
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  /**
+   * (7) defaultTeamId pre-selects the Team selector
+   */
+  test("(7) defaultTeamId pre-selects the team in the selector", () => {
+    renderModal({ defaultTeamId: "team-eng" });
+
+    const select = screen.getByTestId("select-team") as HTMLSelectElement;
+    expect(select.value).toBe("team-eng");
+  });
+});

--- a/src/src/__tests__/components/organizations/add-member-modal.test.tsx
+++ b/src/src/__tests__/components/organizations/add-member-modal.test.tsx
@@ -185,8 +185,8 @@ describe("AddMemberModal", () => {
       RequestInit,
     ];
     const body = JSON.parse(init.body as string);
-    // teamId must NOT appear in the body (or be null) when no team selected
-    expect(body.teamId == null).toBe(true);
+    // teamId must be ABSENT from the body when no team selected
+    expect("teamId" in body).toBe(false);
     // jobTitle must NOT appear when blank
     expect(body.jobTitle).toBeUndefined();
   });
@@ -322,5 +322,57 @@ describe("AddMemberModal", () => {
 
     const select = screen.getByTestId("select-team") as HTMLSelectElement;
     expect(select.value).toBe("team-eng");
+  });
+
+  /**
+   * (8) When defaultTeamId is null (org node selected, not a team), the Team
+   *     select defaults to "— no team —" AND submitting omits teamId from the body
+   */
+  test("(8) no defaultTeamId defaults to '— no team —' and submit omits teamId", async () => {
+    const mockRespondent = {
+      id: "r-8",
+      organizationId: ORG_ID,
+      firstName: "Dana",
+      lastName: "Lee",
+      email: "dana@example.com",
+      teamId: null,
+    };
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({ success: true, data: mockRespondent }),
+    });
+
+    // Render with no defaultTeamId (organisation node is selected, not a team)
+    renderModal({ defaultTeamId: null });
+
+    // Team select must default to empty value ("— no team —")
+    const select = screen.getByTestId("select-team") as HTMLSelectElement;
+    expect(select.value).toBe("");
+
+    // Fill required fields and submit without changing the team select
+    fireEvent.change(screen.getByLabelText(/first name/i), {
+      target: { value: "Dana" },
+    });
+    fireEvent.change(screen.getByLabelText(/last name/i), {
+      target: { value: "Lee" },
+    });
+    fireEvent.change(screen.getByLabelText(/e-?mail/i), {
+      target: { value: "dana@example.com" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /add member/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    const body = JSON.parse(init.body as string);
+    // teamId must be ABSENT from the POST body
+    expect("teamId" in body).toBe(false);
   });
 });

--- a/src/src/__tests__/components/organizations/add-team-modal.test.tsx
+++ b/src/src/__tests__/components/organizations/add-team-modal.test.tsx
@@ -8,6 +8,8 @@
  *  (4) Guard: Type=Company with a non-root Parent is blocked (no fetch, error shown)
  *  (5) Guard: non-Company type with Parent=root is blocked
  *  (6) A failed create shows an inline error and keeps the modal open
+ *  (7) After a successful TEAM create, handleCreated sets the org to expanded=true
+ *  (8) A 400 with { error: [{message: "..."}] } surfaces the specific Zod message
  *
  * Note: uses fireEvent only (no @testing-library/user-event).
  * The Radix Select portal renders items into document.body; we query them
@@ -17,6 +19,7 @@
 import React from "react";
 import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { AddTeamModal } from "@/components/organizations/add-team-modal";
+import { MembersTeamsView } from "@/components/organizations/members-teams-view";
 import type { OrgSummary, ApiTeamNode } from "@/components/organizations/members-teams-view";
 
 // ---------------------------------------------------------------------------
@@ -318,5 +321,107 @@ describe("AddTeamModal", () => {
     // Modal NOT closed
     expect(onClose).not.toHaveBeenCalled();
     expect(onCreated).not.toHaveBeenCalled();
+  });
+
+  /**
+   * (7) After a successful TEAM create via the modal flow, the onCreated callback
+   *     fires with kind="team" so MembersTeamsView can set expanded=true.
+   *     We test this by driving MembersTeamsView end-to-end: open the Add modal,
+   *     fill in a team under Acme Corp, submit — after success the org row should
+   *     be expanded (ChevronDown visible) and the refreshed teams rendered.
+   */
+  test("(7) after successful TEAM create, the org becomes expanded", async () => {
+    // Sequence:
+    //   1st fetch = POST /api/organizations/org-1/teams (the modal submit)
+    //   2nd fetch = GET /api/organizations/org-1/teams (loadTeams after handleCreated)
+    const mockNewTeam = {
+      id: "team-design",
+      organizationId: "org-1",
+      name: "Design",
+      parentTeamId: null,
+      type: "team",
+      description: null,
+      children: [],
+    };
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: async () => ({ success: true, data: mockNewTeam }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, data: [mockNewTeam] }),
+      });
+
+    render(
+      <MembersTeamsView
+        initialOrganizations={[ORG_ACME]}
+      />
+    );
+
+    // Open the Add modal via the FolderPlus button
+    fireEvent.click(screen.getByRole("button", { name: /add company or team/i }));
+
+    // Fill in Name
+    await waitFor(() => {
+      expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+    });
+    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: "Design" } });
+
+    // Parent = Acme Corp
+    fireEvent.change(screen.getByTestId("select-parent"), { target: { value: "org:org-1" } });
+
+    // Type = team
+    fireEvent.change(screen.getByTestId("select-type"), { target: { value: "team" } });
+
+    // Submit
+    fireEvent.click(screen.getByRole("button", { name: /create/i }));
+
+    // After success, the org should be expanded — ChevronDown aria or the team node visible
+    await waitFor(() => {
+      // The refreshed teams list should render "Design" under Acme Corp
+      expect(screen.getByRole("button", { name: "Design" })).toBeInTheDocument();
+    });
+
+    // Verify the org row carries aria-expanded=true
+    expect(screen.getByRole("button", { name: "Acme Corp" })).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
+  });
+
+  /**
+   * (8) A 400 response with { success:false, error: [{message:"Name must be at most 200 characters"}] }
+   *     surfaces the specific Zod message in the modal (not the generic fallback).
+   */
+  test("(8) 400 with Zod array error surfaces the specific message", async () => {
+    const zodMessage = "Name must be at most 200 characters";
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: async () => ({
+        success: false,
+        error: [{ message: zodMessage, path: ["name"], code: "too_big" }],
+      }),
+    });
+
+    renderModal();
+
+    // Fill name + valid company combo
+    fireEvent.change(screen.getByLabelText(/name/i), {
+      target: { value: "A".repeat(201) },
+    });
+    fireEvent.change(screen.getByTestId("select-type"), { target: { value: "company" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /create/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(zodMessage);
+    });
+
+    // Must NOT show the generic fallback
+    expect(screen.queryByText(/failed to create company/i)).not.toBeInTheDocument();
   });
 });

--- a/src/src/__tests__/components/organizations/add-team-modal.test.tsx
+++ b/src/src/__tests__/components/organizations/add-team-modal.test.tsx
@@ -1,0 +1,322 @@
+/**
+ * TDD Red Phase — AddTeamModal tests.
+ *
+ * Test matrix:
+ *  (1) Parent=root + Type=Company → POSTs /api/organizations with {name}
+ *  (2) Parent=a company + Type=Team → POSTs /api/organizations/{id}/teams with parentTeamId:null
+ *  (3) Parent=a team → POSTs /api/organizations/{id}/teams with that parentTeamId
+ *  (4) Guard: Type=Company with a non-root Parent is blocked (no fetch, error shown)
+ *  (5) Guard: non-Company type with Parent=root is blocked
+ *  (6) A failed create shows an inline error and keeps the modal open
+ *
+ * Note: uses fireEvent only (no @testing-library/user-event).
+ * The Radix Select portal renders items into document.body; we query them
+ * with screen.getByRole("option") after opening the trigger.
+ */
+
+import React from "react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { AddTeamModal } from "@/components/organizations/add-team-modal";
+import type { OrgSummary, ApiTeamNode } from "@/components/organizations/members-teams-view";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const ORG_ACME: OrgSummary = { id: "org-1", name: "Acme Corp", ownerCoachId: "coach-1" };
+const ORG_BETA: OrgSummary = { id: "org-2", name: "Beta Inc", ownerCoachId: "coach-1" };
+
+const TEAM_ENG: ApiTeamNode = {
+  id: "team-eng",
+  organizationId: "org-1",
+  parentTeamId: null,
+  name: "Engineering",
+  type: null,
+  description: null,
+  children: [],
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderModal(overrides: Partial<React.ComponentProps<typeof AddTeamModal>> = {}) {
+  const onClose = jest.fn();
+  const onCreated = jest.fn();
+  const defaults: React.ComponentProps<typeof AddTeamModal> = {
+    open: true,
+    onClose,
+    onCreated,
+    organizations: [ORG_ACME, ORG_BETA],
+    loadedTeams: { "org-1": [TEAM_ENG], "org-2": [] },
+  };
+  const props = { ...defaults, ...overrides };
+  render(<AddTeamModal {...props} />);
+  return { onClose: props.onClose, onCreated: props.onCreated };
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  global.fetch = jest.fn();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AddTeamModal", () => {
+  /**
+   * (1) Parent=root + Type=Company → POST /api/organizations with {name}
+   */
+  test("(1) creates a Company (root org) when Parent=none and Type=Company", async () => {
+    const mockOrg = { id: "new-org", name: "New Co", ownerCoachId: "coach-1" };
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({ success: true, data: mockOrg }),
+    });
+
+    const { onCreated, onClose } = renderModal();
+
+    // Fill in Name
+    fireEvent.change(screen.getByLabelText(/name/i), {
+      target: { value: "New Co" },
+    });
+
+    // Type: select "Company" — the select uses data-testid
+    // We drive it via the hidden select element directly
+    fireEvent.change(screen.getByTestId("select-type"), {
+      target: { value: "company" },
+    });
+
+    // Submit
+    fireEvent.click(screen.getByRole("button", { name: /create/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/organizations",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ name: "New Co" }),
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(onCreated).toHaveBeenCalledWith({ kind: "organization", org: mockOrg });
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  /**
+   * (2) Parent=a company + Type=Team → POST /api/organizations/{id}/teams
+   *     with parentTeamId:null
+   */
+  test("(2) creates a team under a company when Parent=company and Type=Team", async () => {
+    const mockTeam = {
+      id: "new-team",
+      organizationId: "org-1",
+      name: "Design",
+      parentTeamId: null,
+    };
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({ success: true, data: mockTeam }),
+    });
+
+    const { onCreated, onClose } = renderModal();
+
+    // Fill in Name
+    fireEvent.change(screen.getByLabelText(/name/i), {
+      target: { value: "Design" },
+    });
+
+    // Parent: select "org:org-1" (Acme Corp)
+    fireEvent.change(screen.getByTestId("select-parent"), {
+      target: { value: "org:org-1" },
+    });
+
+    // Type: "team"
+    fireEvent.change(screen.getByTestId("select-type"), {
+      target: { value: "team" },
+    });
+
+    // Submit
+    fireEvent.click(screen.getByRole("button", { name: /create/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/organizations/org-1/teams",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ name: "Design", type: "team", parentTeamId: null }),
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(onCreated).toHaveBeenCalledWith({
+        kind: "team",
+        team: mockTeam,
+        orgId: "org-1",
+      });
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  /**
+   * (3) Parent=a team → POST /api/organizations/{id}/teams with that parentTeamId
+   */
+  test("(3) creates a sub-team when Parent=a team (populates parentTeamId)", async () => {
+    const mockTeam = {
+      id: "sub-team",
+      organizationId: "org-1",
+      name: "Platform",
+      parentTeamId: "team-eng",
+    };
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({ success: true, data: mockTeam }),
+    });
+
+    const { onCreated } = renderModal();
+
+    // Name
+    fireEvent.change(screen.getByLabelText(/name/i), {
+      target: { value: "Platform" },
+    });
+
+    // Parent: select "team:team-eng" (Engineering under org-1)
+    fireEvent.change(screen.getByTestId("select-parent"), {
+      target: { value: "team:org-1:team-eng" },
+    });
+
+    // Type: "team"
+    fireEvent.change(screen.getByTestId("select-type"), {
+      target: { value: "team" },
+    });
+
+    // Submit
+    fireEvent.click(screen.getByRole("button", { name: /create/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/organizations/org-1/teams",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ name: "Platform", type: "team", parentTeamId: "team-eng" }),
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(onCreated).toHaveBeenCalledWith({
+        kind: "team",
+        team: mockTeam,
+        orgId: "org-1",
+      });
+    });
+  });
+
+  /**
+   * (4) Guard: Type=Company with a non-root Parent is blocked
+   *     — no fetch call, inline error shown
+   */
+  test("(4) blocks submit when Type=Company but Parent is not root", async () => {
+    renderModal();
+
+    // Name
+    fireEvent.change(screen.getByLabelText(/name/i), {
+      target: { value: "Sneaky Co" },
+    });
+
+    // Parent: select Acme Corp (a company — not root)
+    fireEvent.change(screen.getByTestId("select-parent"), {
+      target: { value: "org:org-1" },
+    });
+
+    // Type: Company (invalid combo)
+    fireEvent.change(screen.getByTestId("select-type"), {
+      target: { value: "company" },
+    });
+
+    // Attempt submit
+    fireEvent.click(screen.getByRole("button", { name: /create/i }));
+
+    // Error message visible, no fetch fired
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/company.*root/i);
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  /**
+   * (5) Guard: non-Company type with Parent=root is blocked
+   */
+  test("(5) blocks submit when Type is not Company but Parent=root", async () => {
+    renderModal();
+
+    // Name
+    fireEvent.change(screen.getByLabelText(/name/i), {
+      target: { value: "Orphan Team" },
+    });
+
+    // Leave Parent as root (value "root" or empty — default)
+    // Type: "team"
+    fireEvent.change(screen.getByTestId("select-type"), {
+      target: { value: "team" },
+    });
+
+    // Attempt submit
+    fireEvent.click(screen.getByRole("button", { name: /create/i }));
+
+    // Error visible, no fetch
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/root.*company/i);
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  /**
+   * (6) A failed create (server error) shows an inline error and keeps modal open
+   */
+  test("(6) inline error on server failure, modal stays open", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ success: false, error: "Internal Server Error" }),
+    });
+
+    const { onClose, onCreated } = renderModal();
+
+    // Name
+    fireEvent.change(screen.getByLabelText(/name/i), {
+      target: { value: "Fail Co" },
+    });
+
+    // Parent = root, Type = Company (valid combo)
+    fireEvent.change(screen.getByTestId("select-type"), {
+      target: { value: "company" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /create/i }));
+
+    // Error shown in modal
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    // Modal NOT closed
+    expect(onClose).not.toHaveBeenCalled();
+    expect(onCreated).not.toHaveBeenCalled();
+  });
+});

--- a/src/src/__tests__/components/organizations/members-teams-view.test.tsx
+++ b/src/src/__tests__/components/organizations/members-teams-view.test.tsx
@@ -232,7 +232,9 @@ describe("MembersTeamsView", () => {
   });
 
   test("selecting the company root node shows all org members", async () => {
-    // No teams expansion needed — just clicking the org node itself
+    // First click expands AND selects the org node, triggering a respondents fetch
+    // with no teamId param (all members for the org)
+    mockFetchForOrg1Teams();
     mockFetchRespondents([RESPONDENT_ALICE, RESPONDENT_BOB]);
 
     render(
@@ -241,14 +243,70 @@ describe("MembersTeamsView", () => {
       />
     );
 
-    // Org root node button exists; clicking WITHOUT expanding loads org members
-    // We'll select it directly (not expand)
-    // In the component, there should be a separate "select" click target or
-    // the button click both selects and (optionally) expands.
-    // This test verifies: when org node is selected, members are loaded.
-    mockFetchRespondents([RESPONDENT_ALICE, RESPONDENT_BOB]);
-
-    // The component should start with no members shown (right panel empty)
+    // Right panel starts empty (no node selected)
     expect(screen.queryByText("Alice Smith")).not.toBeInTheDocument();
+
+    // Click the org root node — both selects it and initiates team + member loads
+    fireEvent.click(screen.getByRole("button", { name: /acme corp/i }));
+
+    // Respondents endpoint called WITHOUT a teamId query param
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/organizations/org-1/respondents"
+      );
+    });
+
+    // Both member rows render in the right panel
+    await waitFor(() => {
+      expect(screen.getByText("Alice Smith")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Bob Jones")).toBeInTheDocument();
+  });
+
+  test("(e) member fetch failure shows error affordance and Retry re-fetches", async () => {
+    // First expand to get teams, then fail the member load
+    mockFetchForOrg1Teams();
+
+    render(
+      <MembersTeamsView
+        initialOrganizations={[ORG_1]}
+      />
+    );
+
+    // Expand org to show teams
+    fireEvent.click(screen.getByRole("button", { name: /acme corp/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Engineering")).toBeInTheDocument();
+    });
+
+    // Mock a non-ok response for the member fetch
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ success: false, error: "SERVER_ERROR" }),
+    });
+
+    // Click the Engineering team node to trigger member load
+    fireEvent.click(screen.getByRole("button", { name: /engineering/i }));
+
+    // Error affordance appears — error message + Retry button
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("Failed to load members.");
+    });
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+
+    // No member rows rendered
+    expect(screen.queryByText("Alice Smith")).not.toBeInTheDocument();
+
+    // Clicking Retry re-fetches: mock a successful response this time
+    mockFetchRespondents([RESPONDENT_ALICE]);
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Alice Smith")).toBeInTheDocument();
+    });
+
+    // Error affordance gone
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 });

--- a/src/src/__tests__/components/organizations/members-teams-view.test.tsx
+++ b/src/src/__tests__/components/organizations/members-teams-view.test.tsx
@@ -1,0 +1,254 @@
+/**
+ * TDD Red Phase — MembersTeamsView component tests.
+ *
+ * Tests:
+ *  (a) renders companies as root nodes
+ *  (b) expanding a company calls the teams endpoint and renders its teams
+ *  (c) selecting a node calls the respondents endpoint and renders members
+ *  (d) the "not associated with any team" bucket renders
+ */
+
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MembersTeamsView } from "@/components/organizations/members-teams-view";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const ORG_1 = { id: "org-1", name: "Acme Corp", ownerCoachId: "coach-1" };
+const ORG_2 = { id: "org-2", name: "Beta Inc", ownerCoachId: "coach-1" };
+
+const TEAM_ENG = {
+  id: "team-eng",
+  organizationId: "org-1",
+  parentTeamId: null,
+  name: "Engineering",
+  type: null,
+  description: null,
+  children: [
+    {
+      id: "team-frontend",
+      organizationId: "org-1",
+      parentTeamId: "team-eng",
+      name: "Frontend",
+      type: null,
+      description: null,
+      children: [],
+    },
+  ],
+};
+
+const RESPONDENT_ALICE = {
+  id: "resp-1",
+  firstName: "Alice",
+  lastName: "Smith",
+  email: "alice@acme.com",
+  roleType: "Leadership",
+  teamId: "team-eng",
+  organizationId: "org-1",
+};
+
+const RESPONDENT_BOB = {
+  id: "resp-2",
+  firstName: "Bob",
+  lastName: "Jones",
+  email: "bob@acme.com",
+  roleType: null,
+  teamId: null,
+  organizationId: "org-1",
+};
+
+// ---------------------------------------------------------------------------
+// fetch mock helpers
+// ---------------------------------------------------------------------------
+
+function mockFetchForOrg1Teams() {
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ success: true, data: [TEAM_ENG] }),
+  });
+}
+
+function mockFetchRespondents(respondents: typeof RESPONDENT_ALICE[]) {
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ success: true, data: respondents }),
+  });
+}
+
+beforeEach(() => {
+  global.fetch = jest.fn();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("MembersTeamsView", () => {
+  test("(a) renders companies as root nodes in the Teams panel", () => {
+    render(
+      <MembersTeamsView
+        initialOrganizations={[ORG_1, ORG_2]}
+      />
+    );
+
+    // Both orgs appear as root-level buttons/items in the left panel
+    expect(screen.getByText("Acme Corp")).toBeInTheDocument();
+    expect(screen.getByText("Beta Inc")).toBeInTheDocument();
+  });
+
+  test("(b) expanding a company calls the teams endpoint and renders its teams", async () => {
+    mockFetchForOrg1Teams();
+
+    render(
+      <MembersTeamsView
+        initialOrganizations={[ORG_1]}
+      />
+    );
+
+    // Click the expand control for Acme Corp
+    const expandBtn = screen.getByRole("button", { name: /acme corp/i });
+    fireEvent.click(expandBtn);
+
+    // Should have called GET /api/organizations/org-1/teams
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/organizations/org-1/teams"
+      );
+    });
+
+    // Team name appears
+    await waitFor(() => {
+      expect(screen.getByText("Engineering")).toBeInTheDocument();
+    });
+
+    // Nested child team appears
+    expect(screen.getByText("Frontend")).toBeInTheDocument();
+  });
+
+  test("(c) selecting a team node calls the respondents endpoint and renders members", async () => {
+    // First expand the org to load teams
+    mockFetchForOrg1Teams();
+
+    render(
+      <MembersTeamsView
+        initialOrganizations={[ORG_1]}
+      />
+    );
+
+    // Expand the org
+    fireEvent.click(screen.getByRole("button", { name: /acme corp/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Engineering")).toBeInTheDocument();
+    });
+
+    // Now mock the respondents fetch
+    mockFetchRespondents([RESPONDENT_ALICE]);
+
+    // Click the Engineering team node
+    const teamBtn = screen.getByRole("button", { name: /engineering/i });
+    fireEvent.click(teamBtn);
+
+    // Should have called GET /api/organizations/org-1/respondents?teamId=team-eng
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/organizations/org-1/respondents?teamId=team-eng"
+      );
+    });
+
+    // Members table shows Alice
+    await waitFor(() => {
+      expect(screen.getByText("Alice Smith")).toBeInTheDocument();
+    });
+    expect(screen.getByText("alice@acme.com")).toBeInTheDocument();
+    expect(screen.getByText("Leadership")).toBeInTheDocument();
+  });
+
+  test("(d) 'not associated with any team' bucket renders after org expansion", async () => {
+    mockFetchForOrg1Teams();
+
+    render(
+      <MembersTeamsView
+        initialOrganizations={[ORG_1]}
+      />
+    );
+
+    // Expand the org
+    fireEvent.click(screen.getByRole("button", { name: /acme corp/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Engineering")).toBeInTheDocument();
+    });
+
+    // "Not associated with any team" pseudo-node should also be visible
+    expect(
+      screen.getByText(/not associated with any team/i)
+    ).toBeInTheDocument();
+  });
+
+  test("(d-respondents) selecting 'not associated' fetches respondents with no teamId filter", async () => {
+    mockFetchForOrg1Teams();
+
+    render(
+      <MembersTeamsView
+        initialOrganizations={[ORG_1]}
+      />
+    );
+
+    // Expand the org
+    fireEvent.click(screen.getByRole("button", { name: /acme corp/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/not associated with any team/i)).toBeInTheDocument();
+    });
+
+    // Mock respondents fetch for unassigned
+    mockFetchRespondents([RESPONDENT_BOB]);
+
+    // Click unassigned node
+    const unassignedBtn = screen.getByRole("button", {
+      name: /not associated with any team/i,
+    });
+    fireEvent.click(unassignedBtn);
+
+    // For unassigned: we call respondents WITHOUT a teamId query param,
+    // then filter client-side to those with teamId === null.
+    // The endpoint call itself is to the org respondents root.
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/api/organizations/org-1/respondents")
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Bob Jones")).toBeInTheDocument();
+    });
+  });
+
+  test("selecting the company root node shows all org members", async () => {
+    // No teams expansion needed — just clicking the org node itself
+    mockFetchRespondents([RESPONDENT_ALICE, RESPONDENT_BOB]);
+
+    render(
+      <MembersTeamsView
+        initialOrganizations={[ORG_1]}
+      />
+    );
+
+    // Org root node button exists; clicking WITHOUT expanding loads org members
+    // We'll select it directly (not expand)
+    // In the component, there should be a separate "select" click target or
+    // the button click both selects and (optionally) expands.
+    // This test verifies: when org node is selected, members are loaded.
+    mockFetchRespondents([RESPONDENT_ALICE, RESPONDENT_BOB]);
+
+    // The component should start with no members shown (right panel empty)
+    expect(screen.queryByText("Alice Smith")).not.toBeInTheDocument();
+  });
+});

--- a/src/src/app/(portal)/portal/members/page.tsx
+++ b/src/src/app/(portal)/portal/members/page.tsx
@@ -1,0 +1,53 @@
+/**
+ * Members & Teams — coach portal page (Slice 1, read-only).
+ *
+ * Server component: loads the coach's organizations from the DB
+ * and renders the two-panel MembersTeamsView client component.
+ *
+ * Pattern matches /portal/assessments/page.tsx:
+ *   - requireCoach() for auth
+ *   - db.* for data loading
+ *   - FadeUp for animation
+ *   - brand tokens for styling
+ */
+
+import { db } from "@/lib/db";
+import { requireCoach } from "@/lib/auth/authorization";
+import { FadeUp } from "@/components/ui/animated";
+import {
+  MembersTeamsView,
+  type OrgSummary,
+} from "@/components/organizations/members-teams-view";
+
+export default async function MembersPage() {
+  const { coach } = await requireCoach();
+
+  const organizations = await db.organization.findMany({
+    where: { ownerCoachId: coach.id, deletedAt: null },
+    orderBy: { createdAt: "desc" },
+    select: { id: true, name: true, ownerCoachId: true },
+  });
+
+  const items: OrgSummary[] = organizations.map((o) => ({
+    id: o.id,
+    name: o.name,
+    ownerCoachId: o.ownerCoachId,
+  }));
+
+  return (
+    <div className="space-y-6">
+      <FadeUp>
+        <div>
+          <h1 className="text-2xl font-bold text-foreground">Members &amp; Teams</h1>
+          <p className="text-muted-foreground">
+            Manage your company structure, teams, and members.
+          </p>
+        </div>
+      </FadeUp>
+
+      <FadeUp delay={0.1}>
+        <MembersTeamsView initialOrganizations={items} />
+      </FadeUp>
+    </div>
+  );
+}

--- a/src/src/app/api/assessment-campaigns/route.ts
+++ b/src/src/app/api/assessment-campaigns/route.ts
@@ -305,9 +305,10 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    // Task M — process optional bulkRespondents payload from the wizard
-    // CSV import. Best-effort: any per-row failure is recorded as an error
-    // and returned to the client; the campaign itself stays created.
+    // deprecated: Task M wizard CSV import. The setup-first flip (Slice 1)
+    // stopped the wizard from sending bulkRespondents — coaches now pick
+    // EXISTING members. Kept intact (optional, now unused by the UI) so older
+    // drafts/clients that still POST bulkRespondents keep working.
     let bulkResult: {
       created: Array<{ id: string; email: string }>;
       skipped: Array<{ email: string }>;
@@ -357,6 +358,11 @@ export async function POST(request: NextRequest) {
 // ────────────────────────────────────────────────────────────────────────
 // Task M — bulk-respondent helper (wizard-create path)
 // ────────────────────────────────────────────────────────────────────────
+//
+// deprecated: the campaign wizard no longer sends `bulkRespondents` (Slice 1
+// setup-first flip — coaches pick EXISTING members). This helper + the
+// `bulkRespondents` field on `createAssessmentCampaignSchema` are retained,
+// optional and functional, for backward-compat with older drafts/clients.
 //
 // Idempotent skip-on-conflict semantics: if an OrgRespondent already
 // exists (same org + dedupeValue), the row is reported in `skipped` and

--- a/src/src/components/assessments/CampaignDetail.tsx
+++ b/src/src/components/assessments/CampaignDetail.tsx
@@ -668,6 +668,7 @@ export function CampaignDetail({
     setAdding(true);
     const ids = Array.from(selectedRespondentIds);
     const errors: string[] = [];
+    let successCount = 0;
     for (const orgRespondentId of ids) {
       try {
         const res = await fetch(
@@ -681,7 +682,10 @@ export function CampaignDetail({
         const body = await res.json();
         if (!res.ok || !body.success) {
           const code = body.code as string | undefined;
-          if (code === "ALREADY_PARTICIPANT") continue; // benign
+          if (code === "ALREADY_PARTICIPANT") {
+            successCount++; // benign — already in, counts as success
+            continue;
+          }
           const msg = typeof body.error === "string"
             ? body.error
             : code === "WRONG_ORGANIZATION"
@@ -690,31 +694,46 @@ export function CampaignDetail({
                 ? "Cannot add respondents to a closed campaign."
                 : "Failed to add respondent";
           errors.push(msg);
+        } else {
+          successCount++;
         }
       } catch (err) {
         errors.push(err instanceof Error ? err.message : "Network error");
       }
     }
     setAdding(false);
-    if (errors.length > 0) {
+
+    // Always refresh so any partial successes appear in the table.
+    await refreshRespondents();
+    router.refresh();
+
+    const failCount = errors.length;
+
+    if (successCount > 0 && failCount === 0) {
+      // All succeeded.
+      toast({
+        title: successCount === 1 ? "Respondent added" : `${successCount} respondents added`,
+        description:
+          campaign.status === "ACTIVE"
+            ? "Pending invitation rows created. Use Resend to deliver the emails."
+            : "Participants added to this draft campaign.",
+      });
+      resetAddDialog();
+    } else if (successCount > 0 && failCount > 0) {
+      // Partial success — keep dialog open so the coach can retry the failures.
+      toast({
+        title: `${successCount} added, ${failCount} couldn't be added`,
+        description: errors[0],
+        variant: "destructive",
+      });
+    } else {
+      // All failed.
       toast({
         title: "Could not add respondent",
         description: errors[0],
         variant: "destructive",
       });
-      return;
     }
-    const added = ids.length;
-    toast({
-      title: added === 1 ? "Respondent added" : `${added} respondents added`,
-      description:
-        campaign.status === "ACTIVE"
-          ? "Pending invitation rows created. Use Resend to deliver the emails."
-          : "Participants added to this draft campaign.",
-    });
-    resetAddDialog();
-    await refreshRespondents();
-    router.refresh();
   }
 
   async function handleConfirmRemove() {

--- a/src/src/components/assessments/CampaignDetail.tsx
+++ b/src/src/components/assessments/CampaignDetail.tsx
@@ -16,13 +16,12 @@
  *  - public/wireframes-phase2/revisions/08-revised-individual-results.html
  */
 
-import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
+import { Fragment, useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import {
   ArrowLeft,
   Download,
-  FileUp,
   Loader2,
   Mail,
   Eye,
@@ -31,7 +30,6 @@ import {
   Trash2,
   XCircle,
 } from "lucide-react";
-import { parseRespondentCsv } from "@/lib/assessments/respondent-csv";
 import { useToast } from "@/components/ui/use-toast";
 import {
   Dialog,
@@ -156,26 +154,13 @@ export function CampaignDetail({
   const [closeReason, setCloseReason] = useState("");
   const [closing, setClosing] = useState(false);
 
-  // Add Respondent modal state.
+  // Add Respondent modal state — pick-existing only (Slice 1).
   const [addDialogOpen, setAddDialogOpen] = useState(false);
-  const [addTab, setAddTab] = useState<"single" | "bulk">("single");
   const [orgRespondents, setOrgRespondents] = useState<OrgRespondentRow[]>([]);
   const [loadingOrgRespondents, setLoadingOrgRespondents] = useState(false);
-  const [selectedRespondentId, setSelectedRespondentId] = useState<string>("");
+  const [orgRespondentsLoaded, setOrgRespondentsLoaded] = useState(false);
+  const [selectedRespondentIds, setSelectedRespondentIds] = useState<Set<string>>(new Set());
   const [adding, setAdding] = useState(false);
-  const [newRespondentFirstName, setNewRespondentFirstName] = useState("");
-  const [newRespondentLastName, setNewRespondentLastName] = useState("");
-  const [newRespondentEmail, setNewRespondentEmail] = useState("");
-  const [creatingRespondent, setCreatingRespondent] = useState(false);
-
-  // Task M — Bulk CSV tab state.
-  const [bulkCsvText, setBulkCsvText] = useState("");
-  const [bulkMode, setBulkMode] = useState<"skip" | "merge">("skip");
-  const [bulkSubmitting, setBulkSubmitting] = useState(false);
-  const [bulkProgress, setBulkProgress] = useState<{
-    current: number;
-    total: number;
-  } | null>(null);
 
   // Remove participant confirm dialog state.
   const [removeTarget, setRemoveTarget] =
@@ -644,15 +629,18 @@ export function CampaignDetail({
       });
     } finally {
       setLoadingOrgRespondents(false);
+      setOrgRespondentsLoaded(true);
     }
   }, [campaign.organizationId, toast]);
 
   // Lazy-load the org respondents on first open of the Add dialog.
+  // Use orgRespondentsLoaded flag instead of length check to avoid an
+  // infinite loop when the org has zero members.
   useEffect(() => {
-    if (addDialogOpen && orgRespondents.length === 0 && !loadingOrgRespondents) {
+    if (addDialogOpen && !orgRespondentsLoaded && !loadingOrgRespondents) {
       void loadOrgRespondents();
     }
-  }, [addDialogOpen, orgRespondents.length, loadingOrgRespondents, loadOrgRespondents]);
+  }, [addDialogOpen, orgRespondentsLoaded, loadingOrgRespondents, loadOrgRespondents]);
 
   const participantRespondentIds = new Set(
     respondents.map((r) => r.respondent.id),
@@ -663,232 +651,70 @@ export function CampaignDetail({
 
   function resetAddDialog() {
     setAddDialogOpen(false);
-    setSelectedRespondentId("");
-    setNewRespondentFirstName("");
-    setNewRespondentLastName("");
-    setNewRespondentEmail("");
-    setAddTab("single");
-    setBulkCsvText("");
-    setBulkMode("skip");
-    setBulkProgress(null);
+    setSelectedRespondentIds(new Set());
+    // Clear loaded state so the next open re-fetches fresh members.
+    setOrgRespondents([]);
+    setOrgRespondentsLoaded(false);
   }
 
-  async function handleCreateAndAdd() {
-    const firstName = newRespondentFirstName.trim();
-    const lastName = newRespondentLastName.trim();
-    const email = newRespondentEmail.trim();
-    if (!firstName || !lastName || !email) {
+  /**
+   * Add all selected (checked) respondents to the campaign one by one.
+   * Loops through selectedRespondentIds and calls the existing POST
+   * /api/assessment-campaigns/[id]/respondents endpoint for each.
+   * ALREADY_PARTICIPANT responses are treated as benign (idempotent).
+   */
+  async function handleConfirmAdd() {
+    if (selectedRespondentIds.size === 0 || adding) return;
+    setAdding(true);
+    const ids = Array.from(selectedRespondentIds);
+    const errors: string[] = [];
+    for (const orgRespondentId of ids) {
+      try {
+        const res = await fetch(
+          `/api/assessment-campaigns/${campaign.id}/respondents`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ orgRespondentId }),
+          },
+        );
+        const body = await res.json();
+        if (!res.ok || !body.success) {
+          const code = body.code as string | undefined;
+          if (code === "ALREADY_PARTICIPANT") continue; // benign
+          const msg = typeof body.error === "string"
+            ? body.error
+            : code === "WRONG_ORGANIZATION"
+              ? "Respondent belongs to a different organization."
+              : code === "CAMPAIGN_CLOSED"
+                ? "Cannot add respondents to a closed campaign."
+                : "Failed to add respondent";
+          errors.push(msg);
+        }
+      } catch (err) {
+        errors.push(err instanceof Error ? err.message : "Network error");
+      }
+    }
+    setAdding(false);
+    if (errors.length > 0) {
       toast({
-        title: "Missing fields",
-        description: "First name, last name, and email are required.",
+        title: "Could not add respondent",
+        description: errors[0],
         variant: "destructive",
       });
       return;
     }
-    setCreatingRespondent(true);
-    try {
-      const createRes = await fetch(
-        `/api/organizations/${campaign.organizationId}/respondents`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ firstName, lastName, email }),
-        },
-      );
-      const createBody = await createRes.json();
-      if (!createRes.ok || !createBody.success) {
-        throw new Error(
-          typeof createBody.error === "string"
-            ? createBody.error
-            : "Failed to create respondent",
-        );
-      }
-      const created = createBody.data as OrgRespondentRow;
-      setOrgRespondents((prev) => [...prev, created]);
-      setSelectedRespondentId(created.id);
-      setNewRespondentFirstName("");
-      setNewRespondentLastName("");
-      setNewRespondentEmail("");
-      toast({
-        title: "Respondent created",
-        description: `${created.firstName} ${created.lastName} has been added to the organization.`,
-      });
-    } catch (err) {
-      toast({
-        title: "Could not create respondent",
-        description:
-          err instanceof Error ? err.message : "Please try again.",
-        variant: "destructive",
-      });
-    } finally {
-      setCreatingRespondent(false);
-    }
-  }
-
-  async function handleConfirmAdd() {
-    if (!selectedRespondentId || adding) return;
-    setAdding(true);
-    try {
-      const res = await fetch(
-        `/api/assessment-campaigns/${campaign.id}/respondents`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ orgRespondentId: selectedRespondentId }),
-        },
-      );
-      const body = await res.json();
-      if (!res.ok || !body.success) {
-        throw new Error(
-          typeof body.error === "string"
-            ? body.error
-            : body.code === "ALREADY_PARTICIPANT"
-              ? "This respondent is already a participant."
-              : body.code === "WRONG_ORGANIZATION"
-                ? "This respondent belongs to a different organization."
-                : body.code === "CAMPAIGN_CLOSED"
-                  ? "Cannot add respondents to a closed campaign."
-                  : "Failed to add respondent",
-        );
-      }
-      toast({
-        title: "Respondent added",
-        description:
-          body.data?.invitation !== null
-            ? "Participant added and a pending invitation row was created. Use Resend to deliver the link."
-            : "Participant added to this draft campaign.",
-      });
-      resetAddDialog();
-      await refreshRespondents();
-      router.refresh();
-    } catch (err) {
-      toast({
-        title: "Could not add respondent",
-        description:
-          err instanceof Error ? err.message : "Please try again.",
-        variant: "destructive",
-      });
-    } finally {
-      setAdding(false);
-    }
-  }
-
-  // Task M — Bulk CSV: live-parsed preview.
-  const bulkParsed = useMemo(
-    () =>
-      bulkCsvText.trim().length > 0
-        ? parseRespondentCsv(bulkCsvText)
-        : null,
-    [bulkCsvText],
-  );
-
-  async function handleConfirmBulkAdd() {
-    if (!bulkParsed || bulkParsed.errors.length > 0) return;
-    if (bulkParsed.rows.length === 0) return;
-    setBulkSubmitting(true);
-    setBulkProgress(null);
-    try {
-      // 1) Bulk-create org respondents (Task M's new route).
-      const createRes = await fetch(
-        `/api/organizations/${campaign.organizationId}/respondents/bulk`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            rows: bulkParsed.rows,
-            mode: bulkMode,
-          }),
-        },
-      );
-      const createBody = await createRes.json();
-      if (!createRes.ok || !createBody.success) {
-        throw new Error(
-          typeof createBody.error === "string"
-            ? createBody.error
-            : "Failed to import respondents",
-        );
-      }
-      type RefRow = { id: string; email: string };
-      const created: RefRow[] = createBody.data?.created ?? [];
-      const updated: RefRow[] = createBody.data?.updated ?? [];
-      const skipped: { email: string }[] = createBody.data?.skipped ?? [];
-      const errors: { row: number; reason: string }[] =
-        createBody.data?.errors ?? [];
-
-      // 2) For every created OR updated respondent, attach as campaign
-      // participant. Skipped respondents are NOT auto-attached because
-      // the coach may already be tracking them on another campaign — we
-      // surface them in the toast and let the coach add explicitly via
-      // the Single tab if desired.
-      const attachTargets: RefRow[] = [...created, ...updated];
-      // Filter out anyone already in the participants table to avoid the
-      // 409 ALREADY_PARTICIPANT noise.
-      const alreadyIds = new Set(respondents.map((r) => r.respondent.id));
-      const toAttach = attachTargets.filter((r) => !alreadyIds.has(r.id));
-
-      let attachedCount = 0;
-      const attachErrors: string[] = [];
-      setBulkProgress({ current: 0, total: toAttach.length });
-      for (let i = 0; i < toAttach.length; i++) {
-        const ref = toAttach[i];
-        try {
-          const res = await fetch(
-            `/api/assessment-campaigns/${campaign.id}/respondents`,
-            {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ orgRespondentId: ref.id }),
-            },
-          );
-          if (res.ok) {
-            attachedCount += 1;
-          } else {
-            const body = await res.json().catch(() => ({}));
-            // ALREADY_PARTICIPANT is benign — coach added them via another
-            // path between bulk-create and this attach loop.
-            if (body?.code !== "ALREADY_PARTICIPANT") {
-              attachErrors.push(`${ref.email}: ${body?.error ?? res.status}`);
-            }
-          }
-        } catch (err) {
-          attachErrors.push(
-            `${ref.email}: ${err instanceof Error ? err.message : "network error"}`,
-          );
-        }
-        setBulkProgress({ current: i + 1, total: toAttach.length });
-      }
-
-      const summary = [
-        `${created.length} created`,
-        `${updated.length} updated`,
-        `${skipped.length} skipped`,
-        `${attachedCount} added to campaign`,
-      ];
-      if (errors.length > 0 || attachErrors.length > 0) {
-        summary.push(`${errors.length + attachErrors.length} errors`);
-      }
-
-      toast({
-        title: "Bulk import complete",
-        description: summary.join(" • "),
-        variant:
-          errors.length + attachErrors.length > 0 ? "destructive" : undefined,
-      });
-
-      resetAddDialog();
-      await refreshRespondents();
-      router.refresh();
-    } catch (err) {
-      toast({
-        title: "Could not import respondents",
-        description:
-          err instanceof Error ? err.message : "Please try again.",
-        variant: "destructive",
-      });
-    } finally {
-      setBulkSubmitting(false);
-      setBulkProgress(null);
-    }
+    const added = ids.length;
+    toast({
+      title: added === 1 ? "Respondent added" : `${added} respondents added`,
+      description:
+        campaign.status === "ACTIVE"
+          ? "Pending invitation rows created. Use Resend to deliver the emails."
+          : "Participants added to this draft campaign.",
+    });
+    resetAddDialog();
+    await refreshRespondents();
+    router.refresh();
   }
 
   async function handleConfirmRemove() {
@@ -1482,7 +1308,7 @@ export function CampaignDetail({
       <Dialog
         open={addDialogOpen}
         onOpenChange={(open) => {
-          if (adding || creatingRespondent) return;
+          if (adding) return;
           if (!open) resetAddDialog();
           else setAddDialogOpen(open);
         }}
@@ -1495,277 +1321,74 @@ export function CampaignDetail({
             <DialogTitle>Add respondents to this campaign</DialogTitle>
             <DialogDescription>
               {isDraft
-                ? "Draft campaigns: new respondents are queued and will receive an invitation when you launch."
-                : "Active campaigns: new respondents get pending invitation rows. Use Resend to deliver the email."}
+                ? "Draft campaigns: selected members are queued and will receive an invitation when you launch."
+                : "Active campaigns: selected members get pending invitation rows. Use Resend to deliver the email."}
             </DialogDescription>
           </DialogHeader>
 
-          {/* Task M — Single vs Bulk tabs */}
-          <div
-            className="inline-flex items-center rounded-lg border border-border bg-muted/30 p-0.5 text-xs font-medium"
-            role="tablist"
-            aria-label="Add respondent mode"
-          >
-            <button
-              type="button"
-              role="tab"
-              aria-selected={addTab === "single"}
-              onClick={() => setAddTab("single")}
-              disabled={adding || creatingRespondent || bulkSubmitting}
-              className={
-                addTab === "single"
-                  ? "px-3 py-1.5 rounded-md bg-card text-foreground shadow-sm"
-                  : "px-3 py-1.5 rounded-md text-muted-foreground hover:text-foreground"
-              }
-              data-testid="add-respondent-tab-single"
-            >
-              Single
-            </button>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={addTab === "bulk"}
-              onClick={() => setAddTab("bulk")}
-              disabled={adding || creatingRespondent || bulkSubmitting}
-              className={
-                addTab === "bulk"
-                  ? "px-3 py-1.5 rounded-md bg-card text-foreground shadow-sm inline-flex items-center gap-1"
-                  : "px-3 py-1.5 rounded-md text-muted-foreground hover:text-foreground inline-flex items-center gap-1"
-              }
-              data-testid="add-respondent-tab-bulk"
-            >
-              <FileUp className="w-3.5 h-3.5" />
-              Bulk CSV
-            </button>
-          </div>
-
-          {addTab === "single" && (
-          <div className="space-y-4">
-            <div>
-              <label
-                htmlFor="add-respondent-select"
-                className="text-xs font-semibold uppercase tracking-wider text-muted-foreground"
-              >
-                Existing respondent
-              </label>
-              <select
-                id="add-respondent-select"
-                data-testid="add-respondent-select"
-                value={selectedRespondentId}
-                onChange={(e) => setSelectedRespondentId(e.target.value)}
-                disabled={loadingOrgRespondents || adding}
-                className="mt-1 w-full rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
-              >
-                <option value="">
-                  {loadingOrgRespondents
-                    ? "Loading..."
-                    : availableRespondents.length === 0
-                      ? "No respondents available — create one below"
-                      : "Select a respondent..."}
-                </option>
-                {availableRespondents.map((r) => (
-                  <option key={r.id} value={r.id}>
-                    {r.firstName} {r.lastName} — {r.email}
-                  </option>
-                ))}
-              </select>
+          {/* Pick-existing member list */}
+          {loadingOrgRespondents ? (
+            <div className="flex items-center justify-center py-8 text-sm text-muted-foreground gap-2">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              Loading members…
             </div>
-
-            <div className="border-t border-border pt-4 space-y-3">
-              <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                Or create a new respondent
-              </div>
-              <div className="grid grid-cols-2 gap-2">
-                <input
-                  data-testid="new-respondent-firstName"
-                  type="text"
-                  placeholder="First name"
-                  value={newRespondentFirstName}
-                  onChange={(e) =>
-                    setNewRespondentFirstName(e.target.value)
-                  }
-                  disabled={creatingRespondent}
-                  className="rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
-                />
-                <input
-                  data-testid="new-respondent-lastName"
-                  type="text"
-                  placeholder="Last name"
-                  value={newRespondentLastName}
-                  onChange={(e) =>
-                    setNewRespondentLastName(e.target.value)
-                  }
-                  disabled={creatingRespondent}
-                  className="rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
-                />
-              </div>
-              <input
-                data-testid="new-respondent-email"
-                type="email"
-                placeholder="Email"
-                value={newRespondentEmail}
-                onChange={(e) => setNewRespondentEmail(e.target.value)}
-                disabled={creatingRespondent}
-                className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
-              />
-              <button
-                type="button"
-                onClick={handleCreateAndAdd}
-                disabled={
-                  creatingRespondent ||
-                  !newRespondentFirstName.trim() ||
-                  !newRespondentLastName.trim() ||
-                  !newRespondentEmail.trim()
-                }
-                className="inline-flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-lg border border-border bg-card text-foreground hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                data-testid="create-new-respondent-btn"
-              >
-                {creatingRespondent && (
-                  <Loader2 className="w-3.5 h-3.5 animate-spin" />
-                )}
-                Create & select
-              </button>
-            </div>
-          </div>
-          )}
-
-          {addTab === "bulk" && (
+          ) : availableRespondents.length === 0 ? (
             <div
-              className="space-y-3"
-              data-testid="add-respondent-bulk-panel"
+              className="py-8 text-center space-y-3"
+              data-testid="add-respondent-empty-state"
             >
-              <div>
-                <label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                  Paste CSV
-                </label>
-                <p className="mt-1 text-xs text-muted-foreground">
-                  Header row: <code className="font-mono">name,email,team</code>{" "}
-                  (team optional, slash-delimited). Max 500 rows.
-                </p>
-              </div>
-              <textarea
-                value={bulkCsvText}
-                onChange={(e) => setBulkCsvText(e.target.value)}
-                placeholder={`name,email,team\nAlice Example,alice@example.com,Marketing/Brand\nBob Tester,bob@example.com,`}
-                rows={6}
-                disabled={bulkSubmitting}
-                className="w-full rounded-lg border border-input bg-background px-3 py-2 text-xs font-mono text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
-                data-testid="add-respondent-bulk-textarea"
-              />
-
-              <div className="space-y-2">
-                <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                  If a respondent already exists
-                </div>
-                <div className="flex items-center gap-4 text-xs">
-                  <label className="inline-flex items-center gap-2 cursor-pointer">
+              <p className="text-sm text-muted-foreground">
+                {orgRespondents.length === 0
+                  ? "This company has no members yet."
+                  : "All company members are already participants in this campaign."}
+              </p>
+              <Link
+                href="/portal/members"
+                className="inline-flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-lg border border-border bg-card text-foreground hover:bg-muted transition-colors"
+              >
+                Add members in the Members lane
+              </Link>
+            </div>
+          ) : (
+            <div
+              className="border border-border rounded-lg divide-y divide-border max-h-72 overflow-y-auto"
+              data-testid="add-respondent-member-list"
+            >
+              {availableRespondents.map((r) => {
+                const checked = selectedRespondentIds.has(r.id);
+                return (
+                  <label
+                    key={r.id}
+                    className="flex items-center gap-3 px-3 py-2.5 cursor-pointer hover:bg-muted/30 transition-colors"
+                    aria-label={`${r.firstName} ${r.lastName}`}
+                  >
                     <input
-                      type="radio"
-                      name="bulk-mode"
-                      value="skip"
-                      checked={bulkMode === "skip"}
-                      onChange={() => setBulkMode("skip")}
-                      disabled={bulkSubmitting}
-                      className="accent-primary"
-                      data-testid="add-respondent-bulk-mode-skip"
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => {
+                        setSelectedRespondentIds((prev) => {
+                          const next = new Set(prev);
+                          if (checked) next.delete(r.id);
+                          else next.add(r.id);
+                          return next;
+                        });
+                      }}
+                      disabled={adding}
+                      className="accent-primary shrink-0"
+                      aria-label={`${r.firstName} ${r.lastName}`}
                     />
-                    Skip existing
-                  </label>
-                  <label className="inline-flex items-center gap-2 cursor-pointer">
-                    <input
-                      type="radio"
-                      name="bulk-mode"
-                      value="merge"
-                      checked={bulkMode === "merge"}
-                      onChange={() => setBulkMode("merge")}
-                      disabled={bulkSubmitting}
-                      className="accent-primary"
-                      data-testid="add-respondent-bulk-mode-merge"
-                    />
-                    Merge existing
-                  </label>
-                </div>
-              </div>
-
-              {bulkParsed && (
-                <div
-                  className="text-xs space-y-2"
-                  data-testid="add-respondent-bulk-preview"
-                >
-                  <div className="flex items-center gap-3">
-                    <span className="font-medium text-foreground">
-                      {bulkParsed.rows.length} valid row
-                      {bulkParsed.rows.length === 1 ? "" : "s"}
-                    </span>
-                    {bulkParsed.errors.length > 0 && (
-                      <span className="text-destructive font-medium">
-                        {bulkParsed.errors.length} error
-                        {bulkParsed.errors.length === 1 ? "" : "s"}
-                      </span>
-                    )}
-                  </div>
-                  {bulkParsed.rows.length > 0 && (
-                    <div className="border border-border rounded-md overflow-hidden max-h-48 overflow-y-auto">
-                      <table className="w-full">
-                        <thead className="bg-muted/40 sticky top-0">
-                          <tr>
-                            <th className="text-left px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                              Name
-                            </th>
-                            <th className="text-left px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                              Email
-                            </th>
-                            <th className="text-left px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                              Team
-                            </th>
-                          </tr>
-                        </thead>
-                        <tbody className="divide-y divide-border">
-                          {bulkParsed.rows.map((row, i) => (
-                            <tr key={`${row.email}-${i}`}>
-                              <td className="px-2 py-1 text-foreground">
-                                {row.name}
-                              </td>
-                              <td className="px-2 py-1 text-foreground font-mono">
-                                {row.email}
-                              </td>
-                              <td className="px-2 py-1 text-muted-foreground">
-                                {row.teamPath.length > 0
-                                  ? row.teamPath.join(" / ")
-                                  : "—"}
-                              </td>
-                            </tr>
-                          ))}
-                        </tbody>
-                      </table>
+                    <div className="min-w-0 flex-1">
+                      <div className="text-sm font-medium text-foreground truncate">
+                        {r.firstName} {r.lastName}
+                      </div>
+                      <div className="text-xs text-muted-foreground truncate">
+                        {r.email}
+                        {r.jobTitle ? ` · ${r.jobTitle}` : ""}
+                      </div>
                     </div>
-                  )}
-                  {bulkParsed.errors.length > 0 && (
-                    <ul className="border border-destructive/40 rounded-md p-2 bg-destructive/5 max-h-32 overflow-y-auto space-y-1">
-                      {bulkParsed.errors.slice(0, 20).map((e, i) => (
-                        <li key={i} className="text-destructive">
-                          Row {e.row}: {e.reason}
-                        </li>
-                      ))}
-                      {bulkParsed.errors.length > 20 && (
-                        <li className="text-destructive/80 italic">
-                          + {bulkParsed.errors.length - 20} more errors…
-                        </li>
-                      )}
-                    </ul>
-                  )}
-                </div>
-              )}
-
-              {bulkProgress && (
-                <div
-                  className="text-xs text-muted-foreground"
-                  data-testid="add-respondent-bulk-progress"
-                  role="status"
-                >
-                  Adding {bulkProgress.current} of {bulkProgress.total}…
-                </div>
-              )}
+                  </label>
+                );
+              })}
             </div>
           )}
 
@@ -1773,50 +1396,24 @@ export function CampaignDetail({
             <button
               type="button"
               onClick={resetAddDialog}
-              disabled={adding || creatingRespondent || bulkSubmitting}
+              disabled={adding}
               className="inline-flex items-center justify-center text-sm font-medium px-4 py-2 rounded-lg border border-border bg-card text-foreground hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
               data-testid="add-respondent-cancel"
             >
               Cancel
             </button>
-            {addTab === "single" ? (
-              <button
-                type="button"
-                onClick={handleConfirmAdd}
-                disabled={
-                  !selectedRespondentId || adding || creatingRespondent
-                }
-                className="inline-flex items-center justify-center gap-1.5 text-sm font-medium px-4 py-2 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                data-testid="add-respondent-confirm"
-              >
-                {adding && <Loader2 className="w-4 h-4 animate-spin" />}
-                Add to campaign
-              </button>
-            ) : (
-              <button
-                type="button"
-                onClick={handleConfirmBulkAdd}
-                disabled={
-                  !bulkParsed ||
-                  bulkParsed.rows.length === 0 ||
-                  bulkParsed.errors.length > 0 ||
-                  bulkSubmitting
-                }
-                className="inline-flex items-center justify-center gap-1.5 text-sm font-medium px-4 py-2 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                data-testid="add-respondent-bulk-confirm"
-              >
-                {bulkSubmitting && (
-                  <Loader2 className="w-4 h-4 animate-spin" />
-                )}
-                {bulkSubmitting
-                  ? bulkProgress
-                    ? `Adding ${bulkProgress.current}/${bulkProgress.total}…`
-                    : "Importing…"
-                  : `Import ${bulkParsed?.rows.length ?? 0} respondent${
-                      bulkParsed?.rows.length === 1 ? "" : "s"
-                    }`}
-              </button>
-            )}
+            <button
+              type="button"
+              onClick={handleConfirmAdd}
+              disabled={selectedRespondentIds.size === 0 || adding}
+              className="inline-flex items-center justify-center gap-1.5 text-sm font-medium px-4 py-2 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              data-testid="add-respondent-confirm"
+            >
+              {adding && <Loader2 className="w-4 h-4 animate-spin" />}
+              {selectedRespondentIds.size > 1
+                ? `Add ${selectedRespondentIds.size} to campaign`
+                : "Add to campaign"}
+            </button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/src/src/components/assessments/CampaignWizard.tsx
+++ b/src/src/components/assessments/CampaignWizard.tsx
@@ -58,6 +58,26 @@ function relativeTimeFrom(d: Date): string {
   return `${days}d ago`;
 }
 
+/**
+ * API error fields come back as either a string or a Zod issues array
+ * (`[{ message, path }]`). Reduce either to a single human-readable reason,
+ * falling back to `fallback` when nothing useful is present.
+ */
+function extractErrorMessage(error: unknown, fallback: string): string {
+  if (typeof error === "string" && error.trim() !== "") return error;
+  if (Array.isArray(error)) {
+    const messages = error
+      .map((issue) =>
+        issue && typeof issue === "object" && "message" in issue
+          ? String((issue as { message: unknown }).message)
+          : "",
+      )
+      .filter((m) => m.trim() !== "");
+    if (messages.length > 0) return messages.join("; ");
+  }
+  return fallback;
+}
+
 type EndMode = "OPEN_END" | "ENDS_AFTER";
 
 interface Organization {
@@ -403,6 +423,14 @@ export function CampaignWizard() {
       const campaignId = createBody.data.id as string;
 
       // 2) Add participants.
+      // TODO: atomic create+participants — the create route does NOT accept
+      // respondentIds/ceoRespondentId (only the deprecated bulkRespondents
+      // create-new path), so picking EXISTING members requires this second
+      // call. Until the create route grows a "pick-existing participants"
+      // input, the campaign row exists before participants are attached, so a
+      // failure here leaves a created-but-empty campaign. We surface that
+      // partial state explicitly (below) rather than a generic error, and do
+      // NOT delete-rollback.
       const partRes = await fetch(
         `/api/assessment-campaigns/${campaignId}/participants`,
         {
@@ -416,11 +444,28 @@ export function CampaignWizard() {
       );
       const partBody = await partRes.json();
       if (!partRes.ok || !partBody.success) {
-        throw new Error(
-          typeof partBody.error === "string"
-            ? partBody.error
-            : "Failed to assign participants",
+        // The campaign WAS created — make the partial state understandable
+        // instead of a generic "Could not save campaign" toast.
+        const reason = extractErrorMessage(
+          partBody.error,
+          "the participants could not be added",
         );
+        // Clear the auto-save draft: the campaign exists, so resuming the
+        // wizard draft would create a duplicate. The coach finishes in the
+        // campaign detail page.
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+        try {
+          await fetch(DRAFT_ENDPOINT, { method: "DELETE" });
+        } catch {
+          // best-effort; the campaign was already created
+        }
+        toast({
+          title: "Campaign created, but adding participants failed",
+          description: `${reason}. Open the campaign to add them.`,
+          variant: "destructive",
+        });
+        router.push(`/portal/assessments/${campaignId}`);
+        return;
       }
 
       // 3) Optionally activate.
@@ -533,7 +578,22 @@ export function CampaignWizard() {
         {state.step === 0 && (
           <OrganizationStep
             value={state.organizationId}
-            onChange={(v) => update("organizationId", v)}
+            onChange={(v) =>
+              setState((s) => {
+                // Re-selecting the same org must NOT wipe a valid member
+                // selection. Only on an actual company change do we clear the
+                // picked members + CEO — otherwise their (other-company) ids
+                // would persist and get rejected by /participants later,
+                // leaving an orphaned empty campaign.
+                if (s.organizationId === v) return s;
+                return {
+                  ...s,
+                  organizationId: v,
+                  respondentIds: [],
+                  ceoRespondentId: null,
+                };
+              })
+            }
             onNext={next}
           />
         )}
@@ -827,14 +887,18 @@ function ParticipantsStep({
       ]);
       const teamsBody = await teamsRes.json();
       const respBody = await respRes.json();
-      if (teamsRes.ok && teamsBody.success) {
-        setTeams(teamsBody.data as ApiTeamNode[]);
-      }
-      if (respRes.ok && respBody.success) {
-        setRespondents(respBody.data as Respondent[]);
-      } else {
+      const teamsOk = teamsRes.ok && teamsBody.success;
+      const respOk = respRes.ok && respBody.success;
+      // BOTH fetches must succeed. If teams fails but members load, every
+      // member would silently fall into the "Not associated with any team"
+      // bucket — wrong grouping shown as correct. Surface the error (with the
+      // same Retry affordance) instead.
+      if (!teamsOk || !respOk) {
         setError(true);
+        return;
       }
+      setTeams(teamsBody.data as ApiTeamNode[]);
+      setRespondents(respBody.data as Respondent[]);
     } catch {
       setError(true);
     } finally {

--- a/src/src/components/assessments/CampaignWizard.tsx
+++ b/src/src/components/assessments/CampaignWizard.tsx
@@ -3,35 +3,43 @@
 /**
  * Assessment v7.6 — Coach Campaign Wizard.
  *
+ * Setup-first flip (Slice 1): coaches set up Company → Team → Users in the
+ * Members lane FIRST, then a campaign PICKS an existing company + a subset
+ * of its existing members. No inline create here.
+ *
  * 5 steps:
- *   0. Pick organization (or inline-create one).
+ *   0. Pick an EXISTING organization (no inline-create; CTA to /portal/members
+ *      when the coach has none yet).
  *   1. Pick template (INTERSECTION-filtered).
- *   2. Assign participants + CEO (or inline-create respondents).
+ *   2. Pick EXISTING participants (grouped by team) + manually mark a CEO.
  *   3. Schedule (name, openAt, endMode, closeAt).
  *   4. Review → "Save Draft" or "Create + Activate".
  *
  * Wiring:
  *   GET  /api/organizations
- *   POST /api/organizations
  *   GET  /api/assessment-templates
+ *   GET  /api/organizations/[orgId]/teams
  *   GET  /api/organizations/[orgId]/respondents
- *   POST /api/organizations/[orgId]/respondents
  *   POST /api/assessment-campaigns
  *   POST /api/assessment-campaigns/[id]/participants
  *   POST /api/assessment-campaigns/[id]/activate
  */
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { ArrowLeft, ArrowRight, Check, Loader2, FileUp } from "lucide-react";
+import {
+  ArrowLeft,
+  ArrowRight,
+  Check,
+  Loader2,
+  Building2,
+  Users,
+} from "lucide-react";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/components/ui/use-toast";
-import {
-  parseRespondentCsv,
-  type ParsedRow,
-} from "@/lib/assessments/respondent-csv";
 
 const DRAFT_ENDPOINT = "/api/assessment-campaign-drafts";
 const DRAFT_DEBOUNCE_MS = 800;
@@ -75,6 +83,15 @@ interface Respondent {
   teamId: string | null;
 }
 
+/** Shape returned by GET /api/organizations/[id]/teams (nested tree). */
+interface ApiTeamNode {
+  id: string;
+  organizationId: string;
+  parentTeamId: string | null;
+  name: string;
+  children: ApiTeamNode[];
+}
+
 interface WizardState {
   step: number;
   organizationId: string;
@@ -85,11 +102,6 @@ interface WizardState {
   openAt: string; // datetime-local string
   endMode: EndMode;
   closeAt: string;
-  // Task M — bulk CSV import staged in the wizard. Server-side
-  // `POST /api/assessment-campaigns` accepts this alongside the singly-
-  // assigned `respondentIds` and creates OrgRespondent rows after the
-  // campaign exists. Skipped on resubmit (idempotent dedupe).
-  bulkRespondents: ParsedRow[];
   // Task O UI — per-campaign invitation email overrides. Null/empty = fall back to template default.
   invitationSubject: string;
   invitationBodyMarkdown: string;
@@ -157,7 +169,6 @@ export function CampaignWizard() {
       openAt: formatDateTimeLocal(tomorrow),
       endMode: "OPEN_END",
       closeAt: "",
-      bulkRespondents: [],
       invitationSubject: "",
       invitationBodyMarkdown: "",
     };
@@ -217,9 +228,6 @@ export function CampaignWizard() {
           openAt: parsed.openAt ?? state.openAt,
           endMode: parsed.endMode === "ENDS_AFTER" ? "ENDS_AFTER" : "OPEN_END",
           closeAt: parsed.closeAt ?? "",
-          bulkRespondents: Array.isArray(parsed.bulkRespondents)
-            ? (parsed.bulkRespondents as ParsedRow[])
-            : [],
           invitationSubject:
             typeof parsed.invitationSubject === "string"
               ? parsed.invitationSubject
@@ -266,7 +274,6 @@ export function CampaignWizard() {
             openAt: snapshot.openAt,
             endMode: snapshot.endMode,
             closeAt: snapshot.closeAt,
-            bulkRespondents: snapshot.bulkRespondents,
           },
         }),
       });
@@ -346,8 +353,7 @@ export function CampaignWizard() {
   const canActivate =
     state.organizationId &&
     state.templateId &&
-    (state.respondentIds.length > 0 ||
-      state.bulkRespondents.length > 0) &&
+    state.respondentIds.length > 0 &&
     state.name &&
     state.openAt &&
     (state.endMode === "OPEN_END" || state.closeAt);
@@ -360,10 +366,9 @@ export function CampaignWizard() {
     if (!canActivate) return;
     setSubmitting(true);
     try {
-      // 1) Create campaign (Task M: include staged bulkRespondents so the
-      // server creates the OrgRespondent rows in the same request — they
-      // were parsed client-side from a CSV but couldn't be POSTed earlier
-      // because the wizard hasn't created the Organization yet).
+      // 1) Create campaign. Setup-first flip: participants are EXISTING
+      // members picked in Step 2, so the create body no longer carries a
+      // `bulkRespondents` array — the company + members already exist.
       const createRes = await fetch("/api/assessment-campaigns", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -377,10 +382,6 @@ export function CampaignWizard() {
             state.endMode === "ENDS_AFTER" && state.closeAt
               ? new Date(state.closeAt).toISOString()
               : null,
-          bulkRespondents:
-            state.bulkRespondents.length > 0
-              ? state.bulkRespondents
-              : undefined,
           invitationSubject:
             state.invitationSubject.trim() !== ""
               ? state.invitationSubject.trim()
@@ -549,7 +550,6 @@ export function CampaignWizard() {
             organizationId={state.organizationId}
             respondentIds={state.respondentIds}
             ceoRespondentId={state.ceoRespondentId}
-            bulkRespondents={state.bulkRespondents}
             onChange={(rIds, ceoId) => {
               setState((s) => ({
                 ...s,
@@ -557,9 +557,6 @@ export function CampaignWizard() {
                 ceoRespondentId: ceoId,
               }));
             }}
-            onChangeBulk={(rows) =>
-              setState((s) => ({ ...s, bulkRespondents: rows }))
-            }
             onBack={back}
             onNext={next}
           />
@@ -602,13 +599,8 @@ function OrganizationStep({
   onChange: (v: string) => void;
   onNext: () => void;
 }) {
-  const { toast } = useToast();
   const [orgs, setOrgs] = useState<Organization[]>([]);
   const [loading, setLoading] = useState(true);
-  const [showCreate, setShowCreate] = useState(false);
-  const [name, setName] = useState("");
-  const [externalId, setExternalId] = useState("");
-  const [creating, setCreating] = useState(false);
 
   const refresh = useCallback(async () => {
     try {
@@ -627,49 +619,15 @@ function OrganizationStep({
     refresh();
   }, [refresh]);
 
-  async function handleCreate(e: React.FormEvent) {
-    e.preventDefault();
-    if (!name.trim()) return;
-    setCreating(true);
-    try {
-      const res = await fetch("/api/organizations", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          name: name.trim(),
-          externalId: externalId.trim() || undefined,
-        }),
-      });
-      const body = await res.json();
-      if (!res.ok || !body.success) {
-        throw new Error(
-          typeof body.error === "string" ? body.error : "Failed to create",
-        );
-      }
-      setName("");
-      setExternalId("");
-      setShowCreate(false);
-      onChange(body.data.id);
-      await refresh();
-    } catch (err) {
-      toast({
-        title: "Failed to create organization",
-        description: err instanceof Error ? err.message : "",
-        variant: "destructive",
-      });
-    } finally {
-      setCreating(false);
-    }
-  }
-
   return (
     <div className="space-y-6">
       <div>
         <h2 className="text-xl font-semibold text-foreground">
-          Pick an organization
+          Pick a company
         </h2>
         <p className="text-sm text-muted-foreground">
-          Assessments are scoped to a single organization that you own.
+          Assessments are scoped to a single company you&apos;ve set up. Pick
+          the one this campaign is for.
         </p>
       </div>
 
@@ -677,17 +635,19 @@ function OrganizationStep({
         <div className="flex items-center text-sm text-muted-foreground">
           <Loader2 className="w-4 h-4 animate-spin mr-2" /> Loading...
         </div>
-      ) : orgs.length === 0 && !showCreate ? (
-        <div className="text-sm text-muted-foreground">
-          You don&apos;t have any organizations yet.{" "}
-          <button
-            type="button"
-            className="text-primary hover:underline"
-            onClick={() => setShowCreate(true)}
+      ) : orgs.length === 0 ? (
+        <div className="border border-dashed border-border rounded-lg p-6 text-center space-y-3">
+          <Building2 className="w-8 h-8 mx-auto text-muted-foreground" />
+          <div className="text-sm text-muted-foreground">
+            You haven&apos;t set up any companies yet. Create a company and add
+            its people before you start a campaign.
+          </div>
+          <Link
+            href="/portal/members"
+            className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
           >
-            Create one
-          </button>
-          .
+            Set up a company first
+          </Link>
         </div>
       ) : (
         <div className="space-y-2">
@@ -719,62 +679,6 @@ function OrganizationStep({
             </label>
           ))}
         </div>
-      )}
-
-      {!showCreate ? (
-        <button
-          type="button"
-          className="text-sm text-primary hover:underline"
-          onClick={() => setShowCreate(true)}
-        >
-          + New organization
-        </button>
-      ) : (
-        <form
-          onSubmit={handleCreate}
-          className="border border-border rounded-lg p-4 space-y-3 bg-muted/30"
-        >
-          <div className="space-y-2">
-            <Label htmlFor="orgName">Organization name</Label>
-            <Input
-              id="orgName"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="Acme Corp"
-              required
-              maxLength={200}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="orgExt">External ID (optional)</Label>
-            <Input
-              id="orgExt"
-              value={externalId}
-              onChange={(e) => setExternalId(e.target.value)}
-              placeholder="HUB-12345"
-              maxLength={200}
-            />
-          </div>
-          <div className="flex gap-2 justify-end">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => setShowCreate(false)}
-              disabled={creating}
-            >
-              Cancel
-            </Button>
-            <Button type="submit" disabled={creating || !name.trim()}>
-              {creating ? (
-                <>
-                  <Loader2 className="w-4 h-4 animate-spin mr-2" /> Creating...
-                </>
-              ) : (
-                "Create"
-              )}
-            </Button>
-          </div>
-        </form>
       )}
 
       <div className="flex justify-end pt-4">
@@ -893,65 +797,46 @@ function ParticipantsStep({
   organizationId,
   respondentIds,
   ceoRespondentId,
-  bulkRespondents,
   onChange,
-  onChangeBulk,
   onBack,
   onNext,
 }: {
   organizationId: string;
   respondentIds: string[];
   ceoRespondentId: string | null;
-  bulkRespondents: ParsedRow[];
   onChange: (rIds: string[], ceoId: string | null) => void;
-  onChangeBulk: (rows: ParsedRow[]) => void;
   onBack: () => void;
   onNext: () => void;
 }) {
-  const { toast } = useToast();
   const [respondents, setRespondents] = useState<Respondent[]>([]);
+  const [teams, setTeams] = useState<ApiTeamNode[]>([]);
   const [loading, setLoading] = useState(true);
-  const [showCreate, setShowCreate] = useState(false);
-  const [showBulk, setShowBulk] = useState(bulkRespondents.length > 0);
-  const [bulkCsvText, setBulkCsvText] = useState("");
-  const [firstName, setFirstName] = useState("");
-  const [lastName, setLastName] = useState("");
-  const [email, setEmail] = useState("");
-  const [jobTitle, setJobTitle] = useState("");
-  const [creating, setCreating] = useState(false);
-
-  // Task M — live-parse the CSV textarea so the preview/error counters
-  // update on every keystroke.
-  const bulkParsed = useMemo(
-    () => (bulkCsvText.trim().length > 0 ? parseRespondentCsv(bulkCsvText) : null),
-    [bulkCsvText],
-  );
-
-  function applyParsedBulk() {
-    if (!bulkParsed) return;
-    if (bulkParsed.errors.length > 0) return;
-    if (bulkParsed.rows.length === 0) return;
-    onChangeBulk(bulkParsed.rows);
-    setBulkCsvText("");
-    toast({
-      title: "Staged for import",
-      description: `${bulkParsed.rows.length} respondent${bulkParsed.rows.length === 1 ? "" : "s"} will be created when you save the campaign.`,
-    });
-  }
-
-  function clearStagedBulk() {
-    onChangeBulk([]);
-  }
+  const [error, setError] = useState(false);
 
   const refresh = useCallback(async () => {
     if (!organizationId) return;
     setLoading(true);
+    setError(false);
     try {
-      const res = await fetch(`/api/organizations/${organizationId}/respondents`);
-      const body = await res.json();
-      if (res.ok && body.success) {
-        setRespondents(body.data as Respondent[]);
+      // Fetch the team tree + all members for THIS company only. The picker
+      // is strictly scoped to the selected org — other companies are never
+      // requested or shown.
+      const [teamsRes, respRes] = await Promise.all([
+        fetch(`/api/organizations/${organizationId}/teams`),
+        fetch(`/api/organizations/${organizationId}/respondents`),
+      ]);
+      const teamsBody = await teamsRes.json();
+      const respBody = await respRes.json();
+      if (teamsRes.ok && teamsBody.success) {
+        setTeams(teamsBody.data as ApiTeamNode[]);
       }
+      if (respRes.ok && respBody.success) {
+        setRespondents(respBody.data as Respondent[]);
+      } else {
+        setError(true);
+      }
+    } catch {
+      setError(true);
     } finally {
       setLoading(false);
     }
@@ -975,357 +860,173 @@ function ParticipantsStep({
 
   function setCEO(id: string) {
     if (!respondentIds.includes(id)) {
-      // Auto-include if user clicked CEO without checking first.
+      // Auto-include if the coach marked CEO without checking the box first.
       onChange([...respondentIds, id], id);
     } else {
       onChange(respondentIds, id);
     }
   }
 
-  async function handleCreate(e: React.FormEvent) {
-    e.preventDefault();
-    if (!firstName.trim() || !lastName.trim() || !email.trim()) return;
-    setCreating(true);
-    try {
-      const res = await fetch(
-        `/api/organizations/${organizationId}/respondents`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            firstName: firstName.trim(),
-            lastName: lastName.trim(),
-            email: email.trim(),
-            jobTitle: jobTitle.trim() || undefined,
-          }),
-        },
-      );
-      const body = await res.json();
-      if (!res.ok || !body.success) {
-        throw new Error(
-          typeof body.error === "string" ? body.error : "Failed to create",
-        );
+  // Build ordered team groups (flattened, with depth) + an "unassigned"
+  // bucket for members whose teamId is null or points at a team we don't
+  // have. Members within a group keep the server order (lastName, firstName).
+  const groups = useMemo(() => {
+    const flat: Array<{ id: string; name: string; depth: number }> = [];
+    const walk = (nodes: ApiTeamNode[], depth: number) => {
+      for (const n of nodes) {
+        flat.push({ id: n.id, name: n.name, depth });
+        if (n.children?.length) walk(n.children, depth + 1);
       }
-      // Auto-add the new respondent.
-      onChange([...respondentIds, body.data.id], ceoRespondentId);
-      setFirstName("");
-      setLastName("");
-      setEmail("");
-      setJobTitle("");
-      setShowCreate(false);
-      await refresh();
-    } catch (err) {
-      toast({
-        title: "Failed to add respondent",
-        description: err instanceof Error ? err.message : "",
-        variant: "destructive",
-      });
-    } finally {
-      setCreating(false);
+    };
+    walk(teams, 0);
+
+    const knownTeamIds = new Set(flat.map((t) => t.id));
+    const byTeam = new Map<string, Respondent[]>();
+    const unassigned: Respondent[] = [];
+    for (const r of respondents) {
+      if (r.teamId && knownTeamIds.has(r.teamId)) {
+        const list = byTeam.get(r.teamId) ?? [];
+        list.push(r);
+        byTeam.set(r.teamId, list);
+      } else {
+        unassigned.push(r);
+      }
     }
+
+    const result: Array<{
+      key: string;
+      label: string;
+      depth: number;
+      members: Respondent[];
+    }> = [];
+    for (const t of flat) {
+      const members = byTeam.get(t.id) ?? [];
+      if (members.length > 0) {
+        result.push({ key: t.id, label: t.name, depth: t.depth, members });
+      }
+    }
+    if (unassigned.length > 0) {
+      result.push({
+        key: "__unassigned__",
+        label: "Not associated with any team",
+        depth: 0,
+        members: unassigned,
+      });
+    }
+    return result;
+  }, [teams, respondents]);
+
+  function renderRow(r: Respondent) {
+    const checked = respondentIds.includes(r.id);
+    const isCEO = ceoRespondentId === r.id;
+    return (
+      <div
+        key={r.id}
+        className="flex items-center gap-3 px-3 py-2 hover:bg-muted/30"
+      >
+        <input
+          type="checkbox"
+          checked={checked}
+          onChange={(e) => toggleRespondent(r.id, e.target.checked)}
+          className="accent-primary"
+          aria-label={`Include ${r.firstName} ${r.lastName}`}
+        />
+        <div className="flex-1 text-sm">
+          <div className="font-medium text-foreground">
+            {r.firstName} {r.lastName}
+          </div>
+          <div className="text-xs text-muted-foreground">
+            {r.email}
+            {r.jobTitle ? ` • ${r.jobTitle}` : ""}
+          </div>
+        </div>
+        <label className="flex items-center gap-1 text-xs text-muted-foreground cursor-pointer">
+          <input
+            type="radio"
+            name="ceo"
+            checked={isCEO}
+            onChange={() => setCEO(r.id)}
+            className="accent-primary"
+            aria-label={`Mark ${r.firstName} ${r.lastName} as CEO`}
+          />
+          CEO
+        </label>
+      </div>
+    );
   }
 
   return (
     <div className="space-y-6">
       <div>
         <h2 className="text-xl font-semibold text-foreground">
-          Assign participants
+          Pick participants
         </h2>
         <p className="text-sm text-muted-foreground">
-          Pick the respondents who will take this assessment. Choose one as
-          CEO if needed.
+          Choose the existing members of this company who will take the
+          assessment. Mark one as CEO if needed. Need to add someone?{" "}
+          <Link href="/portal/members" className="text-primary hover:underline">
+            Manage members
+          </Link>
+          .
         </p>
       </div>
 
       {loading ? (
         <div className="flex items-center text-sm text-muted-foreground">
-          <Loader2 className="w-4 h-4 animate-spin mr-2" /> Loading respondents...
+          <Loader2 className="w-4 h-4 animate-spin mr-2" /> Loading members...
+        </div>
+      ) : error ? (
+        <div className="flex items-center gap-3 text-sm">
+          <span className="text-destructive" role="alert">
+            Failed to load members.
+          </span>
+          <button
+            type="button"
+            onClick={() => void refresh()}
+            className="text-primary underline hover:no-underline"
+          >
+            Retry
+          </button>
         </div>
       ) : respondents.length === 0 ? (
-        <div className="text-sm text-muted-foreground">
-          No respondents yet for this organization. Add one below.
+        <div className="border border-dashed border-border rounded-lg p-6 text-center space-y-3">
+          <Users className="w-8 h-8 mx-auto text-muted-foreground" />
+          <div className="text-sm text-muted-foreground">
+            This company has no members yet. Add people to the company before
+            you can pick participants.
+          </div>
+          <Link
+            href="/portal/members"
+            className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+          >
+            Manage members
+          </Link>
         </div>
       ) : (
-        <div className="border border-border rounded-lg divide-y divide-border overflow-hidden">
-          {respondents.map((r) => {
-            const checked = respondentIds.includes(r.id);
-            const isCEO = ceoRespondentId === r.id;
-            return (
-              <div
-                key={r.id}
-                className="flex items-center gap-3 px-3 py-2 hover:bg-muted/30"
-              >
-                <input
-                  type="checkbox"
-                  checked={checked}
-                  onChange={(e) => toggleRespondent(r.id, e.target.checked)}
-                  className="accent-primary"
-                  aria-label={`Include ${r.firstName} ${r.lastName}`}
-                />
-                <div className="flex-1 text-sm">
-                  <div className="font-medium text-foreground">
-                    {r.firstName} {r.lastName}
-                  </div>
-                  <div className="text-xs text-muted-foreground">
-                    {r.email}
-                    {r.jobTitle ? ` • ${r.jobTitle}` : ""}
-                  </div>
-                </div>
-                <label className="flex items-center gap-1 text-xs text-muted-foreground cursor-pointer">
-                  <input
-                    type="radio"
-                    name="ceo"
-                    checked={isCEO}
-                    onChange={() => setCEO(r.id)}
-                    className="accent-primary"
-                  />
-                  CEO
-                </label>
-              </div>
-            );
-          })}
-        </div>
-      )}
-
-      {!showCreate ? (
-        <div className="flex items-center gap-4">
-          <button
-            type="button"
-            className="text-sm text-primary hover:underline"
-            onClick={() => setShowCreate(true)}
-          >
-            + New respondent
-          </button>
-          <button
-            type="button"
-            className="text-sm text-primary hover:underline inline-flex items-center gap-1"
-            onClick={() => setShowBulk((v) => !v)}
-            data-testid="wizard-toggle-bulk-csv"
-          >
-            <FileUp className="w-3.5 h-3.5" />
-            {showBulk ? "Hide bulk import" : "Bulk import from CSV"}
-          </button>
-        </div>
-      ) : (
-        <form
-          onSubmit={handleCreate}
-          className="border border-border rounded-lg p-4 space-y-3 bg-muted/30"
-        >
-          <div className="grid grid-cols-2 gap-3">
-            <div className="space-y-2">
-              <Label htmlFor="firstName">First name</Label>
-              <Input
-                id="firstName"
-                value={firstName}
-                onChange={(e) => setFirstName(e.target.value)}
-                required
-                maxLength={200}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="lastName">Last name</Label>
-              <Input
-                id="lastName"
-                value={lastName}
-                onChange={(e) => setLastName(e.target.value)}
-                required
-                maxLength={200}
-              />
-            </div>
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="email">Email</Label>
-            <Input
-              id="email"
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-              maxLength={320}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="jobTitle">Job title (optional)</Label>
-            <Input
-              id="jobTitle"
-              value={jobTitle}
-              onChange={(e) => setJobTitle(e.target.value)}
-              maxLength={200}
-            />
-          </div>
-          <div className="flex gap-2 justify-end">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => setShowCreate(false)}
-              disabled={creating}
-            >
-              Cancel
-            </Button>
-            <Button
-              type="submit"
-              disabled={creating || !firstName.trim() || !lastName.trim() || !email.trim()}
-            >
-              {creating ? (
-                <>
-                  <Loader2 className="w-4 h-4 animate-spin mr-2" /> Adding...
-                </>
-              ) : (
-                "Add respondent"
-              )}
-            </Button>
-          </div>
-        </form>
-      )}
-
-      {showBulk && (
-        <div
-          className="border border-border rounded-lg p-4 space-y-3 bg-muted/20"
-          data-testid="wizard-bulk-csv-panel"
-        >
-          <div>
-            <h3 className="text-sm font-semibold text-foreground">
-              Bulk import respondents from CSV
-            </h3>
-            <p className="text-xs text-muted-foreground">
-              Paste CSV with header row{" "}
-              <code className="font-mono">name,email,team</code> (team
-              optional, slash-delimited). Rows will be created with the
-              campaign and skipped if the email already exists. Max 500
-              rows.
-            </p>
-          </div>
-
-          <textarea
-            data-testid="wizard-bulk-csv-textarea"
-            value={bulkCsvText}
-            onChange={(e) => setBulkCsvText(e.target.value)}
-            placeholder={`name,email,team\nAlice Example,alice@example.com,Marketing/Brand\nBob Tester,bob@example.com,`}
-            rows={6}
-            className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm font-mono text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-          />
-
-          {bulkParsed && (
+        <div className="space-y-4">
+          {groups.map((g) => (
             <div
-              className="text-xs space-y-2"
-              data-testid="wizard-bulk-csv-preview"
+              key={g.key}
+              className="border border-border rounded-lg overflow-hidden"
+              data-testid={`participant-group-${g.key}`}
             >
-              <div className="flex items-center gap-3">
-                <span className="font-medium text-foreground">
-                  {bulkParsed.rows.length} valid row
-                  {bulkParsed.rows.length === 1 ? "" : "s"}
+              <div
+                className="flex items-center gap-2 px-3 py-2 bg-muted/40 border-b border-border"
+                style={{ paddingLeft: `${g.depth * 16 + 12}px` }}
+              >
+                <Users className="w-3.5 h-3.5 text-muted-foreground" />
+                <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  {g.label}
                 </span>
-                {bulkParsed.errors.length > 0 && (
-                  <span className="text-destructive font-medium">
-                    {bulkParsed.errors.length} error
-                    {bulkParsed.errors.length === 1 ? "" : "s"}
-                  </span>
-                )}
+                <span className="text-[10px] text-muted-foreground">
+                  ({g.members.length})
+                </span>
               </div>
-
-              {bulkParsed.rows.length > 0 && (
-                <div className="border border-border rounded-md overflow-hidden">
-                  <table className="w-full">
-                    <thead className="bg-muted/40">
-                      <tr>
-                        <th className="text-left px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                          Name
-                        </th>
-                        <th className="text-left px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                          Email
-                        </th>
-                        <th className="text-left px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                          Team
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody className="divide-y divide-border">
-                      {bulkParsed.rows.slice(0, 10).map((row, i) => (
-                        <tr key={`${row.email}-${i}`}>
-                          <td className="px-2 py-1 text-foreground">
-                            {row.name}
-                          </td>
-                          <td className="px-2 py-1 text-foreground font-mono">
-                            {row.email}
-                          </td>
-                          <td className="px-2 py-1 text-muted-foreground">
-                            {row.teamPath.length > 0
-                              ? row.teamPath.join(" / ")
-                              : "—"}
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                  {bulkParsed.rows.length > 10 && (
-                    <div className="px-2 py-1 text-[10px] text-muted-foreground bg-muted/30 border-t border-border">
-                      + {bulkParsed.rows.length - 10} more rows…
-                    </div>
-                  )}
-                </div>
-              )}
-
-              {bulkParsed.errors.length > 0 && (
-                <ul className="border border-destructive/40 rounded-md p-2 bg-destructive/5 max-h-40 overflow-y-auto space-y-1">
-                  {bulkParsed.errors.slice(0, 20).map((e, i) => (
-                    <li key={i} className="text-destructive">
-                      Row {e.row}: {e.reason}
-                    </li>
-                  ))}
-                  {bulkParsed.errors.length > 20 && (
-                    <li className="text-destructive/80 italic">
-                      + {bulkParsed.errors.length - 20} more errors…
-                    </li>
-                  )}
-                </ul>
-              )}
-            </div>
-          )}
-
-          <div className="flex items-center gap-2 pt-1">
-            <Button
-              type="button"
-              size="sm"
-              onClick={applyParsedBulk}
-              disabled={
-                !bulkParsed ||
-                bulkParsed.rows.length === 0 ||
-                bulkParsed.errors.length > 0
-              }
-              data-testid="wizard-bulk-csv-apply"
-            >
-              Stage for import
-            </Button>
-            <Button
-              type="button"
-              size="sm"
-              variant="outline"
-              onClick={() => setBulkCsvText("")}
-              disabled={bulkCsvText.length === 0}
-            >
-              Clear textarea
-            </Button>
-          </div>
-
-          {bulkRespondents.length > 0 && (
-            <div className="border-t border-border pt-3 text-xs space-y-2">
-              <div className="flex items-center justify-between">
-                <span className="font-medium text-foreground">
-                  {bulkRespondents.length} respondent
-                  {bulkRespondents.length === 1 ? "" : "s"} staged for
-                  creation
-                </span>
-                <button
-                  type="button"
-                  onClick={clearStagedBulk}
-                  className="text-destructive hover:underline"
-                  data-testid="wizard-bulk-csv-clear-staged"
-                >
-                  Remove staged
-                </button>
+              <div className="divide-y divide-border">
+                {g.members.map(renderRow)}
               </div>
             </div>
-          )}
+          ))}
         </div>
       )}
 
@@ -1333,12 +1034,7 @@ function ParticipantsStep({
         <Button variant="outline" onClick={onBack}>
           <ArrowLeft className="w-4 h-4 mr-2" /> Back
         </Button>
-        <Button
-          onClick={onNext}
-          disabled={
-            respondentIds.length === 0 && bulkRespondents.length === 0
-          }
-        >
+        <Button onClick={onNext} disabled={respondentIds.length === 0}>
           Next <ArrowRight className="w-4 h-4 ml-2" />
         </Button>
       </div>

--- a/src/src/components/nav/assessments-sidebar.tsx
+++ b/src/src/components/nav/assessments-sidebar.tsx
@@ -65,14 +65,9 @@ const ADMIN_ENTRIES: SidebarEntry[] = [
 
 const COACH_ENTRIES: SidebarEntry[] = [
   { href: "/portal/assessments", label: "My Campaigns", exact: true },
-  // Placeholder until a dedicated org-list portal page lands. Uses a
-  // sentinel query string so it never matches the My Campaigns active
-  // state on /portal/assessments. Still navigates (Next.js strips the
-  // query at render, so the campaigns page renders normally).
   {
-    href: "/portal/assessments?tab=organizations",
-    label: "My Organizations",
-    placeholder: true,
+    href: "/portal/members",
+    label: "Members",
   },
 ];
 

--- a/src/src/components/organizations/add-member-modal.tsx
+++ b/src/src/components/organizations/add-member-modal.tsx
@@ -54,6 +54,8 @@ export interface AddMemberModalProps {
   teams: ApiTeamNode[];
   /** Pre-selected team (the currently selected TreeNode when it's a team) */
   defaultTeamId: string | null;
+  /** True while the parent is fetching teams for this org */
+  loadingTeams?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -76,6 +78,7 @@ export function AddMemberModal({
   orgId,
   teams,
   defaultTeamId,
+  loadingTeams = false,
 }: AddMemberModalProps) {
   const firstNameId = useId();
   const lastNameId  = useId();
@@ -248,15 +251,21 @@ export function AddMemberModal({
                 data-testid="select-team"
                 value={teamId}
                 onChange={(e) => setTeamId(e.target.value)}
-                disabled={submitting}
+                disabled={submitting || loadingTeams}
                 className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
               >
-                <option value="">— no team —</option>
-                {teams.map((t) => (
-                  <option key={t.id} value={t.id}>
-                    {t.name}
-                  </option>
-                ))}
+                {loadingTeams ? (
+                  <option value="">Loading teams…</option>
+                ) : (
+                  <>
+                    <option value="">— no team —</option>
+                    {teams.map((t) => (
+                      <option key={t.id} value={t.id}>
+                        {t.name}
+                      </option>
+                    ))}
+                  </>
+                )}
               </select>
             </div>
 

--- a/src/src/components/organizations/add-member-modal.tsx
+++ b/src/src/components/organizations/add-member-modal.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+/**
+ * AddMemberModal — single-respondent create within one organization.
+ *
+ * Mirrors AddTeamModal conventions exactly:
+ *   - Dialog + DialogDescription for a11y
+ *   - native <select> with data-testid + linked <Label> via useId
+ *   - submitting guard, setError(null) reset
+ *   - res.ok && json.success checks
+ *   - Array.isArray(json.error) ? json.error[0]?.message : ... unwrap
+ *   - onCreated callback + onClose
+ *
+ * PROPS
+ * ─────
+ * open         — controls visibility
+ * onClose      — called when modal should close (cancel or success)
+ * onCreated    — called after successful create { respondent } so caller refreshes
+ * orgId        — the organization to create the respondent under (one at a time)
+ * teams        — flat list of teams belonging to orgId (pre-fetched by parent)
+ * defaultTeamId — pre-select this team in the selector (pass when a team node is selected)
+ */
+
+import React, { useState, useEffect, useId } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { ApiTeamNode } from "./members-teams-view";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** What we call back with on success */
+export type MemberCreatedResult = {
+  respondent: Record<string, unknown>;
+};
+
+export interface AddMemberModalProps {
+  open: boolean;
+  onClose: () => void;
+  onCreated: (result: MemberCreatedResult) => void;
+  /** The organization under which the respondent will be created */
+  orgId: string;
+  /** Flat team list for this org (already loaded by the parent view) */
+  teams: ApiTeamNode[];
+  /** Pre-selected team (the currently selected TreeNode when it's a team) */
+  defaultTeamId: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Very permissive email shape check — server validates strictly with Zod */
+function isEmailShape(value: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function AddMemberModal({
+  open,
+  onClose,
+  onCreated,
+  orgId,
+  teams,
+  defaultTeamId,
+}: AddMemberModalProps) {
+  const firstNameId = useId();
+  const lastNameId  = useId();
+  const emailId     = useId();
+  const jobTitleId  = useId();
+  const teamId_id   = useId();
+
+  // Form state
+  const [firstName, setFirstName] = useState("");
+  const [lastName,  setLastName]  = useState("");
+  const [email,     setEmail]     = useState("");
+  const [jobTitle,  setJobTitle]  = useState("");
+  const [teamId,    setTeamId]    = useState<string>(defaultTeamId ?? "");
+
+  // Submission state
+  const [submitting, setSubmitting] = useState(false);
+  const [error,      setError]      = useState<string | null>(null);
+
+  // Reset form whenever the dialog opens or the defaultTeamId changes
+  useEffect(() => {
+    if (open) {
+      setFirstName("");
+      setLastName("");
+      setEmail("");
+      setJobTitle("");
+      setTeamId(defaultTeamId ?? "");
+      setError(null);
+    }
+  }, [open, defaultTeamId]);
+
+  // ---------------------------------------------------------------------------
+  // Validation + submit
+  // ---------------------------------------------------------------------------
+
+  function validate(): string | null {
+    if (!firstName.trim()) return "First name is required.";
+    if (!lastName.trim())  return "Last name is required.";
+    if (!email.trim())     return "Email is required.";
+    if (!isEmailShape(email.trim())) return "Please enter a valid email address.";
+    return null;
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    const validationError = validate();
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const body: Record<string, unknown> = {
+        firstName: firstName.trim(),
+        lastName:  lastName.trim(),
+        email:     email.trim(),
+      };
+      if (jobTitle.trim()) body.jobTitle = jobTitle.trim();
+      // Send teamId only when a team is actually selected
+      if (teamId) {
+        body.teamId = teamId;
+      }
+
+      const res = await fetch(`/api/organizations/${orgId}/respondents`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+
+      const json = await res.json();
+      if (!res.ok || !json.success) {
+        setError(
+          Array.isArray(json.error)
+            ? (json.error[0]?.message ?? "Failed to add member. Please try again.")
+            : typeof json.error === "string"
+            ? json.error
+            : "Failed to add member. Please try again."
+        );
+        return;
+      }
+
+      onCreated({ respondent: json.data as Record<string, unknown> });
+      onClose();
+    } catch {
+      setError("An unexpected error occurred. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => { if (!isOpen) onClose(); }}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Add Member</DialogTitle>
+          <DialogDescription>
+            Add a respondent to this organization. Fields marked * are required.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} noValidate>
+          <div className="space-y-4 py-2">
+            {/* ---- First name ---- */}
+            <div className="space-y-1.5">
+              <Label htmlFor={firstNameId}>First name *</Label>
+              <Input
+                id={firstNameId}
+                value={firstName}
+                onChange={(e) => setFirstName(e.target.value)}
+                placeholder="e.g. Jane"
+                disabled={submitting}
+                required
+              />
+            </div>
+
+            {/* ---- Last name ---- */}
+            <div className="space-y-1.5">
+              <Label htmlFor={lastNameId}>Last name *</Label>
+              <Input
+                id={lastNameId}
+                value={lastName}
+                onChange={(e) => setLastName(e.target.value)}
+                placeholder="e.g. Smith"
+                disabled={submitting}
+                required
+              />
+            </div>
+
+            {/* ---- E-mail ---- */}
+            <div className="space-y-1.5">
+              <Label htmlFor={emailId}>E-mail *</Label>
+              <Input
+                id={emailId}
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="jane.smith@company.com"
+                disabled={submitting}
+                required
+              />
+            </div>
+
+            {/* ---- Job title (optional) ---- */}
+            <div className="space-y-1.5">
+              <Label htmlFor={jobTitleId}>Job title</Label>
+              <Input
+                id={jobTitleId}
+                value={jobTitle}
+                onChange={(e) => setJobTitle(e.target.value)}
+                placeholder="e.g. Director of Operations"
+                disabled={submitting}
+              />
+            </div>
+
+            {/* ---- Team (optional) ---- */}
+            <div className="space-y-1.5">
+              <Label htmlFor={teamId_id}>Team</Label>
+              {/*
+                Native <select> so jest/fireEvent.change works reliably
+                without @testing-library/user-event — same pattern as AddTeamModal.
+              */}
+              <select
+                id={teamId_id}
+                data-testid="select-team"
+                value={teamId}
+                onChange={(e) => setTeamId(e.target.value)}
+                disabled={submitting}
+                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <option value="">— no team —</option>
+                {teams.map((t) => (
+                  <option key={t.id} value={t.id}>
+                    {t.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* ---- Inline error ---- */}
+            {error && (
+              <p
+                role="alert"
+                className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive"
+              >
+                {error}
+              </p>
+            )}
+          </div>
+
+          <DialogFooter className="mt-4">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onClose}
+              disabled={submitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? "Adding…" : "Add member"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/src/components/organizations/add-team-modal.tsx
+++ b/src/src/components/organizations/add-team-modal.tsx
@@ -1,0 +1,370 @@
+"use client";
+
+/**
+ * AddTeamModal — dual-create Company (Organization) or Team (OrgTeam).
+ *
+ * MODEL MAPPING
+ * ─────────────
+ * "Company" = an Organization (no parent).  Created via POST /api/organizations.
+ * "Team"    = an OrgTeam under a company.    Created via POST /api/organizations/{orgId}/teams.
+ * "Sub-team"= an OrgTeam with a parentTeamId. Same endpoint, parentTeamId populated.
+ *
+ * GUARDS (enforced before submit)
+ * ─────────────────────────────────
+ * • Type = Company  is ONLY valid when Parent = root.
+ * • Parent = root   is ONLY valid when Type  = Company.
+ *
+ * PROPS
+ * ─────
+ * open          — controls visibility
+ * onClose       — called when the modal should close (cancel or success)
+ * onCreated     — called after a successful create so the parent can refresh
+ *                  { kind: "organization", org }  → refresh companies list
+ *                  { kind: "team", team, orgId }   → refresh that org's team tree
+ * organizations — the coach's existing companies (OrgSummary[])
+ * loadedTeams   — already-fetched teams per org keyed by orgId (may be incomplete)
+ */
+
+import React, { useState, useEffect, useId } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import type { OrgSummary, ApiTeamNode } from "./members-teams-view";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type TeamType = "company" | "department" | "team" | "folder";
+
+/** Possible parent selections */
+type ParentValue =
+  | "root"                 // — none (root) —
+  | `org:${string}`        // a company
+  | `team:${string}:${string}`; // team:<orgId>:<teamId>
+
+/** What we call back with on success */
+export type CreatedResult =
+  | { kind: "organization"; org: OrgSummary }
+  | { kind: "team"; team: Record<string, unknown>; orgId: string };
+
+export interface AddTeamModalProps {
+  open: boolean;
+  onClose: () => void;
+  onCreated: (result: CreatedResult) => void;
+  /** Coach's existing companies */
+  organizations: OrgSummary[];
+  /**
+   * Already-loaded team lists keyed by orgId.
+   * If an org has not been expanded yet the key may be absent or [].
+   */
+  loadedTeams: Record<string, ApiTeamNode[]>;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type FlatTeamEntry = { teamId: string; orgId: string; name: string; depth: number };
+
+/** Flatten nested ApiTeamNode tree into a list for the Parent select. */
+function flattenTeams(
+  nodes: ApiTeamNode[],
+  orgId: string,
+  depth: number
+): FlatTeamEntry[] {
+  const result: FlatTeamEntry[] = [];
+  for (const n of nodes) {
+    result.push({ teamId: n.id, orgId, name: n.name, depth });
+    result.push(...flattenTeams(n.children, orgId, depth + 1));
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function AddTeamModal({
+  open,
+  onClose,
+  onCreated,
+  organizations,
+  loadedTeams,
+}: AddTeamModalProps) {
+  const nameId  = useId();
+  const typeId  = useId();
+  const parentId = useId();
+  const descId  = useId();
+
+  // Form state
+  const [name, setName]           = useState("");
+  const [type, setType]           = useState<TeamType | "">("");
+  const [parent, setParent]       = useState<ParentValue>("root");
+  const [description, setDescription] = useState("");
+
+  // Submission state
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError]           = useState<string | null>(null);
+
+  // Reset form whenever the dialog opens
+  useEffect(() => {
+    if (open) {
+      setName("");
+      setType("");
+      setParent("root");
+      setDescription("");
+      setError(null);
+    }
+  }, [open]);
+
+  // ---------------------------------------------------------------------------
+  // Validation + submit
+  // ---------------------------------------------------------------------------
+
+  function validate(): string | null {
+    if (!name.trim()) return "Name is required.";
+
+    if (type === "company" && parent !== "root") {
+      return 'A Company type must have no parent — set Parent to "— none (root) —".';
+    }
+    if (type !== "company" && parent === "root") {
+      return "Only the Company type may be at root. Choose a parent company or team.";
+    }
+    if (!type) {
+      return "Type is required.";
+    }
+    return null;
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    const validationError = validate();
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      if (parent === "root") {
+        // Create a Company (Organization)
+        const res = await fetch("/api/organizations", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name: name.trim() }),
+        });
+        const json = await res.json();
+        if (!res.ok || !json.success) {
+          setError(
+            typeof json.error === "string"
+              ? json.error
+              : "Failed to create company. Please try again."
+          );
+          return;
+        }
+        onCreated({ kind: "organization", org: json.data as OrgSummary });
+        onClose();
+      } else if (parent.startsWith("org:")) {
+        // Create a Team directly under a company
+        const orgId = parent.slice(4); // strip "org:"
+        const body: Record<string, unknown> = {
+          name: name.trim(),
+          type: type as string,
+          parentTeamId: null,
+        };
+        if (description.trim()) body.description = description.trim();
+
+        const res = await fetch(`/api/organizations/${orgId}/teams`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        const json = await res.json();
+        if (!res.ok || !json.success) {
+          setError(
+            typeof json.error === "string"
+              ? json.error
+              : "Failed to create team. Please try again."
+          );
+          return;
+        }
+        onCreated({ kind: "team", team: json.data as Record<string, unknown>, orgId });
+        onClose();
+      } else {
+        // parent starts with "team:<orgId>:<teamId>"
+        const parts   = parent.slice(5).split(":"); // strip "team:"
+        const orgId   = parts[0];
+        const teamId  = parts[1];
+        const body: Record<string, unknown> = {
+          name: name.trim(),
+          type: type as string,
+          parentTeamId: teamId,
+        };
+        if (description.trim()) body.description = description.trim();
+
+        const res = await fetch(`/api/organizations/${orgId}/teams`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        const json = await res.json();
+        if (!res.ok || !json.success) {
+          setError(
+            typeof json.error === "string"
+              ? json.error
+              : "Failed to create team. Please try again."
+          );
+          return;
+        }
+        onCreated({ kind: "team", team: json.data as Record<string, unknown>, orgId });
+        onClose();
+      }
+    } catch {
+      setError("An unexpected error occurred. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Parent options: root + companies + their teams
+  // ---------------------------------------------------------------------------
+
+  const parentOptions: Array<{ value: string; label: string; indent: number }> = [
+    { value: "root", label: "— none (root) —", indent: 0 },
+  ];
+  for (const org of organizations) {
+    parentOptions.push({ value: `org:${org.id}`, label: org.name, indent: 0 });
+    const teams = loadedTeams[org.id] ?? [];
+    for (const t of flattenTeams(teams, org.id, 1)) {
+      parentOptions.push({
+        value: `team:${t.orgId}:${t.teamId}`,
+        label: `${"  ".repeat(t.depth)}${t.name}`,
+        indent: t.depth,
+      });
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => { if (!isOpen) onClose(); }}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Add Team / Company</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} noValidate>
+          <div className="space-y-4 py-2">
+            {/* ---- Name ---- */}
+            <div className="space-y-1.5">
+              <Label htmlFor={nameId}>Name *</Label>
+              <Input
+                id={nameId}
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g. Engineering"
+                disabled={submitting}
+                required
+              />
+            </div>
+
+            {/* ---- Type ---- */}
+            <div className="space-y-1.5">
+              <Label htmlFor={typeId}>Type *</Label>
+              {/*
+                We use a native <select> here so that jest/fireEvent.change works
+                reliably in tests without @testing-library/user-event.
+                Styled to match the rest of the UI.
+              */}
+              <select
+                id={typeId}
+                data-testid="select-type"
+                value={type}
+                onChange={(e) => setType(e.target.value as TeamType | "")}
+                disabled={submitting}
+                required
+                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <option value="" disabled>Select a type…</option>
+                <option value="company">Company</option>
+                <option value="department">Department</option>
+                <option value="team">Team</option>
+                <option value="folder">Folder</option>
+              </select>
+            </div>
+
+            {/* ---- Parent ---- */}
+            <div className="space-y-1.5">
+              <Label htmlFor={parentId}>Parent</Label>
+              <select
+                id={parentId}
+                data-testid="select-parent"
+                value={parent}
+                onChange={(e) => setParent(e.target.value as ParentValue)}
+                disabled={submitting}
+                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {parentOptions.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* ---- Description (optional, not sent for orgs) ---- */}
+            <div className="space-y-1.5">
+              <Label htmlFor={descId}>Description</Label>
+              <Textarea
+                id={descId}
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Optional description"
+                disabled={submitting}
+                className="min-h-[72px] resize-none"
+              />
+            </div>
+
+            {/* ---- Inline error ---- */}
+            {error && (
+              <p
+                role="alert"
+                className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive"
+              >
+                {error}
+              </p>
+            )}
+          </div>
+
+          <DialogFooter className="mt-4">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onClose}
+              disabled={submitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? "Creating…" : "Create"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/src/components/organizations/add-team-modal.tsx
+++ b/src/src/components/organizations/add-team-modal.tsx
@@ -29,6 +29,7 @@ import React, { useState, useEffect, useId } from "react";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter,
@@ -132,15 +133,13 @@ export function AddTeamModal({
 
   function validate(): string | null {
     if (!name.trim()) return "Name is required.";
+    if (!type) return "Type is required.";
 
     if (type === "company" && parent !== "root") {
       return 'A Company type must have no parent — set Parent to "— none (root) —".';
     }
     if (type !== "company" && parent === "root") {
       return "Only the Company type may be at root. Choose a parent company or team.";
-    }
-    if (!type) {
-      return "Type is required.";
     }
     return null;
   }
@@ -167,7 +166,9 @@ export function AddTeamModal({
         const json = await res.json();
         if (!res.ok || !json.success) {
           setError(
-            typeof json.error === "string"
+            Array.isArray(json.error)
+              ? (json.error[0]?.message ?? "Failed to create company. Please try again.")
+              : typeof json.error === "string"
               ? json.error
               : "Failed to create company. Please try again."
           );
@@ -193,7 +194,9 @@ export function AddTeamModal({
         const json = await res.json();
         if (!res.ok || !json.success) {
           setError(
-            typeof json.error === "string"
+            Array.isArray(json.error)
+              ? (json.error[0]?.message ?? "Failed to create team. Please try again.")
+              : typeof json.error === "string"
               ? json.error
               : "Failed to create team. Please try again."
           );
@@ -221,7 +224,9 @@ export function AddTeamModal({
         const json = await res.json();
         if (!res.ok || !json.success) {
           setError(
-            typeof json.error === "string"
+            Array.isArray(json.error)
+              ? (json.error[0]?.message ?? "Failed to create team. Please try again.")
+              : typeof json.error === "string"
               ? json.error
               : "Failed to create team. Please try again."
           );
@@ -265,6 +270,9 @@ export function AddTeamModal({
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>Add Team / Company</DialogTitle>
+          <DialogDescription>
+            Create a company, department, team, or folder.
+          </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit} noValidate>
@@ -326,18 +334,20 @@ export function AddTeamModal({
               </select>
             </div>
 
-            {/* ---- Description (optional, not sent for orgs) ---- */}
-            <div className="space-y-1.5">
-              <Label htmlFor={descId}>Description</Label>
-              <Textarea
-                id={descId}
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                placeholder="Optional description"
-                disabled={submitting}
-                className="min-h-[72px] resize-none"
-              />
-            </div>
+            {/* ---- Description (optional, not sent for orgs; hidden when Type=Company) ---- */}
+            {type !== "company" && (
+              <div className="space-y-1.5">
+                <Label htmlFor={descId}>Description</Label>
+                <Textarea
+                  id={descId}
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder="Optional description"
+                  disabled={submitting}
+                  className="min-h-[72px] resize-none"
+                />
+              </div>
+            )}
 
             {/* ---- Inline error ---- */}
             {error && (

--- a/src/src/components/organizations/members-teams-view.tsx
+++ b/src/src/components/organizations/members-teams-view.tsx
@@ -511,7 +511,18 @@ export function MembersTeamsView({ initialOrganizations }: MembersTeamsViewProps
           <button
             type="button"
             disabled={!selectedNode}
-            onClick={() => setAddMemberOpen(true)}
+            onClick={() => {
+              if (!selectedNode) return;
+              // Resolve the org for this node and lazy-load teams if not yet fetched
+              const modalOrgId =
+                selectedNode.kind === "organization" ? selectedNode.id :
+                selectedNode.kind === "team"         ? selectedNode.orgId :
+                /* unassigned */                       selectedNode.orgId;
+              if (orgStates[modalOrgId]?.teams === null && !orgStates[modalOrgId]?.loadingTeams) {
+                loadTeams(modalOrgId);
+              }
+              setAddMemberOpen(true);
+            }}
             title={selectedNode ? "Add Member" : "Select a company or team first"}
             className={[
               "p-1 rounded-md transition-colors",
@@ -641,6 +652,7 @@ export function MembersTeamsView({ initialOrganizations }: MembersTeamsViewProps
             orgId={modalOrgId}
             teams={modalTeams}
             defaultTeamId={modalDefaultTeamId}
+            loadingTeams={orgStates[modalOrgId]?.loadingTeams ?? false}
           />
         );
       })()}

--- a/src/src/components/organizations/members-teams-view.tsx
+++ b/src/src/components/organizations/members-teams-view.tsx
@@ -16,6 +16,8 @@ import React, { useState, useCallback, useRef } from "react";
 import { ChevronRight, ChevronDown, Building2, Users, UserPlus, FolderPlus } from "lucide-react";
 import { AddTeamModal } from "./add-team-modal";
 import type { CreatedResult } from "./add-team-modal";
+import { AddMemberModal } from "./add-member-modal";
+import type { MemberCreatedResult } from "./add-member-modal";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -163,6 +165,9 @@ export function MembersTeamsView({ initialOrganizations }: MembersTeamsViewProps
 
   // Add Team modal state
   const [addTeamOpen, setAddTeamOpen] = useState(false);
+
+  // Add Member modal state
+  const [addMemberOpen, setAddMemberOpen] = useState(false);
 
   // Selected node drives the right panel
   const [selectedNode, setSelectedNode] = useState<TreeNode | null>(null);
@@ -341,6 +346,16 @@ export function MembersTeamsView({ initialOrganizations }: MembersTeamsViewProps
     [loadTeams]
   );
 
+  // AddMemberModal callback — refresh the right panel after create
+  const handleMemberCreated = useCallback(
+    async (_result: MemberCreatedResult) => {
+      if (selectedNode) {
+        await loadMembers(selectedNode);
+      }
+    },
+    [selectedNode, loadMembers]
+  );
+
   // Build the loadedTeams map the modal needs for its Parent select
   const loadedTeamsForModal: Record<string, ApiTeamNode[]> = {};
   for (const org of organizations) {
@@ -495,10 +510,16 @@ export function MembersTeamsView({ initialOrganizations }: MembersTeamsViewProps
           </h2>
           <button
             type="button"
-            disabled
-            title="Add Member (coming soon)"
-            className="p-1 rounded-md text-muted-foreground opacity-40 cursor-not-allowed"
-            aria-label="Add Member (coming soon)"
+            disabled={!selectedNode}
+            onClick={() => setAddMemberOpen(true)}
+            title={selectedNode ? "Add Member" : "Select a company or team first"}
+            className={[
+              "p-1 rounded-md transition-colors",
+              selectedNode
+                ? "text-muted-foreground hover:text-foreground hover:bg-muted"
+                : "text-muted-foreground opacity-40 cursor-not-allowed",
+            ].join(" ")}
+            aria-label={selectedNode ? "Add Member" : "Add Member (select a node first)"}
           >
             <UserPlus className="w-4 h-4" />
           </button>
@@ -589,6 +610,40 @@ export function MembersTeamsView({ initialOrganizations }: MembersTeamsViewProps
         organizations={organizations}
         loadedTeams={loadedTeamsForModal}
       />
+
+      {/* AddMemberModal — only mount when we have an org context */}
+      {selectedNode && (() => {
+        // Resolve orgId + defaultTeamId from the current node
+        const modalOrgId =
+          selectedNode.kind === "organization" ? selectedNode.id :
+          selectedNode.kind === "team"         ? selectedNode.orgId :
+          /* unassigned */                       selectedNode.orgId;
+
+        const modalDefaultTeamId =
+          selectedNode.kind === "team" ? selectedNode.id : null;
+
+        // Flatten the org's loaded teams for the Team selector
+        function flattenForModal(nodes: ApiTeamNode[]): ApiTeamNode[] {
+          const result: ApiTeamNode[] = [];
+          for (const n of nodes) {
+            result.push(n);
+            result.push(...flattenForModal(n.children));
+          }
+          return result;
+        }
+        const modalTeams = flattenForModal(orgStates[modalOrgId]?.teams ?? []);
+
+        return (
+          <AddMemberModal
+            open={addMemberOpen}
+            onClose={() => setAddMemberOpen(false)}
+            onCreated={handleMemberCreated}
+            orgId={modalOrgId}
+            teams={modalTeams}
+            defaultTeamId={modalDefaultTeamId}
+          />
+        );
+      })()}
     </>
   );
 }

--- a/src/src/components/organizations/members-teams-view.tsx
+++ b/src/src/components/organizations/members-teams-view.tsx
@@ -330,7 +330,11 @@ export function MembersTeamsView({ initialOrganizations }: MembersTeamsViewProps
           [result.org.id]: { expanded: false, teams: null, loadingTeams: false, teamsError: false },
         }));
       } else {
-        // Refresh the team tree for the affected org so the new team appears
+        // Expand the org so the new team is visible, then refresh its team tree
+        setOrgStates((prev) => ({
+          ...prev,
+          [result.orgId]: { ...(prev[result.orgId] ?? { teams: null, loadingTeams: false, teamsError: false }), expanded: true },
+        }));
         await loadTeams(result.orgId);
       }
     },

--- a/src/src/components/organizations/members-teams-view.tsx
+++ b/src/src/components/organizations/members-teams-view.tsx
@@ -1,0 +1,478 @@
+"use client";
+
+/**
+ * MembersTeamsView — two-panel read-only display of a coach's companies,
+ * their team hierarchy, and the members in each team.
+ *
+ * LEFT panel:  company root nodes (expandable) → OrgTeam tree + "not associated" bucket
+ * RIGHT panel: respondent list for the selected node (Name, Email, Level)
+ *
+ * All data fetched on demand from existing REST APIs:
+ *   GET /api/organizations/[id]/teams
+ *   GET /api/organizations/[id]/respondents?teamId=<id>
+ */
+
+import React, { useState, useCallback } from "react";
+import { ChevronRight, ChevronDown, Building2, Users, UserPlus, FolderPlus } from "lucide-react";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Minimal org shape passed from the server page */
+export interface OrgSummary {
+  id: string;
+  name: string;
+  ownerCoachId: string;
+}
+
+/** Shape returned by GET /api/organizations/[id]/teams (nested tree) */
+export interface ApiTeamNode {
+  id: string;
+  organizationId: string;
+  parentTeamId: string | null;
+  name: string;
+  type: string | null;
+  description: string | null;
+  children: ApiTeamNode[];
+}
+
+/** Shape returned by GET /api/organizations/[id]/respondents */
+export interface ApiRespondent {
+  id: string;
+  organizationId: string;
+  teamId: string | null;
+  firstName: string;
+  lastName: string;
+  email: string;
+  roleType: string | null;
+  jobTitle?: string | null;
+}
+
+/**
+ * Discriminated union for every selectable / expandable node.
+ * Every handler branches on `kind`.
+ */
+export type TreeNode =
+  | { kind: "organization"; id: string; name: string }
+  | { kind: "team"; id: string; orgId: string; name: string; parentTeamId: string | null }
+  | { kind: "unassigned"; orgId: string };
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface MembersTeamsViewProps {
+  initialOrganizations: OrgSummary[];
+}
+
+// ---------------------------------------------------------------------------
+// State shapes
+// ---------------------------------------------------------------------------
+
+interface OrgState {
+  expanded: boolean;
+  teams: ApiTeamNode[] | null; // null = not yet loaded
+  loadingTeams: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Flatten a nested tree into a breadth-first list for rendering */
+function flattenTree(
+  nodes: ApiTeamNode[],
+  orgId: string,
+  depth: number
+): Array<{ node: ApiTeamNode; depth: number; orgId: string }> {
+  const result: Array<{ node: ApiTeamNode; depth: number; orgId: string }> = [];
+  for (const n of nodes) {
+    result.push({ node: n, depth, orgId });
+    result.push(...flattenTree(n.children, orgId, depth + 1));
+  }
+  return result;
+}
+
+/** Check two TreeNode values for equality */
+function isSameNode(a: TreeNode | null, b: TreeNode): boolean {
+  if (!a) return false;
+  if (a.kind !== b.kind) return false;
+  if (a.kind === "organization" && b.kind === "organization") return a.id === b.id;
+  if (a.kind === "team" && b.kind === "team") return a.id === b.id;
+  if (a.kind === "unassigned" && b.kind === "unassigned") return a.orgId === b.orgId;
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function NodeButton({
+  label,
+  selected,
+  depth,
+  icon,
+  onClick,
+}: {
+  label: string;
+  selected: boolean;
+  depth: number;
+  icon?: React.ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      aria-pressed={selected}
+      onClick={onClick}
+      style={{ paddingLeft: `${depth * 16 + 8}px` }}
+      className={[
+        "w-full flex items-center gap-2 py-1.5 pr-3 rounded-md text-sm text-left transition-colors",
+        selected
+          ? "bg-primary/10 text-primary font-medium"
+          : "text-foreground hover:bg-muted",
+      ].join(" ")}
+    >
+      {icon}
+      <span className="truncate">{label}</span>
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function MembersTeamsView({ initialOrganizations }: MembersTeamsViewProps) {
+  // Per-org expansion + team data state
+  const [orgStates, setOrgStates] = useState<Record<string, OrgState>>(() => {
+    const init: Record<string, OrgState> = {};
+    for (const org of initialOrganizations) {
+      init[org.id] = { expanded: false, teams: null, loadingTeams: false };
+    }
+    return init;
+  });
+
+  // Selected node drives the right panel
+  const [selectedNode, setSelectedNode] = useState<TreeNode | null>(null);
+
+  // Members for the currently selected node
+  const [members, setMembers] = useState<ApiRespondent[]>([]);
+  const [loadingMembers, setLoadingMembers] = useState(false);
+
+  // --------------------------------------------------------------------------
+  // Fetch helpers
+  // --------------------------------------------------------------------------
+
+  const loadTeams = useCallback(async (orgId: string) => {
+    setOrgStates((prev) => ({
+      ...prev,
+      [orgId]: { ...prev[orgId], loadingTeams: true },
+    }));
+    try {
+      const res = await fetch(`/api/organizations/${orgId}/teams`);
+      const json = await res.json();
+      setOrgStates((prev) => ({
+        ...prev,
+        [orgId]: {
+          ...prev[orgId],
+          teams: json.success ? (json.data as ApiTeamNode[]) : [],
+          loadingTeams: false,
+        },
+      }));
+    } catch {
+      setOrgStates((prev) => ({
+        ...prev,
+        [orgId]: { ...prev[orgId], teams: [], loadingTeams: false },
+      }));
+    }
+  }, []);
+
+  const loadMembers = useCallback(async (node: TreeNode) => {
+    setLoadingMembers(true);
+    setMembers([]);
+    try {
+      let url: string;
+      if (node.kind === "organization") {
+        url = `/api/organizations/${node.id}/respondents`;
+      } else if (node.kind === "team") {
+        url = `/api/organizations/${node.orgId}/respondents?teamId=${node.id}`;
+      } else {
+        // unassigned — fetch all, then filter client-side to those with teamId === null
+        url = `/api/organizations/${node.orgId}/respondents`;
+      }
+      const res = await fetch(url);
+      const json = await res.json();
+      if (json.success) {
+        let data = json.data as ApiRespondent[];
+        // For the unassigned bucket, filter to only unteamed respondents
+        if (node.kind === "unassigned") {
+          data = data.filter((r) => r.teamId === null);
+        }
+        setMembers(data);
+      }
+    } catch {
+      setMembers([]);
+    } finally {
+      setLoadingMembers(false);
+    }
+  }, []);
+
+  // --------------------------------------------------------------------------
+  // Handlers
+  // --------------------------------------------------------------------------
+
+  const handleOrgClick = useCallback(
+    async (org: OrgSummary) => {
+      const state = orgStates[org.id];
+      const isExpanding = !state.expanded;
+
+      // Toggle expansion
+      setOrgStates((prev) => ({
+        ...prev,
+        [org.id]: { ...prev[org.id], expanded: isExpanding },
+      }));
+
+      // Lazy-load teams on first expand
+      if (isExpanding && state.teams === null) {
+        await loadTeams(org.id);
+      }
+
+      // Select the org node for member display
+      const node: TreeNode = { kind: "organization", id: org.id, name: org.name };
+      setSelectedNode(node);
+      await loadMembers(node);
+    },
+    [orgStates, loadTeams, loadMembers]
+  );
+
+  const handleTeamClick = useCallback(
+    async (teamNode: ApiTeamNode, orgId: string) => {
+      const node: TreeNode = {
+        kind: "team",
+        id: teamNode.id,
+        orgId,
+        name: teamNode.name,
+        parentTeamId: teamNode.parentTeamId,
+      };
+      setSelectedNode(node);
+      await loadMembers(node);
+    },
+    [loadMembers]
+  );
+
+  const handleUnassignedClick = useCallback(
+    async (orgId: string) => {
+      const node: TreeNode = { kind: "unassigned", orgId };
+      setSelectedNode(node);
+      await loadMembers(node);
+    },
+    [loadMembers]
+  );
+
+  // --------------------------------------------------------------------------
+  // Render — LEFT panel
+  // --------------------------------------------------------------------------
+
+  function renderLeftPanel() {
+    return (
+      <div className="flex-none w-64 border-r border-border overflow-y-auto">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+          <h2 className="text-sm font-semibold text-foreground uppercase tracking-wide">
+            Teams
+          </h2>
+          <button
+            type="button"
+            disabled
+            title="Add Team (coming soon)"
+            className="p-1 rounded-md text-muted-foreground opacity-40 cursor-not-allowed"
+            aria-label="Add Team (coming soon)"
+          >
+            <FolderPlus className="w-4 h-4" />
+          </button>
+        </div>
+
+        {initialOrganizations.length === 0 && (
+          <p className="px-4 py-6 text-sm text-muted-foreground">
+            No companies yet. Create one to get started.
+          </p>
+        )}
+
+        <div className="p-2 space-y-0.5">
+          {initialOrganizations.map((org) => {
+            const state = orgStates[org.id];
+            const orgNode: TreeNode = { kind: "organization", id: org.id, name: org.name };
+            const isSelected = isSameNode(selectedNode, orgNode);
+
+            return (
+              <div key={org.id}>
+                {/* Company root node */}
+                <button
+                  type="button"
+                  aria-label={org.name}
+                  aria-pressed={isSelected}
+                  aria-expanded={state.expanded}
+                  onClick={() => handleOrgClick(org)}
+                  className={[
+                    "w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-sm text-left transition-colors",
+                    isSelected
+                      ? "bg-primary/10 text-primary font-medium"
+                      : "text-foreground hover:bg-muted",
+                  ].join(" ")}
+                >
+                  {state.expanded ? (
+                    <ChevronDown className="w-4 h-4 flex-shrink-0 text-muted-foreground" />
+                  ) : (
+                    <ChevronRight className="w-4 h-4 flex-shrink-0 text-muted-foreground" />
+                  )}
+                  <Building2 className="w-4 h-4 flex-shrink-0" />
+                  <span className="truncate font-medium">{org.name}</span>
+                </button>
+
+                {/* Expanded children */}
+                {state.expanded && (
+                  <div className="mt-0.5 space-y-0.5">
+                    {state.loadingTeams && (
+                      <p className="pl-8 py-1 text-xs text-muted-foreground">Loading…</p>
+                    )}
+
+                    {/* Nested team tree */}
+                    {state.teams &&
+                      flattenTree(state.teams, org.id, 1).map(({ node: tn, depth }) => {
+                        const teamNode: TreeNode = {
+                          kind: "team",
+                          id: tn.id,
+                          orgId: org.id,
+                          name: tn.name,
+                          parentTeamId: tn.parentTeamId,
+                        };
+                        const isTeamSelected = isSameNode(selectedNode, teamNode);
+                        return (
+                          <NodeButton
+                            key={tn.id}
+                            label={tn.name}
+                            selected={isTeamSelected}
+                            depth={depth}
+                            icon={<Users className="w-3.5 h-3.5 flex-shrink-0 text-muted-foreground" />}
+                            onClick={() => handleTeamClick(tn, org.id)}
+                          />
+                        );
+                      })}
+
+                    {/* "Not associated with any team" pseudo-node */}
+                    {state.teams !== null && (
+                      <NodeButton
+                        label="Not associated with any team"
+                        selected={isSameNode(selectedNode, { kind: "unassigned", orgId: org.id })}
+                        depth={1}
+                        icon={<Users className="w-3.5 h-3.5 flex-shrink-0 text-muted-foreground opacity-50" />}
+                        onClick={() => handleUnassignedClick(org.id)}
+                      />
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
+  // --------------------------------------------------------------------------
+  // Render — RIGHT panel
+  // --------------------------------------------------------------------------
+
+  function renderRightPanel() {
+    const panelTitle = selectedNode
+      ? selectedNode.kind === "organization"
+        ? initialOrganizations.find((o) => o.id === selectedNode.id)?.name ?? "Organization"
+        : selectedNode.kind === "team"
+        ? selectedNode.name
+        : "Not associated with any team"
+      : null;
+
+    return (
+      <div className="flex-1 overflow-y-auto">
+        <div className="flex items-center justify-between px-6 py-3 border-b border-border">
+          <h2 className="text-sm font-semibold text-foreground uppercase tracking-wide">
+            {panelTitle ? `Members — ${panelTitle}` : "Members"}
+          </h2>
+          <button
+            type="button"
+            disabled
+            title="Add Member (coming soon)"
+            className="p-1 rounded-md text-muted-foreground opacity-40 cursor-not-allowed"
+            aria-label="Add Member (coming soon)"
+          >
+            <UserPlus className="w-4 h-4" />
+          </button>
+        </div>
+
+        {!selectedNode && (
+          <div className="flex items-center justify-center h-48">
+            <p className="text-sm text-muted-foreground">
+              Select a company or team to view its members.
+            </p>
+          </div>
+        )}
+
+        {selectedNode && loadingMembers && (
+          <div className="flex items-center justify-center h-48">
+            <p className="text-sm text-muted-foreground">Loading members…</p>
+          </div>
+        )}
+
+        {selectedNode && !loadingMembers && members.length === 0 && (
+          <div className="flex items-center justify-center h-48">
+            <p className="text-sm text-muted-foreground">No members found.</p>
+          </div>
+        )}
+
+        {selectedNode && !loadingMembers && members.length > 0 && (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-border bg-muted/40">
+                  <th className="px-6 py-2.5 text-left font-medium text-muted-foreground">Name</th>
+                  <th className="px-6 py-2.5 text-left font-medium text-muted-foreground">Email</th>
+                  <th className="px-6 py-2.5 text-left font-medium text-muted-foreground">Level</th>
+                </tr>
+              </thead>
+              <tbody>
+                {members.map((m) => (
+                  <tr
+                    key={m.id}
+                    className="border-b border-border hover:bg-muted/20 transition-colors"
+                    data-testid={`member-row-${m.id}`}
+                  >
+                    <td className="px-6 py-3 text-foreground font-medium">
+                      {m.firstName} {m.lastName}
+                    </td>
+                    <td className="px-6 py-3 text-muted-foreground">{m.email}</td>
+                    <td className="px-6 py-3 text-muted-foreground">
+                      {m.roleType ?? "—"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // --------------------------------------------------------------------------
+  // Root render
+  // --------------------------------------------------------------------------
+
+  return (
+    <div className="flex h-full min-h-[500px] rounded-xl border border-border bg-card overflow-hidden">
+      {renderLeftPanel()}
+      {renderRightPanel()}
+    </div>
+  );
+}

--- a/src/src/components/organizations/members-teams-view.tsx
+++ b/src/src/components/organizations/members-teams-view.tsx
@@ -12,7 +12,7 @@
  *   GET /api/organizations/[id]/respondents?teamId=<id>
  */
 
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useRef } from "react";
 import { ChevronRight, ChevronDown, Building2, Users, UserPlus, FolderPlus } from "lucide-react";
 
 // ---------------------------------------------------------------------------
@@ -74,6 +74,7 @@ interface OrgState {
   expanded: boolean;
   teams: ApiTeamNode[] | null; // null = not yet loaded
   loadingTeams: boolean;
+  teamsError: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -150,7 +151,7 @@ export function MembersTeamsView({ initialOrganizations }: MembersTeamsViewProps
   const [orgStates, setOrgStates] = useState<Record<string, OrgState>>(() => {
     const init: Record<string, OrgState> = {};
     for (const org of initialOrganizations) {
-      init[org.id] = { expanded: false, teams: null, loadingTeams: false };
+      init[org.id] = { expanded: false, teams: null, loadingTeams: false, teamsError: false };
     }
     return init;
   });
@@ -161,38 +162,65 @@ export function MembersTeamsView({ initialOrganizations }: MembersTeamsViewProps
   // Members for the currently selected node
   const [members, setMembers] = useState<ApiRespondent[]>([]);
   const [loadingMembers, setLoadingMembers] = useState(false);
+  const [membersError, setMembersError] = useState(false);
+
+  // Sequence counters for request-ordering guards (prevent stale responses overwriting newer ones)
+  const memberSeqRef = useRef(0);
+  // Per-org team sequence counters: orgId → latest seq number
+  const teamSeqRef = useRef<Record<string, number>>({});
 
   // --------------------------------------------------------------------------
   // Fetch helpers
   // --------------------------------------------------------------------------
 
   const loadTeams = useCallback(async (orgId: string) => {
+    // Increment per-org sequence; capture this call's seq
+    const prevSeq = teamSeqRef.current[orgId] ?? 0;
+    const mySeq = prevSeq + 1;
+    teamSeqRef.current = { ...teamSeqRef.current, [orgId]: mySeq };
+
     setOrgStates((prev) => ({
       ...prev,
-      [orgId]: { ...prev[orgId], loadingTeams: true },
+      [orgId]: { ...prev[orgId], loadingTeams: true, teamsError: false },
     }));
     try {
       const res = await fetch(`/api/organizations/${orgId}/teams`);
       const json = await res.json();
+      // Bail if a newer call has started for this org
+      if (teamSeqRef.current[orgId] !== mySeq) return;
+      if (!res.ok || !json.success) {
+        setOrgStates((prev) => ({
+          ...prev,
+          [orgId]: { ...prev[orgId], teams: null, loadingTeams: false, teamsError: true },
+        }));
+        return;
+      }
       setOrgStates((prev) => ({
         ...prev,
         [orgId]: {
           ...prev[orgId],
-          teams: json.success ? (json.data as ApiTeamNode[]) : [],
+          teams: json.data as ApiTeamNode[],
           loadingTeams: false,
+          teamsError: false,
         },
       }));
     } catch {
+      if (teamSeqRef.current[orgId] !== mySeq) return;
       setOrgStates((prev) => ({
         ...prev,
-        [orgId]: { ...prev[orgId], teams: [], loadingTeams: false },
+        [orgId]: { ...prev[orgId], teams: null, loadingTeams: false, teamsError: true },
       }));
     }
   }, []);
 
   const loadMembers = useCallback(async (node: TreeNode) => {
+    // Increment sequence; capture this call's seq
+    const mySeq = memberSeqRef.current + 1;
+    memberSeqRef.current = mySeq;
+
     setLoadingMembers(true);
     setMembers([]);
+    setMembersError(false);
     try {
       let url: string;
       if (node.kind === "organization") {
@@ -205,18 +233,26 @@ export function MembersTeamsView({ initialOrganizations }: MembersTeamsViewProps
       }
       const res = await fetch(url);
       const json = await res.json();
-      if (json.success) {
-        let data = json.data as ApiRespondent[];
-        // For the unassigned bucket, filter to only unteamed respondents
-        if (node.kind === "unassigned") {
-          data = data.filter((r) => r.teamId === null);
-        }
-        setMembers(data);
+      // Bail if a newer call has started
+      if (memberSeqRef.current !== mySeq) return;
+      if (!res.ok || !json.success) {
+        setMembersError(true);
+        return;
       }
+      let data = json.data as ApiRespondent[];
+      // For the unassigned bucket, filter to only unteamed respondents
+      if (node.kind === "unassigned") {
+        data = data.filter((r) => r.teamId === null);
+      }
+      setMembers(data);
     } catch {
-      setMembers([]);
+      if (memberSeqRef.current !== mySeq) return;
+      setMembersError(true);
     } finally {
-      setLoadingMembers(false);
+      // Only clear loading if this call is still the latest
+      if (memberSeqRef.current === mySeq) {
+        setLoadingMembers(false);
+      }
     }
   }, []);
 
@@ -338,6 +374,19 @@ export function MembersTeamsView({ initialOrganizations }: MembersTeamsViewProps
                       <p className="pl-8 py-1 text-xs text-muted-foreground">Loading…</p>
                     )}
 
+                    {!state.loadingTeams && state.teamsError && (
+                      <div className="pl-8 py-1 flex items-center gap-2">
+                        <p className="text-xs text-destructive" role="alert">Failed to load teams.</p>
+                        <button
+                          type="button"
+                          onClick={() => loadTeams(org.id)}
+                          className="text-xs text-primary underline hover:no-underline"
+                        >
+                          Retry
+                        </button>
+                      </div>
+                    )}
+
                     {/* Nested team tree */}
                     {state.teams &&
                       flattenTree(state.teams, org.id, 1).map(({ node: tn, depth }) => {
@@ -425,13 +474,26 @@ export function MembersTeamsView({ initialOrganizations }: MembersTeamsViewProps
           </div>
         )}
 
-        {selectedNode && !loadingMembers && members.length === 0 && (
+        {selectedNode && !loadingMembers && membersError && (
+          <div className="flex flex-col items-center justify-center h-48 gap-2">
+            <p className="text-sm text-destructive" role="alert">Failed to load members.</p>
+            <button
+              type="button"
+              onClick={() => loadMembers(selectedNode)}
+              className="text-sm text-primary underline hover:no-underline"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+
+        {selectedNode && !loadingMembers && !membersError && members.length === 0 && (
           <div className="flex items-center justify-center h-48">
             <p className="text-sm text-muted-foreground">No members found.</p>
           </div>
         )}
 
-        {selectedNode && !loadingMembers && members.length > 0 && (
+        {selectedNode && !loadingMembers && !membersError && members.length > 0 && (
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>

--- a/src/src/components/organizations/members-teams-view.tsx
+++ b/src/src/components/organizations/members-teams-view.tsx
@@ -14,6 +14,8 @@
 
 import React, { useState, useCallback, useRef } from "react";
 import { ChevronRight, ChevronDown, Building2, Users, UserPlus, FolderPlus } from "lucide-react";
+import { AddTeamModal } from "./add-team-modal";
+import type { CreatedResult } from "./add-team-modal";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -147,6 +149,9 @@ function NodeButton({
 // ---------------------------------------------------------------------------
 
 export function MembersTeamsView({ initialOrganizations }: MembersTeamsViewProps) {
+  // Companies list — may grow when a new Company is created via the modal
+  const [organizations, setOrganizations] = useState<OrgSummary[]>(initialOrganizations);
+
   // Per-org expansion + team data state
   const [orgStates, setOrgStates] = useState<Record<string, OrgState>>(() => {
     const init: Record<string, OrgState> = {};
@@ -155,6 +160,9 @@ export function MembersTeamsView({ initialOrganizations }: MembersTeamsViewProps
     }
     return init;
   });
+
+  // Add Team modal state
+  const [addTeamOpen, setAddTeamOpen] = useState(false);
 
   // Selected node drives the right panel
   const [selectedNode, setSelectedNode] = useState<TreeNode | null>(null);
@@ -309,6 +317,38 @@ export function MembersTeamsView({ initialOrganizations }: MembersTeamsViewProps
   );
 
   // --------------------------------------------------------------------------
+  // AddTeamModal callback
+  // --------------------------------------------------------------------------
+
+  const handleCreated = useCallback(
+    async (result: CreatedResult) => {
+      if (result.kind === "organization") {
+        // Add the new company to the local list + bootstrap its org state
+        setOrganizations((prev) => [result.org, ...prev]);
+        setOrgStates((prev) => ({
+          ...prev,
+          [result.org.id]: { expanded: false, teams: null, loadingTeams: false, teamsError: false },
+        }));
+      } else {
+        // Refresh the team tree for the affected org so the new team appears
+        await loadTeams(result.orgId);
+      }
+    },
+    [loadTeams]
+  );
+
+  // Build the loadedTeams map the modal needs for its Parent select
+  const loadedTeamsForModal: Record<string, ApiTeamNode[]> = {};
+  for (const org of organizations) {
+    const state = orgStates[org.id];
+    if (state?.teams) {
+      loadedTeamsForModal[org.id] = state.teams;
+    } else {
+      loadedTeamsForModal[org.id] = [];
+    }
+  }
+
+  // --------------------------------------------------------------------------
   // Render — LEFT panel
   // --------------------------------------------------------------------------
 
@@ -321,23 +361,23 @@ export function MembersTeamsView({ initialOrganizations }: MembersTeamsViewProps
           </h2>
           <button
             type="button"
-            disabled
-            title="Add Team (coming soon)"
-            className="p-1 rounded-md text-muted-foreground opacity-40 cursor-not-allowed"
-            aria-label="Add Team (coming soon)"
+            onClick={() => setAddTeamOpen(true)}
+            title="Add Company or Team"
+            className="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+            aria-label="Add Company or Team"
           >
             <FolderPlus className="w-4 h-4" />
           </button>
         </div>
 
-        {initialOrganizations.length === 0 && (
+        {organizations.length === 0 && (
           <p className="px-4 py-6 text-sm text-muted-foreground">
             No companies yet. Create one to get started.
           </p>
         )}
 
         <div className="p-2 space-y-0.5">
-          {initialOrganizations.map((org) => {
+          {organizations.map((org) => {
             const state = orgStates[org.id];
             const orgNode: TreeNode = { kind: "organization", id: org.id, name: org.name };
             const isSelected = isSameNode(selectedNode, orgNode);
@@ -437,7 +477,7 @@ export function MembersTeamsView({ initialOrganizations }: MembersTeamsViewProps
   function renderRightPanel() {
     const panelTitle = selectedNode
       ? selectedNode.kind === "organization"
-        ? initialOrganizations.find((o) => o.id === selectedNode.id)?.name ?? "Organization"
+        ? organizations.find((o) => o.id === selectedNode.id)?.name ?? "Organization"
         : selectedNode.kind === "team"
         ? selectedNode.name
         : "Not associated with any team"
@@ -532,9 +572,19 @@ export function MembersTeamsView({ initialOrganizations }: MembersTeamsViewProps
   // --------------------------------------------------------------------------
 
   return (
-    <div className="flex h-full min-h-[500px] rounded-xl border border-border bg-card overflow-hidden">
-      {renderLeftPanel()}
-      {renderRightPanel()}
-    </div>
+    <>
+      <div className="flex h-full min-h-[500px] rounded-xl border border-border bg-card overflow-hidden">
+        {renderLeftPanel()}
+        {renderRightPanel()}
+      </div>
+
+      <AddTeamModal
+        open={addTeamOpen}
+        onClose={() => setAddTeamOpen(false)}
+        onCreated={handleCreated}
+        organizations={organizations}
+        loadedTeams={loadedTeamsForModal}
+      />
+    </>
   );
 }

--- a/src/src/lib/validations.ts
+++ b/src/src/lib/validations.ts
@@ -511,10 +511,12 @@ export const createAssessmentCampaignSchema = z
         // Task O — per-campaign invitation email overrides (null = fall back to template defaults)
         invitationSubject: z.string().max(200).transform(_trim).optional().nullable(),
         invitationBodyMarkdown: z.string().max(5000).transform(_trim).optional().nullable(),
-        // Task M — optional bulk-respondent payload from the wizard CSV
-        // import. Server resolves teamPath to OrgTeam rows (creating any
-        // missing teams), and creates OrgRespondent rows with skip-on-conflict
-        // semantics so the wizard can retry idempotently.
+        // deprecated: Task M optional bulk-respondent payload from the wizard
+        // CSV import. The setup-first flip (Slice 1) stopped the wizard from
+        // sending this — coaches now pick EXISTING members. Kept optional and
+        // functional for backward-compat with older drafts/clients. Server
+        // resolves teamPath to OrgTeam rows (creating any missing teams), and
+        // creates OrgRespondent rows with skip-on-conflict semantics.
         bulkRespondents: z
             .array(
                 z.object({


### PR DESCRIPTION
## Summary
- New `/portal/members` Members & Teams lane: coaches now set up **Company → Team → Users** *first* (hierarchical tree, Add Team dual-create with guards, Add Member, sidebar repoint).
- Campaign wizard flipped to **pick existing** company + members (no inline-create, no bulk-CSV); `saveCampaign` drops `bulkRespondents` (server helper kept for BC — older drafts still work).
- CampaignDetail Add Respondent → **add-existing only**, excludes current participants.
- SDD/Codex review caught a **Critical cross-company stale-selection bug** (would've created orphaned campaigns) and several Important issues — all fixed before merge.
- Roadmap reconciliation: new canonical spec `docs/specs/v7.6/08-members-teams-lane.md`; PLAN.md ledger + status updated.

## Test plan
- [x] **114/114** organizations + wizard + detail + sidebar suites pass
- [x] **Full suite: 2038 passing, 3 failing** — all 3 are pre-existing (no-inline-tolocaledatestring / org-survey-exchange / assessment-campaigns/detail-route), files this branch never touched
- [x] `CI=true npx next build --turbopack` clean against the new safety-gated build pipeline (1b797bb)
- [x] Browser smoke on Vercel preview as a coach: company / team / member create, wizard pick-existing end-to-end, CampaignDetail add-existing, and a **legacy May 22 campaign still renders + functions** (no data displacement)
- [x] Zero migrations; zero destructive ops — no wipe vector

🤖 Generated with [Claude Code](https://claude.com/claude-code)