### PR TITLE
feat(assessment): Slice 3 — Levels + CEO-from-Level suggestion

### DIFF
--- a/src/src/__tests__/api/organizations/respondents.test.ts
+++ b/src/src/__tests__/api/organizations/respondents.test.ts
@@ -300,6 +300,78 @@ describe("POST /api/organizations/[id]/respondents", () => {
     const body = await res.json();
     expect(body.existingId).toBe("existing-r");
   });
+
+  // C1 — roleType must be forwarded to Prisma create
+  it("C1: persists roleType to Prisma create data when provided", async () => {
+    (getApiActor as jest.Mock).mockResolvedValue(coachActor);
+    (canAccessOrganization as jest.Mock).mockResolvedValue(true);
+    (db.orgRespondent.create as jest.Mock).mockResolvedValue({
+      id: "r-level",
+      organizationId: "o1",
+      email: "carol@example.com",
+      normalizedEmail: "carol@example.com",
+      firstName: "Carol",
+      lastName: "Doe",
+      roleType: "employee",
+      dedupeSource: "email",
+      dedupeValue: "carol@example.com",
+    });
+
+    const res = await listPost(
+      jsonReq({
+        email: "carol@example.com",
+        firstName: "Carol",
+        lastName: "Doe",
+        roleType: "employee",
+      }) as never,
+      listParams("o1")
+    );
+
+    expect(res.status).toBe(201);
+    // The critical assertion: roleType must be in the data passed to Prisma
+    expect(db.orgRespondent.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          roleType: "employee",
+        }),
+      })
+    );
+  });
+
+  // C1 — null roleType (omitted in body) must be stored as null, not skipped
+  it("C1: persists roleType: null to Prisma when not provided", async () => {
+    (getApiActor as jest.Mock).mockResolvedValue(coachActor);
+    (canAccessOrganization as jest.Mock).mockResolvedValue(true);
+    (db.orgRespondent.create as jest.Mock).mockResolvedValue({
+      id: "r-nolevel",
+      organizationId: "o1",
+      email: "dave@example.com",
+      normalizedEmail: "dave@example.com",
+      firstName: "Dave",
+      lastName: "Kim",
+      roleType: null,
+      dedupeSource: "email",
+      dedupeValue: "dave@example.com",
+    });
+
+    await listPost(
+      jsonReq({
+        email: "dave@example.com",
+        firstName: "Dave",
+        lastName: "Kim",
+        // no roleType
+      }) as never,
+      listParams("o1")
+    );
+
+    expect(db.orgRespondent.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          roleType: null,
+        }),
+      })
+    );
+  });
 });
 
 describe("PATCH /api/organizations/[id]/respondents/[respondentId]", () => {
@@ -378,6 +450,86 @@ describe("PATCH /api/organizations/[id]/respondents/[respondentId]", () => {
         data: expect.objectContaining({ lastName: "Updated" }),
       })
     );
+  });
+
+  // C1 — roleType must be forwarded to Prisma update data
+  it("C1: persists roleType to Prisma update data when provided", async () => {
+    (getApiActor as jest.Mock).mockResolvedValue(coachActor);
+    (canAccessOrganization as jest.Mock).mockResolvedValue(true);
+    (db.orgRespondent.findUnique as jest.Mock).mockResolvedValue({
+      id: "r1",
+      organizationId: "o1",
+      deletedAt: null,
+    });
+    (db.orgRespondent.update as jest.Mock).mockResolvedValue({
+      id: "r1",
+      roleType: "ceofounder",
+    });
+
+    const res = await detailPatch(
+      jsonReq({ roleType: "ceofounder" }, "PATCH") as never,
+      detailParams("o1", "r1")
+    );
+
+    expect(res.status).toBe(200);
+    // The critical assertion: roleType must be in the data arg, not dropped
+    expect(db.orgRespondent.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "r1" },
+        data: expect.objectContaining({ roleType: "ceofounder" }),
+      })
+    );
+  });
+
+  // C1 — null roleType must clear the field (not skip the write)
+  it("C1: persists roleType: null to Prisma to clear the field", async () => {
+    (getApiActor as jest.Mock).mockResolvedValue(coachActor);
+    (canAccessOrganization as jest.Mock).mockResolvedValue(true);
+    (db.orgRespondent.findUnique as jest.Mock).mockResolvedValue({
+      id: "r1",
+      organizationId: "o1",
+      deletedAt: null,
+    });
+    (db.orgRespondent.update as jest.Mock).mockResolvedValue({
+      id: "r1",
+      roleType: null,
+    });
+
+    const res = await detailPatch(
+      jsonReq({ roleType: null }, "PATCH") as never,
+      detailParams("o1", "r1")
+    );
+
+    expect(res.status).toBe(200);
+    expect(db.orgRespondent.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "r1" },
+        data: expect.objectContaining({ roleType: null }),
+      })
+    );
+  });
+
+  // C1 — when roleType is absent from body, it must NOT appear in update data
+  it("C1: omits roleType from Prisma update data when not in body", async () => {
+    (getApiActor as jest.Mock).mockResolvedValue(coachActor);
+    (canAccessOrganization as jest.Mock).mockResolvedValue(true);
+    (db.orgRespondent.findUnique as jest.Mock).mockResolvedValue({
+      id: "r1",
+      organizationId: "o1",
+      deletedAt: null,
+    });
+    (db.orgRespondent.update as jest.Mock).mockResolvedValue({
+      id: "r1",
+      lastName: "Updated",
+    });
+
+    await detailPatch(
+      jsonReq({ lastName: "Updated" }, "PATCH") as never,
+      detailParams("o1", "r1")
+    );
+
+    const updateCall = (db.orgRespondent.update as jest.Mock).mock.calls[0][0];
+    expect(updateCall.data).not.toHaveProperty("roleType");
   });
 });
 

--- a/src/src/__tests__/components/assessments/campaign-wizard-pick-existing.test.tsx
+++ b/src/src/__tests__/components/assessments/campaign-wizard-pick-existing.test.tsx
@@ -50,6 +50,7 @@ const ALICE = {
   jobTitle: "CEO",
   teamId: "team-eng",
   organizationId: "org-1",
+  roleType: null as string | null,
 };
 const BOB = {
   id: "resp-2",
@@ -59,6 +60,7 @@ const BOB = {
   jobTitle: null,
   teamId: null,
   organizationId: "org-1",
+  roleType: null as string | null,
 };
 
 // ---------------------------------------------------------------------------
@@ -170,6 +172,7 @@ const CAROL = {
   jobTitle: null,
   teamId: "team-sales-b",
   organizationId: "org-2",
+  roleType: null as string | null,
 };
 
 /**
@@ -491,6 +494,234 @@ describe("CampaignWizard — C1 cross-company selection reset", () => {
       name: /alice smith/i,
     });
     expect(aliceAgain).toBeChecked();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CEO-from-Level suggestion (decision #5)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a fetch installer for the CEO-Level tests. The respondents returned by
+ * /api/organizations/org-1/respondents are customisable per test via
+ * `respondents`.
+ */
+function installCEOLevelFetch(respondents: typeof ALICE[]) {
+  fetchCalls = [];
+  global.fetch = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : String(input);
+    const method = (init?.method ?? "GET").toUpperCase();
+    let body: unknown = undefined;
+    if (init?.body && typeof init.body === "string") {
+      try { body = JSON.parse(init.body); } catch { body = init.body; }
+    }
+    fetchCalls.push({ url, method, body });
+
+    if (url.includes("/api/assessment-campaign-drafts")) {
+      if (method === "GET") return jsonResponse({ success: true, data: null });
+      return jsonResponse({ success: true });
+    }
+    if (url.endsWith("/api/organizations") && method === "GET") {
+      return jsonResponse({ success: true, data: [ORG] });
+    }
+    if (url.match(/\/api\/organizations\/org-1$/) && method === "GET") {
+      return jsonResponse({ success: true, data: ORG });
+    }
+    if (url.endsWith("/api/assessment-templates") && method === "GET") {
+      return jsonResponse({ success: true, data: [TEMPLATE] });
+    }
+    if (url.includes("/api/organizations/org-1/teams") && method === "GET") {
+      return jsonResponse({ success: true, data: [TEAM_ENG] });
+    }
+    if (url.includes("/api/organizations/org-1/respondents") && method === "GET") {
+      return jsonResponse({ success: true, data: respondents });
+    }
+    if (url.endsWith("/api/assessment-campaigns") && method === "POST") {
+      return jsonResponse({ success: true, data: { id: "camp-1" } });
+    }
+    if (url.includes("/api/assessment-campaigns/camp-1/participants")) {
+      return jsonResponse({ success: true, data: { added: 1 } });
+    }
+    if (url.includes("/api/assessment-campaigns/camp-1/activate")) {
+      return jsonResponse({ success: true, data: { status: "ACTIVE" } });
+    }
+    return jsonResponse({ success: false, error: "unhandled" }, false);
+  }) as unknown as typeof fetch;
+}
+
+/** Navigate the wizard from Step 0 → Step 2 (Participants). */
+async function advanceToParticipantsCEO() {
+  const orgRadio = await screen.findByRole("radio", { name: /acme corp/i });
+  fireEvent.click(orgRadio);
+  fireEvent.click(screen.getByRole("button", { name: /next/i }));
+
+  const tplRadio = await screen.findByRole("radio", { name: /rockefeller habits/i });
+  fireEvent.click(tplRadio);
+  fireEvent.click(screen.getByRole("button", { name: /next/i }));
+}
+
+describe("CampaignWizard — CEO-from-Level suggestion", () => {
+  it("L1: one CEO/Founder-Level member selected → auto-suggests as CEO", async () => {
+    const respondents = [
+      { ...ALICE, id: "resp-1", firstName: "Alice", lastName: "Smith", roleType: "ceofounder", teamId: "team-eng" },
+      { ...BOB,   id: "resp-2", firstName: "Bob",   lastName: "Jones", roleType: "employee",   teamId: null },
+    ];
+    installCEOLevelFetch(respondents);
+    render(<CampaignWizard />);
+    await advanceToParticipantsCEO();
+
+    // Check Alice — she has ceofounder roleType.
+    const aliceCheckbox = await screen.findByRole("checkbox", { name: /alice smith/i });
+    fireEvent.click(aliceCheckbox);
+
+    // Alice's CEO radio should be auto-selected.
+    await waitFor(() => {
+      const aliceCeoRadio = screen.getByRole("radio", { name: /mark alice smith as ceo/i });
+      expect(aliceCeoRadio).toBeChecked();
+    });
+
+    // "Suggested by Level" hint visible near Alice's row.
+    expect(screen.getByText(/suggested by level/i)).toBeInTheDocument();
+
+    // Bob's CEO radio is NOT checked and has no hint.
+    const bobCeoRadio = screen.getByRole("radio", { name: /mark bob jones as ceo/i });
+    expect(bobCeoRadio).not.toBeChecked();
+  });
+
+  it("L2: two CEO-Level members selected → no auto-suggest, no hint", async () => {
+    const respondents = [
+      { ...ALICE, id: "resp-1", firstName: "Alice", lastName: "Smith", roleType: "ceofounder",         teamId: "team-eng" },
+      { ...BOB,   id: "resp-2", firstName: "Bob",   lastName: "Jones", roleType: "ceofounderwithteam", teamId: null },
+      { id: "resp-3", firstName: "Carol", lastName: "C", email: "carol@acme.com", jobTitle: null, teamId: null, organizationId: "org-1", roleType: "employee" },
+    ];
+    installCEOLevelFetch(respondents);
+    render(<CampaignWizard />);
+    await advanceToParticipantsCEO();
+
+    // Select both CEO-Level members.
+    const aliceCheckbox = await screen.findByRole("checkbox", { name: /alice smith/i });
+    const bobCheckbox = screen.getByRole("checkbox", { name: /bob jones/i });
+    fireEvent.click(aliceCheckbox);
+    fireEvent.click(bobCheckbox);
+
+    // Neither CEO radio should be selected.
+    await waitFor(() => {
+      const aliceCeo = screen.getByRole("radio", { name: /mark alice smith as ceo/i });
+      const bobCeo   = screen.getByRole("radio", { name: /mark bob jones as ceo/i });
+      expect(aliceCeo).not.toBeChecked();
+      expect(bobCeo).not.toBeChecked();
+    });
+
+    // No "Suggested by Level" hint anywhere.
+    expect(screen.queryByText(/suggested by level/i)).not.toBeInTheDocument();
+  });
+
+  it("L3: user clicks a non-CEO-Level member as CEO → manual pick wins, hint gone", async () => {
+    const respondents = [
+      { ...ALICE, id: "resp-1", firstName: "Alice", lastName: "Smith", roleType: "ceofounder", teamId: "team-eng" },
+      { ...BOB,   id: "resp-2", firstName: "Bob",   lastName: "Jones", roleType: "employee",   teamId: null },
+    ];
+    installCEOLevelFetch(respondents);
+    render(<CampaignWizard />);
+    await advanceToParticipantsCEO();
+
+    // Check Alice → auto-suggest should fire.
+    const aliceCheckbox = await screen.findByRole("checkbox", { name: /alice smith/i });
+    fireEvent.click(aliceCheckbox);
+    await waitFor(() => {
+      expect(screen.getByRole("radio", { name: /mark alice smith as ceo/i })).toBeChecked();
+    });
+    expect(screen.getByText(/suggested by level/i)).toBeInTheDocument();
+
+    // Check Bob too so his CEO radio is accessible.
+    const bobCheckbox = screen.getByRole("checkbox", { name: /bob jones/i });
+    fireEvent.click(bobCheckbox);
+
+    // User manually picks Bob as CEO.
+    const bobCeoRadio = screen.getByRole("radio", { name: /mark bob jones as ceo/i });
+    fireEvent.click(bobCeoRadio);
+
+    // Bob should now be CEO and the hint should be gone.
+    await waitFor(() => {
+      expect(screen.getByRole("radio", { name: /mark bob jones as ceo/i })).toBeChecked();
+      expect(screen.getByRole("radio", { name: /mark alice smith as ceo/i })).not.toBeChecked();
+    });
+    expect(screen.queryByText(/suggested by level/i)).not.toBeInTheDocument();
+  });
+
+  it("L4: unchecking the auto-suggested CEO member clears CEO", async () => {
+    const respondents = [
+      { ...ALICE, id: "resp-1", firstName: "Alice", lastName: "Smith", roleType: "ceofounder", teamId: "team-eng" },
+      { ...BOB,   id: "resp-2", firstName: "Bob",   lastName: "Jones", roleType: "employee",   teamId: null },
+    ];
+    installCEOLevelFetch(respondents);
+    render(<CampaignWizard />);
+    await advanceToParticipantsCEO();
+
+    // Check Alice → auto-suggest fires.
+    const aliceCheckbox = await screen.findByRole("checkbox", { name: /alice smith/i });
+    fireEvent.click(aliceCheckbox);
+    await waitFor(() => {
+      expect(screen.getByRole("radio", { name: /mark alice smith as ceo/i })).toBeChecked();
+    });
+
+    // Uncheck Alice.
+    fireEvent.click(aliceCheckbox);
+
+    // CEO radio for Alice should no longer be checked.
+    await waitFor(() => {
+      const aliceCeoRadio = screen.getByRole("radio", { name: /mark alice smith as ceo/i });
+      expect(aliceCeoRadio).not.toBeChecked();
+    });
+    // Hint also gone.
+    expect(screen.queryByText(/suggested by level/i)).not.toBeInTheDocument();
+  });
+
+  it("L5: |C| > 1 → remove one → auto-suggest resumes for the remaining CEO-Level member", async () => {
+    const respondents = [
+      { ...ALICE, id: "resp-1", firstName: "Alice", lastName: "Smith", roleType: "ceofounder",         teamId: "team-eng" },
+      { ...BOB,   id: "resp-2", firstName: "Bob",   lastName: "Jones", roleType: "ceofounderalone",    teamId: null },
+    ];
+    installCEOLevelFetch(respondents);
+    render(<CampaignWizard />);
+    await advanceToParticipantsCEO();
+
+    // Select both — |C| = 2 → no auto-suggest.
+    const aliceCheckbox = await screen.findByRole("checkbox", { name: /alice smith/i });
+    const bobCheckbox = screen.getByRole("checkbox", { name: /bob jones/i });
+    fireEvent.click(aliceCheckbox);
+    fireEvent.click(bobCheckbox);
+
+    await waitFor(() => {
+      expect(screen.queryByText(/suggested by level/i)).not.toBeInTheDocument();
+    });
+
+    // Uncheck Bob → |C| = 1 → auto-suggest Alice.
+    fireEvent.click(bobCheckbox);
+    await waitFor(() => {
+      expect(screen.getByRole("radio", { name: /mark alice smith as ceo/i })).toBeChecked();
+      expect(screen.getByText(/suggested by level/i)).toBeInTheDocument();
+    });
+  });
+
+  it("L6: null roleType members are never auto-suggested", async () => {
+    const respondents = [
+      { ...ALICE, id: "resp-1", firstName: "Alice", lastName: "Smith", roleType: null,     teamId: "team-eng" },
+      { ...BOB,   id: "resp-2", firstName: "Bob",   lastName: "Jones", roleType: null,     teamId: null },
+    ];
+    installCEOLevelFetch(respondents);
+    render(<CampaignWizard />);
+    await advanceToParticipantsCEO();
+
+    // Select Alice.
+    const aliceCheckbox = await screen.findByRole("checkbox", { name: /alice smith/i });
+    fireEvent.click(aliceCheckbox);
+
+    // No CEO radio selected, no hint.
+    await waitFor(() => {
+      expect(screen.getByRole("radio", { name: /mark alice smith as ceo/i })).not.toBeChecked();
+    });
+    expect(screen.queryByText(/suggested by level/i)).not.toBeInTheDocument();
   });
 });
 

--- a/src/src/__tests__/components/organizations/add-member-modal.test.tsx
+++ b/src/src/__tests__/components/organizations/add-member-modal.test.tsx
@@ -325,6 +325,138 @@ describe("AddMemberModal", () => {
   });
 
   /**
+   * (7b) Level select renders all 6 options in spec order
+   */
+  test("(7b) Level select renders all 6 options in spec order", () => {
+    renderModal();
+
+    const levelSelect = screen.getByTestId("select-level") as HTMLSelectElement;
+    // 7 options: "— no level —" + 6 levels
+    expect(levelSelect.options).toHaveLength(7);
+
+    // Verify the placeholder
+    expect(levelSelect.options[0].value).toBe("");
+    expect(levelSelect.options[0].text).toMatch(/no level/i);
+
+    // Verify each level option in order
+    expect(levelSelect.options[1].value).toBe("teamleader");
+    expect(levelSelect.options[1].text).toBe("Leadership team member");
+
+    expect(levelSelect.options[2].value).toBe("employee");
+    expect(levelSelect.options[2].text).toBe("Employee");
+
+    expect(levelSelect.options[3].value).toBe("guest");
+    expect(levelSelect.options[3].text).toBe("Guest");
+
+    expect(levelSelect.options[4].value).toBe("ceofounderwithteam");
+    expect(levelSelect.options[4].text).toBe("CEO/Founder with team");
+
+    expect(levelSelect.options[5].value).toBe("ceofounderalone");
+    expect(levelSelect.options[5].text).toBe("CEO/Founder alone");
+
+    expect(levelSelect.options[6].value).toBe("ceofounder");
+    expect(levelSelect.options[6].text).toBe("CEO/Founder");
+  });
+
+  /**
+   * (7c) Selecting Level=teamleader → POST body includes roleType: "teamleader"
+   */
+  test("(7c) selecting Level=teamleader includes roleType in POST body", async () => {
+    const mockRespondent = {
+      id: "r-level",
+      organizationId: ORG_ID,
+      firstName: "Eve",
+      lastName: "Taylor",
+      email: "eve@example.com",
+      roleType: "teamleader",
+      teamId: null,
+    };
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({ success: true, data: mockRespondent }),
+    });
+
+    renderModal();
+
+    fireEvent.change(screen.getByLabelText(/first name/i), {
+      target: { value: "Eve" },
+    });
+    fireEvent.change(screen.getByLabelText(/last name/i), {
+      target: { value: "Taylor" },
+    });
+    fireEvent.change(screen.getByLabelText(/e-?mail/i), {
+      target: { value: "eve@example.com" },
+    });
+    fireEvent.change(screen.getByTestId("select-level"), {
+      target: { value: "teamleader" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /add member/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    const body = JSON.parse(init.body as string);
+    expect(body.roleType).toBe("teamleader");
+  });
+
+  /**
+   * (7d) "— no level —" → roleType is OMITTED from the POST body
+   */
+  test("(7d) '— no level —' selection omits roleType from POST body", async () => {
+    const mockRespondent = {
+      id: "r-nolevel",
+      organizationId: ORG_ID,
+      firstName: "Frank",
+      lastName: "Brown",
+      email: "frank@example.com",
+      roleType: null,
+      teamId: null,
+    };
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({ success: true, data: mockRespondent }),
+    });
+
+    renderModal();
+
+    fireEvent.change(screen.getByLabelText(/first name/i), {
+      target: { value: "Frank" },
+    });
+    fireEvent.change(screen.getByLabelText(/last name/i), {
+      target: { value: "Brown" },
+    });
+    fireEvent.change(screen.getByLabelText(/e-?mail/i), {
+      target: { value: "frank@example.com" },
+    });
+    // Explicitly pick "— no level —" (default, but be explicit)
+    fireEvent.change(screen.getByTestId("select-level"), {
+      target: { value: "" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /add member/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    const body = JSON.parse(init.body as string);
+    // roleType must be ABSENT from the body when no level selected
+    expect("roleType" in body).toBe(false);
+  });
+
+  /**
    * (8) When defaultTeamId is null (org node selected, not a team), the Team
    *     select defaults to "— no team —" AND submitting omits teamId from the body
    */

--- a/src/src/__tests__/components/organizations/edit-member-modal.test.tsx
+++ b/src/src/__tests__/components/organizations/edit-member-modal.test.tsx
@@ -52,6 +52,7 @@ const MEMBER = {
   email: "jane.smith@example.com",
   jobTitle: "Director",
   teamId: "team-eng",
+  roleType: null as string | null,
 };
 
 // ---------------------------------------------------------------------------
@@ -182,6 +183,7 @@ describe("EditMemberModal", () => {
       lastName: "Smithson",
       jobTitle: "VP",
       teamId: "team-mkt",
+      roleType: null,
     });
 
     await waitFor(() => {
@@ -249,6 +251,91 @@ describe("EditMemberModal", () => {
 
     expect(onUpdated).not.toHaveBeenCalled();
     expect(onClose).not.toHaveBeenCalled();
+  });
+
+  /**
+   * (7) Opening with roleType: "ceofounder" → select pre-selected to that value.
+   */
+  test("(7) opening with roleType: 'ceofounder' pre-selects that value", () => {
+    renderModal({ member: { ...MEMBER, roleType: "ceofounder" } });
+
+    const levelSelect = screen.getByTestId("select-level") as HTMLSelectElement;
+    expect(levelSelect.value).toBe("ceofounder");
+  });
+
+  /**
+   * (8) Opening with an unknown legacy value → the legacy value appears as an extra option
+   *     AND is the selected value.
+   */
+  test("(8) unknown legacy roleType shows legacy option and is selected", () => {
+    renderModal({ member: { ...MEMBER, roleType: "senior_vp_legacy" } });
+
+    const levelSelect = screen.getByTestId("select-level") as HTMLSelectElement;
+    expect(levelSelect.value).toBe("senior_vp_legacy");
+
+    // The legacy option text must include the raw value
+    const legacyOption = Array.from(levelSelect.options).find(
+      (o) => o.value === "senior_vp_legacy"
+    );
+    expect(legacyOption).toBeDefined();
+    expect(legacyOption!.text).toContain("senior_vp_legacy");
+    expect(legacyOption!.text).toContain("legacy");
+  });
+
+  /**
+   * (9) Changing Level → PATCH body includes the new roleType.
+   */
+  test("(9) changing Level includes new roleType in PATCH body", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, data: { id: "respondent-1" } }),
+    });
+
+    renderModal({ member: { ...MEMBER, roleType: "employee" } });
+
+    fireEvent.change(screen.getByTestId("select-level"), {
+      target: { value: "teamleader" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    const call = (global.fetch as jest.Mock).mock.calls[0];
+    const sentBody = JSON.parse(call[1].body as string);
+    expect(sentBody.roleType).toBe("teamleader");
+  });
+
+  /**
+   * (10) Clearing Level (selecting "— no level —") → PATCH body includes roleType: null.
+   */
+  test("(10) clearing Level sends roleType: null in PATCH body", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, data: { id: "respondent-1" } }),
+    });
+
+    renderModal({ member: { ...MEMBER, roleType: "employee" } });
+
+    // Clear the level by picking "— no level —"
+    fireEvent.change(screen.getByTestId("select-level"), {
+      target: { value: "" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    const call = (global.fetch as jest.Mock).mock.calls[0];
+    const sentBody = JSON.parse(call[1].body as string);
+    // roleType must be explicitly null so the server can unset the field
+    expect(sentBody.roleType).toBeNull();
   });
 
   /**

--- a/src/src/__tests__/components/organizations/edit-member-modal.test.tsx
+++ b/src/src/__tests__/components/organizations/edit-member-modal.test.tsx
@@ -339,6 +339,88 @@ describe("EditMemberModal", () => {
   });
 
   /**
+   * I1(a) — legacy roleType unchanged: PATCH body must NOT include roleType
+   * so the unknown slug never hits the Zod enum gate.
+   */
+  test("I1(a) legacy roleType unchanged — omits roleType from PATCH body", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, data: { id: "respondent-1" } }),
+    });
+
+    renderModal({ member: { ...MEMBER, roleType: "weirdlegacy" } });
+
+    // Do NOT change the level — user opens modal and saves as-is
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    const call = (global.fetch as jest.Mock).mock.calls[0];
+    const sentBody = JSON.parse(call[1].body as string);
+    // roleType must be absent so Zod doesn't reject the unknown slug
+    expect(sentBody).not.toHaveProperty("roleType");
+  });
+
+  /**
+   * I1(b) — legacy roleType changed to known: PATCH body MUST include new roleType.
+   */
+  test("I1(b) legacy roleType changed to known slug — includes new roleType in body", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, data: { id: "respondent-1" } }),
+    });
+
+    renderModal({ member: { ...MEMBER, roleType: "weirdlegacy" } });
+
+    // User explicitly picks a known value
+    fireEvent.change(screen.getByTestId("select-level"), {
+      target: { value: "employee" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    const call = (global.fetch as jest.Mock).mock.calls[0];
+    const sentBody = JSON.parse(call[1].body as string);
+    expect(sentBody.roleType).toBe("employee");
+  });
+
+  /**
+   * I1(c) — legacy roleType explicitly cleared to "— no level —": sends roleType: null.
+   */
+  test("I1(c) legacy roleType cleared to no-level — sends roleType: null", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, data: { id: "respondent-1" } }),
+    });
+
+    renderModal({ member: { ...MEMBER, roleType: "weirdlegacy" } });
+
+    // User picks "— no level —" to explicitly clear
+    fireEvent.change(screen.getByTestId("select-level"), {
+      target: { value: "" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    const call = (global.fetch as jest.Mock).mock.calls[0];
+    const sentBody = JSON.parse(call[1].body as string);
+    expect(sentBody.roleType).toBeNull();
+  });
+
+  /**
    * (6) onUpdated is awaited BEFORE onClose.
    */
   test("(6) onUpdated is awaited before onClose is called", async () => {

--- a/src/src/__tests__/components/organizations/members-teams-view.test.tsx
+++ b/src/src/__tests__/components/organizations/members-teams-view.test.tsx
@@ -405,4 +405,55 @@ describe("MembersTeamsView", () => {
     const nameInput = screen.getByLabelText(/name \*/i) as HTMLInputElement;
     expect(nameInput.value).toBe("Engineering");
   });
+
+  /**
+   * (i) Level column renders human label for a member with a known roleType slug.
+   */
+  test("(i) Level column renders human label for known roleType", async () => {
+    mockFetchForOrg1Teams();
+
+    // Override RESPONDENT_ALICE with a known slug
+    const memberWithLevel = {
+      ...RESPONDENT_ALICE,
+      roleType: "employee",
+    };
+    mockFetchRespondents([memberWithLevel]);
+
+    render(<MembersTeamsView initialOrganizations={[ORG_1]} />);
+
+    // Expand org and load members
+    fireEvent.click(screen.getByRole("button", { name: /^Acme Corp$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Alice Smith")).toBeInTheDocument();
+    });
+
+    // The Level cell must show the human label, NOT the raw slug
+    expect(screen.getByText("Employee")).toBeInTheDocument();
+    // Raw slug must NOT be in the document
+    expect(screen.queryByText("employee")).not.toBeInTheDocument();
+  });
+
+  /**
+   * (j) Level column renders "—" for a member with null roleType.
+   */
+  test("(j) Level column renders '—' for null roleType", async () => {
+    mockFetchForOrg1Teams();
+
+    // RESPONDENT_BOB has roleType: null
+    mockFetchRespondents([RESPONDENT_BOB]);
+
+    render(<MembersTeamsView initialOrganizations={[ORG_1]} />);
+
+    // Expand org and load members
+    fireEvent.click(screen.getByRole("button", { name: /^Acme Corp$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Bob Jones")).toBeInTheDocument();
+    });
+
+    // The Level column must render the em-dash
+    const memberRow = screen.getByTestId("member-row-resp-2");
+    expect(memberRow).toHaveTextContent("—");
+  });
 });

--- a/src/src/__tests__/lib/respondent-levels.test.ts
+++ b/src/src/__tests__/lib/respondent-levels.test.ts
@@ -1,0 +1,154 @@
+/**
+ * TDD Red Phase — respondent-levels tests.
+ *
+ * Test matrix:
+ *  (1) RESPONDENT_LEVELS has exactly 6 entries in spec order with correct values + labels
+ *  (2) RESPONDENT_LEVEL_VALUES is a tuple of the 6 slugs in order
+ *  (3) levelLabel returns "—" for null / undefined / empty string
+ *  (4) levelLabel returns the human label for known slugs
+ *  (5) levelLabel returns the raw value for unknown (legacy) slugs
+ *  (6) isCEOFamily is true for the 3 CEO/Founder slugs, false for the other 3
+ *  (7) isCEOFamily returns false for null / undefined / unknown
+ */
+
+import {
+  RESPONDENT_LEVELS,
+  RESPONDENT_LEVEL_VALUES,
+  levelLabel,
+  isCEOFamily,
+} from "@/lib/assessments/respondent-levels";
+
+describe("RESPONDENT_LEVELS", () => {
+  test("(1) has exactly 6 entries in spec order with correct values and labels", () => {
+    expect(RESPONDENT_LEVELS).toHaveLength(6);
+
+    // Exact order + shapes
+    expect(RESPONDENT_LEVELS[0]).toEqual({
+      value: "teamleader",
+      label: "Leadership team member",
+      isCEOFamily: false,
+    });
+    expect(RESPONDENT_LEVELS[1]).toEqual({
+      value: "employee",
+      label: "Employee",
+      isCEOFamily: false,
+    });
+    expect(RESPONDENT_LEVELS[2]).toEqual({
+      value: "guest",
+      label: "Guest",
+      isCEOFamily: false,
+    });
+    expect(RESPONDENT_LEVELS[3]).toEqual({
+      value: "ceofounderwithteam",
+      label: "CEO/Founder with team",
+      isCEOFamily: true,
+    });
+    expect(RESPONDENT_LEVELS[4]).toEqual({
+      value: "ceofounderalone",
+      label: "CEO/Founder alone",
+      isCEOFamily: true,
+    });
+    expect(RESPONDENT_LEVELS[5]).toEqual({
+      value: "ceofounder",
+      label: "CEO/Founder",
+      isCEOFamily: true,
+    });
+  });
+
+  test("(2) RESPONDENT_LEVEL_VALUES is a tuple of all 6 slugs in order", () => {
+    expect(RESPONDENT_LEVEL_VALUES).toEqual([
+      "teamleader",
+      "employee",
+      "guest",
+      "ceofounderwithteam",
+      "ceofounderalone",
+      "ceofounder",
+    ]);
+    // Must be non-empty tuple (first element present — needed for z.enum)
+    expect(RESPONDENT_LEVEL_VALUES.length).toBe(6);
+  });
+});
+
+describe("levelLabel", () => {
+  test("(3a) returns '—' for null", () => {
+    expect(levelLabel(null)).toBe("—");
+  });
+
+  test("(3b) returns '—' for undefined", () => {
+    expect(levelLabel(undefined)).toBe("—");
+  });
+
+  test("(3c) returns '—' for empty string", () => {
+    expect(levelLabel("")).toBe("—");
+  });
+
+  test("(4a) returns 'Leadership team member' for 'teamleader'", () => {
+    expect(levelLabel("teamleader")).toBe("Leadership team member");
+  });
+
+  test("(4b) returns 'Employee' for 'employee'", () => {
+    expect(levelLabel("employee")).toBe("Employee");
+  });
+
+  test("(4c) returns 'Guest' for 'guest'", () => {
+    expect(levelLabel("guest")).toBe("Guest");
+  });
+
+  test("(4d) returns 'CEO/Founder with team' for 'ceofounderwithteam'", () => {
+    expect(levelLabel("ceofounderwithteam")).toBe("CEO/Founder with team");
+  });
+
+  test("(4e) returns 'CEO/Founder alone' for 'ceofounderalone'", () => {
+    expect(levelLabel("ceofounderalone")).toBe("CEO/Founder alone");
+  });
+
+  test("(4f) returns 'CEO/Founder' for 'ceofounder'", () => {
+    expect(levelLabel("ceofounder")).toBe("CEO/Founder");
+  });
+
+  test("(5a) returns the raw value for an unknown legacy slug", () => {
+    expect(levelLabel("senior_manager")).toBe("senior_manager");
+  });
+
+  test("(5b) returns the raw value for another unknown slug", () => {
+    expect(levelLabel("EXECUTIVE")).toBe("EXECUTIVE");
+  });
+});
+
+describe("isCEOFamily", () => {
+  test("(6a) returns true for 'ceofounderwithteam'", () => {
+    expect(isCEOFamily("ceofounderwithteam")).toBe(true);
+  });
+
+  test("(6b) returns true for 'ceofounderalone'", () => {
+    expect(isCEOFamily("ceofounderalone")).toBe(true);
+  });
+
+  test("(6c) returns true for 'ceofounder'", () => {
+    expect(isCEOFamily("ceofounder")).toBe(true);
+  });
+
+  test("(6d) returns false for 'teamleader'", () => {
+    expect(isCEOFamily("teamleader")).toBe(false);
+  });
+
+  test("(6e) returns false for 'employee'", () => {
+    expect(isCEOFamily("employee")).toBe(false);
+  });
+
+  test("(6f) returns false for 'guest'", () => {
+    expect(isCEOFamily("guest")).toBe(false);
+  });
+
+  test("(7a) returns false for null", () => {
+    expect(isCEOFamily(null)).toBe(false);
+  });
+
+  test("(7b) returns false for undefined", () => {
+    expect(isCEOFamily(undefined)).toBe(false);
+  });
+
+  test("(7c) returns false for an unknown slug", () => {
+    expect(isCEOFamily("super_admin")).toBe(false);
+  });
+});

--- a/src/src/app/api/organizations/[id]/respondents/[respondentId]/route.ts
+++ b/src/src/app/api/organizations/[id]/respondents/[respondentId]/route.ts
@@ -106,12 +106,14 @@ export async function PATCH(
       lastName?: string;
       jobTitle?: string | null;
       teamId?: string | null;
+      roleType?: string | null;
     } = {};
     if (data.firstName !== undefined) updateData.firstName = data.firstName;
     if (data.lastName !== undefined) updateData.lastName = data.lastName;
     if (data.jobTitle !== undefined)
       updateData.jobTitle = data.jobTitle ?? null;
     if (data.teamId !== undefined) updateData.teamId = data.teamId ?? null;
+    if (data.roleType !== undefined) updateData.roleType = data.roleType;
 
     const respondent = await db.orgRespondent.update({
       where: { id: respondentId },

--- a/src/src/app/api/organizations/[id]/respondents/route.ts
+++ b/src/src/app/api/organizations/[id]/respondents/route.ts
@@ -156,6 +156,7 @@ export async function POST(
         data: {
           organizationId,
           teamId: data.teamId ?? null,
+          roleType: data.roleType ?? null,
           email: data.email,
           normalizedEmail,
           firstName: data.firstName,

--- a/src/src/components/assessments/CampaignWizard.tsx
+++ b/src/src/components/assessments/CampaignWizard.tsx
@@ -36,6 +36,7 @@ import {
   Building2,
   Users,
 } from "lucide-react";
+import { isCEOFamily } from "@/lib/assessments/respondent-levels";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -101,6 +102,7 @@ interface Respondent {
   email: string;
   jobTitle: string | null;
   teamId: string | null;
+  roleType?: string | null;
 }
 
 /** Shape returned by GET /api/organizations/[id]/teams (nested tree). */
@@ -853,6 +855,14 @@ function TemplateStep({
 
 // ── Step 2 — Participants ──────────────────────────────────────────────
 
+/**
+ * Internal CEO pick source discriminator.
+ *   'auto'  — the system derived the CEO from a single CEO-family Level member
+ *   'user'  — the coach explicitly clicked a CEO radio button
+ *   null    — no CEO set
+ */
+type CeoPickSource = "auto" | "user" | null;
+
 function ParticipantsStep({
   organizationId,
   respondentIds,
@@ -872,6 +882,8 @@ function ParticipantsStep({
   const [teams, setTeams] = useState<ApiTeamNode[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
+  // Tracks whether the current ceoRespondentId was auto-derived (vs. user-clicked).
+  const [ceoPickSource, setCeoPickSource] = useState<CeoPickSource>(null);
 
   const refresh = useCallback(async () => {
     if (!organizationId) return;
@@ -910,19 +922,68 @@ function ParticipantsStep({
     refresh();
   }, [refresh]);
 
+  // ── CEO-from-Level suggestion (decision #5) ───────────────────────────────
+  // Runs whenever the selection or loaded member list changes. Only applies
+  // when ceoPickSource !== 'user' (i.e., no deliberate user pick is in effect
+  // for a still-selected member).
+  useEffect(() => {
+    if (loading || error) return;
+
+    // If the user explicitly picked a CEO and that member is still selected,
+    // their manual choice wins — do nothing.
+    if (ceoPickSource === "user" && ceoRespondentId !== null && respondentIds.includes(ceoRespondentId)) {
+      return;
+    }
+
+    // C = selected members whose roleType is in the CEO/Founder family.
+    const ceoFamilySelected = respondentIds
+      .map((id) => respondents.find((r) => r.id === id))
+      .filter((r): r is Respondent => r !== undefined && isCEOFamily(r.roleType ?? null));
+
+    if (ceoFamilySelected.length === 1) {
+      // Exactly one CEO-family member selected → auto-suggest.
+      const suggested = ceoFamilySelected[0].id;
+      if (ceoRespondentId !== suggested || ceoPickSource !== "auto") {
+        setCeoPickSource("auto");
+        onChange(respondentIds, suggested);
+      }
+    } else {
+      // 0 or >1 CEO-family members → clear auto-suggest.
+      if (ceoPickSource === "auto" && ceoRespondentId !== null) {
+        setCeoPickSource(null);
+        onChange(respondentIds, null);
+      } else if (ceoPickSource !== "user" && ceoRespondentId !== null && ceoFamilySelected.length === 0) {
+        // The previously auto-set CEO is no longer selected at all.
+        setCeoPickSource(null);
+        onChange(respondentIds, null);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [respondentIds, respondents, loading, error]);
+
   function toggleRespondent(id: string, checked: boolean) {
     let next = respondentIds.slice();
     let ceo = ceoRespondentId;
+    let pickSource = ceoPickSource;
     if (checked) {
       if (!next.includes(id)) next.push(id);
     } else {
       next = next.filter((r) => r !== id);
-      if (ceo === id) ceo = null;
+      if (ceo === id) {
+        ceo = null;
+        pickSource = null;
+        setCeoPickSource(null);
+      }
     }
     onChange(next, ceo);
+    // If we just cleared an auto-pick via uncheck, the effect will re-run.
+    // Keep pickSource in sync locally so the effect's guard sees the right state.
+    void pickSource;
   }
 
   function setCEO(id: string) {
+    // Explicit user click — mark as user pick.
+    setCeoPickSource("user");
     if (!respondentIds.includes(id)) {
       // Auto-include if the coach marked CEO without checking the box first.
       onChange([...respondentIds, id], id);
@@ -983,6 +1044,7 @@ function ParticipantsStep({
   function renderRow(r: Respondent) {
     const checked = respondentIds.includes(r.id);
     const isCEO = ceoRespondentId === r.id;
+    const isAutoSuggested = isCEO && ceoPickSource === "auto";
     return (
       <div
         key={r.id}
@@ -1004,17 +1066,24 @@ function ParticipantsStep({
             {r.jobTitle ? ` • ${r.jobTitle}` : ""}
           </div>
         </div>
-        <label className="flex items-center gap-1 text-xs text-muted-foreground cursor-pointer">
-          <input
-            type="radio"
-            name="ceo"
-            checked={isCEO}
-            onChange={() => setCEO(r.id)}
-            className="accent-primary"
-            aria-label={`Mark ${r.firstName} ${r.lastName} as CEO`}
-          />
-          CEO
-        </label>
+        <div className="flex flex-col items-end gap-0.5">
+          <label className="flex items-center gap-1 text-xs text-muted-foreground cursor-pointer">
+            <input
+              type="radio"
+              name="ceo"
+              checked={isCEO}
+              onChange={() => setCEO(r.id)}
+              className="accent-primary"
+              aria-label={`Mark ${r.firstName} ${r.lastName} as CEO`}
+            />
+            CEO
+          </label>
+          {isAutoSuggested && (
+            <span className="text-xs text-muted-foreground italic">
+              Suggested by Level
+            </span>
+          )}
+        </div>
       </div>
     );
   }

--- a/src/src/components/organizations/add-member-modal.tsx
+++ b/src/src/components/organizations/add-member-modal.tsx
@@ -34,6 +34,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import type { ApiTeamNode } from "./members-teams-view";
+import { RESPONDENT_LEVELS } from "@/lib/assessments/respondent-levels";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -85,6 +86,7 @@ export function AddMemberModal({
   const emailId     = useId();
   const jobTitleId  = useId();
   const teamId_id   = useId();
+  const levelId     = useId();
 
   // Form state
   const [firstName, setFirstName] = useState("");
@@ -92,6 +94,7 @@ export function AddMemberModal({
   const [email,     setEmail]     = useState("");
   const [jobTitle,  setJobTitle]  = useState("");
   const [teamId,    setTeamId]    = useState<string>(defaultTeamId ?? "");
+  const [roleType,  setRoleType]  = useState<string>("");
 
   // Submission state
   const [submitting, setSubmitting] = useState(false);
@@ -105,6 +108,7 @@ export function AddMemberModal({
       setEmail("");
       setJobTitle("");
       setTeamId(defaultTeamId ?? "");
+      setRoleType("");
       setError(null);
     }
   }, [open, defaultTeamId]);
@@ -142,6 +146,10 @@ export function AddMemberModal({
       // Send teamId only when a team is actually selected
       if (teamId) {
         body.teamId = teamId;
+      }
+      // Send roleType only when a level is actually selected
+      if (roleType) {
+        body.roleType = roleType;
       }
 
       const res = await fetch(`/api/organizations/${orgId}/respondents`, {
@@ -266,6 +274,30 @@ export function AddMemberModal({
                     ))}
                   </>
                 )}
+              </select>
+            </div>
+
+            {/* ---- Level (optional) ---- */}
+            <div className="space-y-1.5">
+              <Label htmlFor={levelId}>Level</Label>
+              {/*
+                Native <select> — same pattern as Team selector above.
+                Six Esperto-aligned options; omits roleType from body when empty.
+              */}
+              <select
+                id={levelId}
+                data-testid="select-level"
+                value={roleType}
+                onChange={(e) => setRoleType(e.target.value)}
+                disabled={submitting}
+                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <option value="">— no level —</option>
+                {RESPONDENT_LEVELS.map((l) => (
+                  <option key={l.value} value={l.value}>
+                    {l.label}
+                  </option>
+                ))}
               </select>
             </div>
 

--- a/src/src/components/organizations/edit-member-modal.tsx
+++ b/src/src/components/organizations/edit-member-modal.tsx
@@ -39,6 +39,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import type { ApiTeamNode } from "./members-teams-view";
+import { RESPONDENT_LEVELS, RESPONDENT_LEVEL_VALUES } from "@/lib/assessments/respondent-levels";
+import type { RespondentLevelValue } from "@/lib/assessments/respondent-levels";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -52,6 +54,7 @@ export interface EditMemberModalMember {
   email: string;
   jobTitle?: string | null;
   teamId?: string | null;
+  roleType?: string | null;
 }
 
 export interface EditMemberModalProps {
@@ -85,12 +88,14 @@ export function EditMemberModal({
   const emailId     = useId();
   const jobTitleId  = useId();
   const teamId_id   = useId();
+  const levelId     = useId();
 
   // Form state — pre-filled from member prop
   const [firstName, setFirstName] = useState(member.firstName);
   const [lastName,  setLastName]  = useState(member.lastName);
   const [jobTitle,  setJobTitle]  = useState(member.jobTitle ?? "");
   const [teamId,    setTeamId]    = useState<string>(member.teamId ?? "");
+  const [roleType,  setRoleType]  = useState<string>(member.roleType ?? "");
 
   // Submission state
   const [submitting, setSubmitting] = useState(false);
@@ -103,10 +108,11 @@ export function EditMemberModal({
       setLastName(member.lastName);
       setJobTitle(member.jobTitle ?? "");
       setTeamId(member.teamId ?? "");
+      setRoleType(member.roleType ?? "");
       setError(null);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, member.id, member.firstName, member.lastName, member.jobTitle, member.teamId]);
+  }, [open, member.id, member.firstName, member.lastName, member.jobTitle, member.teamId, member.roleType]);
 
   // ---------------------------------------------------------------------------
   // Validation + submit
@@ -142,6 +148,8 @@ export function EditMemberModal({
       if (teamId) {
         body.teamId = teamId;
       }
+      // Always include roleType so the user can unset it (null = clear the field)
+      body.roleType = roleType || null;
       // NOTE: email is intentionally NOT included — the API rejects email changes
       // (email is the dedupe key for OrgRespondent).
 
@@ -270,6 +278,39 @@ export function EditMemberModal({
                     {t.name}
                   </option>
                 ))}
+              </select>
+            </div>
+
+            {/* ---- Level (optional) ---- */}
+            <div className="space-y-1.5">
+              <Label htmlFor={levelId}>Level</Label>
+              {/*
+                Native <select> — same pattern as Team selector.
+                Six Esperto-aligned options; always sends roleType (null = clear).
+                If member.roleType is set but isn't one of the 6 known values (legacy
+                data), a "(legacy)" option is appended so the saved value is preserved.
+              */}
+              <select
+                id={levelId}
+                data-testid="select-level"
+                value={roleType}
+                onChange={(e) => setRoleType(e.target.value)}
+                disabled={submitting}
+                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <option value="">— no level —</option>
+                {RESPONDENT_LEVELS.map((l) => (
+                  <option key={l.value} value={l.value}>
+                    {l.label}
+                  </option>
+                ))}
+                {/* Passthrough for legacy values not in the 6 known slugs */}
+                {member.roleType &&
+                  !(RESPONDENT_LEVEL_VALUES as readonly string[]).includes(member.roleType) && (
+                    <option value={member.roleType}>
+                      {member.roleType} (legacy)
+                    </option>
+                  )}
               </select>
             </div>
 

--- a/src/src/components/organizations/edit-member-modal.tsx
+++ b/src/src/components/organizations/edit-member-modal.tsx
@@ -91,11 +91,14 @@ export function EditMemberModal({
   const levelId     = useId();
 
   // Form state — pre-filled from member prop
-  const [firstName, setFirstName] = useState(member.firstName);
-  const [lastName,  setLastName]  = useState(member.lastName);
-  const [jobTitle,  setJobTitle]  = useState(member.jobTitle ?? "");
-  const [teamId,    setTeamId]    = useState<string>(member.teamId ?? "");
-  const [roleType,  setRoleType]  = useState<string>(member.roleType ?? "");
+  const [firstName,       setFirstName]       = useState(member.firstName);
+  const [lastName,        setLastName]        = useState(member.lastName);
+  const [jobTitle,        setJobTitle]        = useState(member.jobTitle ?? "");
+  const [teamId,          setTeamId]          = useState<string>(member.teamId ?? "");
+  const [roleType,        setRoleType]        = useState<string>(member.roleType ?? "");
+  // Track the value that was in the DB when the modal opened so we can detect
+  // if the user actually changed it (needed for legacy-slug preservation below).
+  const [initialRoleType, setInitialRoleType] = useState<string | null | undefined>(member.roleType);
 
   // Submission state
   const [submitting, setSubmitting] = useState(false);
@@ -109,6 +112,7 @@ export function EditMemberModal({
       setJobTitle(member.jobTitle ?? "");
       setTeamId(member.teamId ?? "");
       setRoleType(member.roleType ?? "");
+      setInitialRoleType(member.roleType);
       setError(null);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -148,8 +152,19 @@ export function EditMemberModal({
       if (teamId) {
         body.teamId = teamId;
       }
-      // Always include roleType so the user can unset it (null = clear the field)
-      body.roleType = roleType || null;
+      // roleType handling:
+      //  - If the user explicitly cleared the field (empty string), send null to wipe it.
+      //  - If the user explicitly picked a known slug, send it.
+      //  - If the value is unchanged AND it's a legacy/unknown slug (not in the known list),
+      //    omit roleType entirely so the unknown slug passes through the Zod enum guard on
+      //    PATCH without a 400 rejection.
+      const isLegacyUnchanged =
+        roleType === (initialRoleType ?? "") &&
+        initialRoleType != null &&
+        !(RESPONDENT_LEVEL_VALUES as readonly string[]).includes(initialRoleType);
+      if (!isLegacyUnchanged) {
+        body.roleType = roleType || null;
+      }
       // NOTE: email is intentionally NOT included — the API rejects email changes
       // (email is the dedupe key for OrgRespondent).
 

--- a/src/src/components/organizations/members-teams-view.tsx
+++ b/src/src/components/organizations/members-teams-view.tsx
@@ -14,6 +14,7 @@
 
 import React, { useState, useCallback, useRef } from "react";
 import { ChevronRight, ChevronDown, Building2, Users, UserPlus, FolderPlus, Pencil } from "lucide-react";
+import { levelLabel } from "@/lib/assessments/respondent-levels";
 import { AddTeamModal } from "./add-team-modal";
 import type { CreatedResult } from "./add-team-modal";
 import { AddMemberModal } from "./add-member-modal";
@@ -676,7 +677,7 @@ export function MembersTeamsView({ initialOrganizations }: MembersTeamsViewProps
                       </td>
                       <td className="px-6 py-3 text-muted-foreground">{m.email}</td>
                       <td className="px-6 py-3 text-muted-foreground">
-                        {m.roleType ?? "—"}
+                        {levelLabel(m.roleType)}
                       </td>
                       <td className="px-3 py-3 text-right">
                         {/* Edit affordance — shown on row hover */}
@@ -694,6 +695,7 @@ export function MembersTeamsView({ initialOrganizations }: MembersTeamsViewProps
                               email: m.email,
                               jobTitle: m.jobTitle ?? null,
                               teamId: m.teamId ?? null,
+                              roleType: m.roleType ?? null,
                             });
                             // Lazy-load teams if not yet fetched
                             if (

--- a/src/src/lib/assessments/respondent-levels.ts
+++ b/src/src/lib/assessments/respondent-levels.ts
@@ -1,0 +1,31 @@
+/**
+ * Esperto-compatible Level taxonomy for OrgRespondent.roleType.
+ * Six exact labels from Esperto's Add Member dropdown.
+ *
+ * NOTE: only `ceofounder` is a confirmed Esperto stored slug (from a live
+ * member row). The 3 CEO-variant slugs (`ceofounderwithteam` /
+ * `ceofounderalone`) are best-guess pending a real Esperto CSV export. If the
+ * actual stored values differ, update them here — they're the single source of
+ * truth for UI display, validation, and (eventually) CEO-suggestion logic.
+ */
+export const RESPONDENT_LEVELS = [
+  { value: "teamleader",         label: "Leadership team member", isCEOFamily: false },
+  { value: "employee",           label: "Employee",               isCEOFamily: false },
+  { value: "guest",              label: "Guest",                  isCEOFamily: false },
+  { value: "ceofounderwithteam", label: "CEO/Founder with team",  isCEOFamily: true  },
+  { value: "ceofounderalone",    label: "CEO/Founder alone",      isCEOFamily: true  },
+  { value: "ceofounder",         label: "CEO/Founder",            isCEOFamily: true  },
+] as const;
+
+export type RespondentLevelValue = (typeof RESPONDENT_LEVELS)[number]["value"];
+export const RESPONDENT_LEVEL_VALUES = RESPONDENT_LEVELS.map((l) => l.value) as [RespondentLevelValue, ...RespondentLevelValue[]];
+
+export function levelLabel(value: string | null | undefined): string {
+  if (!value) return "—";
+  return RESPONDENT_LEVELS.find((l) => l.value === value)?.label ?? value;
+}
+
+export function isCEOFamily(value: string | null | undefined): boolean {
+  if (!value) return false;
+  return RESPONDENT_LEVELS.find((l) => l.value === value)?.isCEOFamily ?? false;
+}

--- a/src/src/lib/validations.ts
+++ b/src/src/lib/validations.ts
@@ -4,6 +4,7 @@
  */
 
 import { z } from "zod";
+import { RESPONDENT_LEVEL_VALUES } from "./assessments/respondent-levels";
 
 // ============================================================
 // Common Schemas
@@ -486,6 +487,7 @@ export const createRespondentSchema = z.object({
     jobTitle: z.string().max(200).transform(_trim).nullable().optional(),
     teamId: z.string().min(1).nullable().optional(),
     externalId: z.string().min(1).max(200).transform(_trim).nullable().optional(),
+    roleType: z.enum(RESPONDENT_LEVEL_VALUES).optional().nullable(),
 });
 
 export const updateRespondentSchema = z.object({
@@ -493,6 +495,7 @@ export const updateRespondentSchema = z.object({
     lastName: z.string().min(1).max(200).transform(_trim).optional(),
     jobTitle: z.string().max(200).transform(_trim).nullable().optional(),
     teamId: z.string().min(1).nullable().optional(),
+    roleType: z.enum(RESPONDENT_LEVEL_VALUES).optional().nullable(),
 });
 
 // ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Wire Esperto's 6 Levels end-to-end through the Members & Teams lane + add an auto-suggest-CEO behavior in the campaign wizard that never silently first-wins under ambiguity.

- **Levels infrastructure** (`9d1e890` + Critical fix `b5012fa`): new `src/src/lib/assessments/respondent-levels.ts` (6 levels: Leadership team member / Employee / Guest / CEO/Founder with team / CEO/Founder alone / CEO/Founder; slugs lower-cased; only `ceofounder` confirmed against a live Esperto member row — the 3 CEO-variant slugs are best-guess pending a real CSV export, flagged in code). Zod schemas (`createRespondentSchema` + `updateRespondentSchema`) extended with `roleType: z.enum(...).optional().nullable()`. Level select wired into both Add Member + Edit Member modals; members table renders the human label. **Critical caught in review**: roleType validated but never persisted to Prisma — fixed by threading it into both POST `create.data` and PATCH `updateData` (with `!== undefined` so explicit `null` clears the column). EditMember preserves legacy unknown slugs by omitting `roleType` from the PATCH body when unchanged.
- **CEO-from-Level suggestion** (`20accd2`): in the wizard's Participants step, when exactly one CEO/Founder-Level member is selected → auto-suggest them as the campaign CEO (state machine: `ceoPickSource: 'auto' | 'user' | null` — a deliberate user click always wins). Renders an inline "Suggested by Level" hint next to the auto-suggested row. Multiple CEO-family selected → no auto (forces explicit pick). Zero CEO-family → no auto. Removing the suggested member clears the CEO. Never silently first-wins.

Per decision #5: pre-suggest, never silently set; explicit single-CEO confirmation before save (the existing Review step + Save click is the explicit confirmation point).

## Test plan
- [x] **2140/2143** passing (3 known pre-existing only: `no-inline-tolocaledatestring` / `org-survey/exchange` / `assessment-campaigns/detail-route`)
- [x] 22 new respondent-levels tests; 6 new API persistence tests (assert Prisma `create.data` / `update.data` shape, not just request body); 3 new legacy-slug passthrough tests; 6 new wizard CEO-suggestion tests covering all branches
- [x] `CI=true npx next build --turbopack` clean under the safety gate
- [x] Zero migrations; zero destructive ops

🤖 Generated with [Claude Code](https://claude.com/claude-code)