### PR TITLE
feat(assessment): Slice 4 — bulk CSV import + wizard persistent quick-add

### DIFF
--- a/src/src/__tests__/components/assessments/campaign-wizard-pick-existing.test.tsx
+++ b/src/src/__tests__/components/assessments/campaign-wizard-pick-existing.test.tsx
@@ -726,6 +726,211 @@ describe("CampaignWizard — CEO-from-Level suggestion", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Slice 4 / Task 2 — Persistent quick-add member from within the wizard
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch installer for the quick-add tests.  The respondents list returned by
+ * GET /api/organizations/org-1/respondents can be replaced mid-test by
+ * swapping `respondentStore` — the fetch closure captures the reference.
+ *
+ * POST /api/organizations/org-1/respondents returns the fixture passed in
+ * `postResult`.
+ */
+const NEW_MEMBER = {
+  id: "new-id-1",
+  firstName: "New",
+  lastName: "Member",
+  email: "new@example.com",
+  jobTitle: null as string | null,
+  teamId: null as string | null,
+  roleType: null as string | null,
+};
+const NEW_CEO_MEMBER = {
+  id: "new-ceo-1",
+  firstName: "CEO",
+  lastName: "Quick",
+  email: "ceoquick@example.com",
+  jobTitle: null as string | null,
+  teamId: null as string | null,
+  roleType: "ceofounder" as string | null,
+};
+
+function installQuickAddFetch(opts: {
+  postResult: typeof NEW_MEMBER;
+  afterRespondents: (typeof NEW_MEMBER)[];
+}) {
+  fetchCalls = [];
+  global.fetch = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : String(input);
+    const method = (init?.method ?? "GET").toUpperCase();
+    let body: unknown = undefined;
+    if (init?.body && typeof init.body === "string") {
+      try { body = JSON.parse(init.body); } catch { body = init.body; }
+    }
+    fetchCalls.push({ url, method, body });
+
+    if (url.includes("/api/assessment-campaign-drafts")) {
+      if (method === "GET") return jsonResponse({ success: true, data: null });
+      return jsonResponse({ success: true });
+    }
+    if (url.endsWith("/api/organizations") && method === "GET") {
+      return jsonResponse({ success: true, data: [ORG] });
+    }
+    if (url.match(/\/api\/organizations\/org-1$/) && method === "GET") {
+      return jsonResponse({ success: true, data: ORG });
+    }
+    if (url.endsWith("/api/assessment-templates") && method === "GET") {
+      return jsonResponse({ success: true, data: [TEMPLATE] });
+    }
+    if (url.includes("/api/organizations/org-1/teams") && method === "GET") {
+      return jsonResponse({ success: true, data: [TEAM_ENG] });
+    }
+    // POST /respondents — creates the new member
+    if (url.includes("/api/organizations/org-1/respondents") && method === "POST") {
+      return jsonResponse({ success: true, data: opts.postResult });
+    }
+    // GET /respondents — first call returns ALICE+BOB; subsequent calls include the new member
+    if (url.includes("/api/organizations/org-1/respondents") && method === "GET") {
+      const callCount = fetchCalls.filter(
+        (c) => c.url.includes("/api/organizations/org-1/respondents") && c.method === "GET"
+      ).length;
+      // First call (initial load) returns original members; re-fetch returns extended list
+      if (callCount <= 1) {
+        return jsonResponse({ success: true, data: [ALICE, BOB] });
+      }
+      return jsonResponse({ success: true, data: opts.afterRespondents });
+    }
+    if (url.endsWith("/api/assessment-campaigns") && method === "POST") {
+      return jsonResponse({ success: true, data: { id: "camp-1" } });
+    }
+    if (url.includes("/api/assessment-campaigns/camp-1/participants")) {
+      return jsonResponse({ success: true, data: { added: 1 } });
+    }
+    if (url.includes("/api/assessment-campaigns/camp-1/activate")) {
+      return jsonResponse({ success: true, data: { status: "ACTIVE" } });
+    }
+    return jsonResponse({ success: false, error: "unhandled" }, false);
+  }) as unknown as typeof fetch;
+}
+
+describe("CampaignWizard — Slice 4 quick-add member", () => {
+  /** Navigate Step 0 → Step 2 (Participants) using installQuickAddFetch. */
+  async function advanceToParticipantsQA() {
+    const orgRadio = await screen.findByRole("radio", { name: /acme corp/i });
+    fireEvent.click(orgRadio);
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+
+    const tplRadio = await screen.findByRole("radio", { name: /rockefeller habits/i });
+    fireEvent.click(tplRadio);
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+  }
+
+  it("QA1: 'Add new member' button is visible in Step 3 with an org selected", async () => {
+    installQuickAddFetch({
+      postResult: NEW_MEMBER,
+      afterRespondents: [ALICE, BOB, NEW_MEMBER],
+    });
+    render(<CampaignWizard />);
+    await advanceToParticipantsQA();
+
+    // Members list rendered.
+    await screen.findByText("Alice Smith");
+
+    // The quick-add button must be present.
+    expect(
+      screen.getByRole("button", { name: /add new member/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("QA2: clicking 'Add new member' opens the AddMemberModal with the right description", async () => {
+    installQuickAddFetch({
+      postResult: NEW_MEMBER,
+      afterRespondents: [ALICE, BOB, NEW_MEMBER],
+    });
+    render(<CampaignWizard />);
+    await advanceToParticipantsQA();
+
+    await screen.findByText("Alice Smith");
+
+    fireEvent.click(screen.getByRole("button", { name: /add new member/i }));
+
+    // The modal dialog should open.
+    await screen.findByRole("dialog");
+
+    // Decision #8 explicit labeling: description must mention "Acme Corp's roster".
+    expect(
+      screen.getByText(/adds this person to acme corp's roster/i),
+    ).toBeInTheDocument();
+  });
+
+  it("QA3: successful add auto-includes the new member and they appear checked", async () => {
+    installQuickAddFetch({
+      postResult: NEW_MEMBER,
+      afterRespondents: [ALICE, BOB, NEW_MEMBER],
+    });
+    render(<CampaignWizard />);
+    await advanceToParticipantsQA();
+
+    await screen.findByText("Alice Smith");
+
+    // Open the quick-add modal.
+    fireEvent.click(screen.getByRole("button", { name: /add new member/i }));
+    await screen.findByRole("dialog");
+
+    // Fill in required fields.
+    fireEvent.change(screen.getByLabelText(/first name/i), { target: { value: "New" } });
+    fireEvent.change(screen.getByLabelText(/last name/i), { target: { value: "Member" } });
+    fireEvent.change(screen.getByLabelText(/e-mail/i), { target: { value: "new@example.com" } });
+
+    // Submit the modal.
+    fireEvent.click(screen.getByRole("button", { name: /add member/i }));
+
+    // After save, the new member row should appear and be checked.
+    await waitFor(() => {
+      const checkbox = screen.getByRole("checkbox", { name: /new member/i });
+      expect(checkbox).toBeChecked();
+    });
+  });
+
+  it("QA4: quick-add CEO/Founder-Level member triggers auto-suggest", async () => {
+    installQuickAddFetch({
+      postResult: NEW_CEO_MEMBER,
+      afterRespondents: [ALICE, BOB, NEW_CEO_MEMBER],
+    });
+    render(<CampaignWizard />);
+    await advanceToParticipantsQA();
+
+    await screen.findByText("Alice Smith");
+
+    // Open the quick-add modal.
+    fireEvent.click(screen.getByRole("button", { name: /add new member/i }));
+    await screen.findByRole("dialog");
+
+    // Fill required fields.
+    fireEvent.change(screen.getByLabelText(/first name/i), { target: { value: "CEO" } });
+    fireEvent.change(screen.getByLabelText(/last name/i), { target: { value: "Quick" } });
+    fireEvent.change(screen.getByLabelText(/e-mail/i), { target: { value: "ceoquick@example.com" } });
+    // Select ceofounder level.
+    fireEvent.change(screen.getByTestId("select-level"), { target: { value: "ceofounder" } });
+
+    // Submit the modal.
+    fireEvent.click(screen.getByRole("button", { name: /add member/i }));
+
+    // New CEO member checked AND auto-suggested as CEO.
+    await waitFor(() => {
+      const checkbox = screen.getByRole("checkbox", { name: /ceo quick/i });
+      expect(checkbox).toBeChecked();
+    });
+    await waitFor(() => {
+      const ceoRadio = screen.getByRole("radio", { name: /mark ceo quick as ceo/i });
+      expect(ceoRadio).toBeChecked();
+    });
+    expect(screen.getByText(/suggested by level/i)).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // I2 — a teams-fetch failure is surfaced (not silently swallowed) even when
 // the respondents fetch succeeds.
 // ---------------------------------------------------------------------------

--- a/src/src/__tests__/components/organizations/add-member-modal.test.tsx
+++ b/src/src/__tests__/components/organizations/add-member-modal.test.tsx
@@ -308,7 +308,17 @@ describe("AddMemberModal", () => {
     fireEvent.click(screen.getByRole("button", { name: /add member/i }));
 
     await waitFor(() => {
-      expect(onCreated).toHaveBeenCalledWith({ respondent: mockRespondent });
+      expect(onCreated).toHaveBeenCalledWith(
+        expect.objectContaining({
+          respondent: mockRespondent,
+          created: expect.objectContaining({
+            id: "r-3",
+            firstName: "Carol",
+            lastName: "White",
+            email: "carol@example.com",
+          }),
+        })
+      );
     });
 
     expect(onClose).toHaveBeenCalled();

--- a/src/src/__tests__/components/organizations/import-members-modal.test.tsx
+++ b/src/src/__tests__/components/organizations/import-members-modal.test.tsx
@@ -263,4 +263,72 @@ describe("ImportMembersModal", () => {
     // No text pasted yet → button disabled
     expect(importBtn).toBeDisabled();
   });
+
+  /**
+   * (7) Partial-success — success:true but server returns row-level errors.
+   *     Asserts: counts render, each row reason renders, modal stays open,
+   *     onUpdated was still called (the data did write).
+   */
+  test("(7) partial-success: counts render, row errors listed, modal stays open, onUpdated called", async () => {
+    const PARTIAL_CSV =
+      "name,email,team\n" +
+      "Alice Smith,alice@example.com,Engineering\n" +
+      "Bob Jones,bob@example.com,Sales\n" +
+      "Carol White,carol@example.com,Marketing\n" +
+      "Dave Black,dave@example.com,\n" +
+      "Eve Green,eve@example.com,\n";
+
+    const onUpdatedMock = jest.fn().mockResolvedValue(undefined);
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: {
+          created: [
+            { id: "r1", email: "alice@example.com" },
+            { id: "r3", email: "carol@example.com" },
+            { id: "r4", email: "dave@example.com" },
+          ],
+          updated: [],
+          skipped: [],
+          errors: [
+            { row: 2, reason: "team create failed" },
+            { row: 5, reason: "duplicate email" },
+          ],
+        },
+      }),
+    });
+
+    const { onClose } = renderModal({ onUpdated: onUpdatedMock });
+
+    const textarea = screen.getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: PARTIAL_CSV } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/parsed 5 rows/i)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /import 5 respondents/i }));
+
+    // Success counts must render
+    await waitFor(() => {
+      expect(screen.getByText(/imported 3/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/3 created/i)).toBeInTheDocument();
+
+    // Row-level reasons must render
+    expect(screen.getByText(/team create failed/i)).toBeInTheDocument();
+    expect(screen.getByText(/duplicate email/i)).toBeInTheDocument();
+
+    // onUpdated must have been called (data did write)
+    expect(onUpdatedMock).toHaveBeenCalled();
+
+    // Modal must stay open — no auto-close when errors exist
+    // Advance past the 1.5 s auto-close window
+    await act(async () => {
+      jest.advanceTimersByTime(3000);
+    });
+    expect(onClose).not.toHaveBeenCalled();
+  });
 });

--- a/src/src/__tests__/components/organizations/import-members-modal.test.tsx
+++ b/src/src/__tests__/components/organizations/import-members-modal.test.tsx
@@ -1,0 +1,266 @@
+/**
+ * TDD Red Phase — ImportMembersModal tests.
+ *
+ * Test matrix:
+ *  (1) Live preview parses pasted CSV — paste 3-row valid CSV; parsed-row count + table rows appear.
+ *  (2) Errors block import — paste CSV with bad email; Import disabled + error listed.
+ *  (3) Valid submit POSTs the right body — 2 valid rows, mode=merge → asserts URL + body shape.
+ *  (4) Result summary — mock success response; summary text appears, onUpdated awaited before onClose.
+ *  (5) Failure — mock { success:false, error:[{message}] }; specific message renders, modal stays open.
+ *  (6) Empty paste — Import button disabled with no rows.
+ */
+
+import React from "react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { ImportMembersModal } from "@/components/organizations/import-members-modal";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const ORG_ID   = "org-abc";
+const ORG_NAME = "Acme Corp";
+
+const VALID_CSV_3_ROWS =
+  "name,email,team\n" +
+  "Alice Smith,alice@example.com,Engineering\n" +
+  "Bob Jones,bob@example.com,Engineering/Frontend\n" +
+  "Carol White,carol@example.com,\n";
+
+const VALID_CSV_2_ROWS =
+  "name,email\n" +
+  "Alice Smith,alice@example.com\n" +
+  "Bob Jones,bob@example.com\n";
+
+const CSV_WITH_BAD_EMAIL =
+  "name,email\n" +
+  "Alice Smith,alice@example.com\n" +
+  "Bob Jones,not-an-email\n";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderModal(
+  overrides: Partial<React.ComponentProps<typeof ImportMembersModal>> = {}
+) {
+  const onClose    = jest.fn();
+  const onUpdated  = jest.fn().mockResolvedValue(undefined);
+
+  const defaults: React.ComponentProps<typeof ImportMembersModal> = {
+    open:      true,
+    onClose,
+    onUpdated,
+    orgId:     ORG_ID,
+    orgName:   ORG_NAME,
+  };
+  const props = { ...defaults, ...overrides };
+  render(<ImportMembersModal {...props} />);
+  return {
+    onClose:   props.onClose   as jest.Mock,
+    onUpdated: props.onUpdated as jest.Mock,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  global.fetch = jest.fn();
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.runAllTimers();
+  jest.useRealTimers();
+  jest.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ImportMembersModal", () => {
+  /**
+   * (1) Live preview parses pasted CSV — paste a 3-row valid CSV;
+   *     assert the parsed-rows count + table rows.
+   */
+  test("(1) live preview parses pasted CSV and shows row count + table", async () => {
+    renderModal();
+
+    const textarea = screen.getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: VALID_CSV_3_ROWS } });
+
+    // "Parsed N rows" summary appears (3 data rows + possible empty trailing row = 3)
+    await waitFor(() => {
+      expect(screen.getByText(/parsed 3 rows/i)).toBeInTheDocument();
+    });
+
+    // Preview table shows the three names
+    expect(screen.getByText("Alice Smith")).toBeInTheDocument();
+    expect(screen.getByText("Bob Jones")).toBeInTheDocument();
+    expect(screen.getByText("Carol White")).toBeInTheDocument();
+  });
+
+  /**
+   * (2) Errors block import — paste a CSV with a bad email;
+   *     assert Import button is disabled AND the error is listed.
+   */
+  test("(2) CSV with bad email disables Import and shows the error", async () => {
+    renderModal();
+
+    const textarea = screen.getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: CSV_WITH_BAD_EMAIL } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/1 error/i)).toBeInTheDocument();
+    });
+
+    // Import button is disabled because errors.length > 0
+    const importBtn = screen.getByRole("button", { name: /import/i });
+    expect(importBtn).toBeDisabled();
+
+    // Error details mention the bad-email row
+    expect(screen.getByText(/not a valid email/i)).toBeInTheDocument();
+  });
+
+  /**
+   * (3) Valid submit POSTs the right body — paste 2 valid rows, pick merge,
+   *     click Import; assert POST URL + body { rows: [...], mode: "merge" }.
+   */
+  test("(3) valid submit POSTs to the correct URL with rows + mode in the body", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: { created: [{ id: "r1", email: "alice@example.com" }], updated: [], skipped: [], errors: [] },
+      }),
+    });
+
+    renderModal();
+
+    const textarea = screen.getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: VALID_CSV_2_ROWS } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/parsed 2 rows/i)).toBeInTheDocument();
+    });
+
+    // Change mode to merge
+    fireEvent.click(screen.getByLabelText(/merge/i));
+
+    fireEvent.click(screen.getByRole("button", { name: /import 2 respondents/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    const [url, init] = (global.fetch as jest.Mock).mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`/api/organizations/${ORG_ID}/respondents/bulk`);
+
+    const body = JSON.parse(init.body as string) as { rows: unknown[]; mode: string };
+    expect(body.mode).toBe("merge");
+    expect(body.rows).toHaveLength(2);
+    // Each row must have name, email, teamPath
+    const row0 = body.rows[0] as { name: string; email: string; teamPath: string[] };
+    expect(row0.name).toBe("Alice Smith");
+    expect(row0.email).toBe("alice@example.com");
+    expect(row0.teamPath).toEqual([]);
+  });
+
+  /**
+   * (4) Result summary — mock success response; summary text appears,
+   *     onUpdated awaited before onClose.
+   */
+  test("(4) success: summary renders, onUpdated awaited before onClose", async () => {
+    const onUpdatedMock = jest.fn().mockResolvedValue(undefined);
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: {
+          created: [{ id: "r1", email: "alice@example.com" }],
+          updated: [{ id: "r2", email: "bob@example.com" }],
+          skipped: [],
+          errors:  [],
+        },
+      }),
+    });
+
+    renderModal({ onUpdated: onUpdatedMock });
+
+    const textarea = screen.getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: VALID_CSV_2_ROWS } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/parsed 2 rows/i)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /import 2 respondents/i }));
+
+    // Summary text must appear
+    await waitFor(() => {
+      expect(screen.getByText(/imported 2/i)).toBeInTheDocument();
+    });
+
+    // "1 created, 1 updated" details visible too
+    expect(screen.getByText(/1 created/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 updated/i)).toBeInTheDocument();
+
+    // onUpdated must have been called
+    expect(onUpdatedMock).toHaveBeenCalled();
+
+    // After the brief display delay, onClose fires
+    // (advance timers past the ~1500ms display window)
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+    });
+  });
+
+  /**
+   * (5) Failure — mock { success:false, error:[{message}] };
+   *     the specific message renders + modal stays open.
+   */
+  test("(5) server failure shows specific error and keeps modal open", async () => {
+    const errMsg = "Row 2: email invalid";
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({
+        success: false,
+        error: [{ message: errMsg }],
+      }),
+    });
+
+    const { onClose } = renderModal();
+
+    const textarea = screen.getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: VALID_CSV_2_ROWS } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/parsed 2 rows/i)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /import 2 respondents/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(errMsg);
+    });
+
+    // Modal stays open
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  /**
+   * (6) Empty paste — Import disabled with no rows.
+   */
+  test("(6) empty textarea keeps Import button disabled", () => {
+    renderModal();
+
+    const importBtn = screen.getByRole("button", { name: /import/i });
+    // No text pasted yet → button disabled
+    expect(importBtn).toBeDisabled();
+  });
+});

--- a/src/src/__tests__/components/organizations/members-teams-view.test.tsx
+++ b/src/src/__tests__/components/organizations/members-teams-view.test.tsx
@@ -456,4 +456,42 @@ describe("MembersTeamsView", () => {
     const memberRow = screen.getByTestId("member-row-resp-2");
     expect(memberRow).toHaveTextContent("—");
   });
+
+  /**
+   * (k) Clicking "Import members" with a node selected opens ImportMembersModal.
+   */
+  test("(k) clicking Import members with a node selected opens the ImportMembersModal", async () => {
+    mockFetchForOrg1Teams();
+
+    render(<MembersTeamsView initialOrganizations={[ORG_1]} />);
+
+    // Import members button exists but is disabled before selecting a node
+    const importBtn = screen.getByRole("button", { name: /import members \(select a node first\)/i });
+    expect(importBtn).toBeDisabled();
+
+    // Expand and select the org node (this also loads members, need to mock)
+    mockFetchRespondents([RESPONDENT_ALICE]);
+    fireEvent.click(screen.getByRole("button", { name: /^Acme Corp$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Alice Smith")).toBeInTheDocument();
+    });
+
+    // Now the Import members button should be enabled
+    const importBtnEnabled = screen.getByRole("button", { name: /^import members$/i });
+    expect(importBtnEnabled).not.toBeDisabled();
+
+    // Click it — the ImportMembersModal dialog should open
+    fireEvent.click(importBtnEnabled);
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: /import members/i })).toBeInTheDocument();
+    });
+
+    // Cancel closes the modal cleanly
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    await waitFor(() => {
+      expect(screen.queryByRole("heading", { name: /import members/i })).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/src/components/assessments/CampaignWizard.tsx
+++ b/src/src/components/assessments/CampaignWizard.tsx
@@ -35,12 +35,15 @@ import {
   Loader2,
   Building2,
   Users,
+  UserPlus,
 } from "lucide-react";
 import { isCEOFamily } from "@/lib/assessments/respondent-levels";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/components/ui/use-toast";
+import { AddMemberModal } from "@/components/organizations/add-member-modal";
+import type { MemberCreatedResult } from "@/components/organizations/add-member-modal";
 
 const DRAFT_ENDPOINT = "/api/assessment-campaign-drafts";
 const DRAFT_DEBOUNCE_MS = 800;
@@ -111,12 +114,18 @@ interface ApiTeamNode {
   organizationId: string;
   parentTeamId: string | null;
   name: string;
+  type: string | null;
+  description: string | null;
   children: ApiTeamNode[];
 }
 
 interface WizardState {
   step: number;
   organizationId: string;
+  /** Display name of the selected org — tracked so ParticipantsStep can show
+   *  the decision-#8 "adds to <orgName>'s roster" hint without an extra fetch.
+   *  NOT persisted to the draft (ephemeral UI label only). */
+  orgName: string;
   templateId: string;
   respondentIds: string[];
   ceoRespondentId: string | null;
@@ -184,6 +193,7 @@ export function CampaignWizard() {
     return {
       step: 0,
       organizationId: "",
+      orgName: "",
       templateId: "",
       respondentIds: [],
       ceoRespondentId: null,
@@ -241,6 +251,7 @@ export function CampaignWizard() {
         const merged: WizardState = {
           step: typeof draft.currentStep === "number" ? draft.currentStep : 0,
           organizationId: parsed.organizationId ?? "",
+          orgName: "", // ephemeral — not persisted; will re-populate when org is re-selected
           templateId: parsed.templateId ?? "",
           respondentIds: Array.isArray(parsed.respondentIds)
             ? parsed.respondentIds
@@ -580,17 +591,18 @@ export function CampaignWizard() {
         {state.step === 0 && (
           <OrganizationStep
             value={state.organizationId}
-            onChange={(v) =>
+            onChange={({ id, name }) =>
               setState((s) => {
                 // Re-selecting the same org must NOT wipe a valid member
                 // selection. Only on an actual company change do we clear the
                 // picked members + CEO — otherwise their (other-company) ids
                 // would persist and get rejected by /participants later,
                 // leaving an orphaned empty campaign.
-                if (s.organizationId === v) return s;
+                if (s.organizationId === id) return s;
                 return {
                   ...s,
-                  organizationId: v,
+                  organizationId: id,
+                  orgName: name,
                   respondentIds: [],
                   ceoRespondentId: null,
                 };
@@ -610,6 +622,7 @@ export function CampaignWizard() {
         {state.step === 2 && (
           <ParticipantsStep
             organizationId={state.organizationId}
+            orgName={state.orgName}
             respondentIds={state.respondentIds}
             ceoRespondentId={state.ceoRespondentId}
             onChange={(rIds, ceoId) => {
@@ -658,7 +671,7 @@ function OrganizationStep({
   onNext,
 }: {
   value: string;
-  onChange: (v: string) => void;
+  onChange: (v: { id: string; name: string }) => void;
   onNext: () => void;
 }) {
   const [orgs, setOrgs] = useState<Organization[]>([]);
@@ -727,7 +740,7 @@ function OrganizationStep({
                 name="org"
                 value={o.id}
                 checked={value === o.id}
-                onChange={() => onChange(o.id)}
+                onChange={() => onChange({ id: o.id, name: o.name })}
                 className="accent-primary"
               />
               <div>
@@ -865,6 +878,7 @@ type CeoPickSource = "auto" | "user" | null;
 
 function ParticipantsStep({
   organizationId,
+  orgName,
   respondentIds,
   ceoRespondentId,
   onChange,
@@ -872,6 +886,8 @@ function ParticipantsStep({
   onNext,
 }: {
   organizationId: string;
+  /** Display name of the selected org — used for the quick-add modal hint. */
+  orgName: string;
   respondentIds: string[];
   ceoRespondentId: string | null;
   onChange: (rIds: string[], ceoId: string | null) => void;
@@ -882,6 +898,7 @@ function ParticipantsStep({
   const [teams, setTeams] = useState<ApiTeamNode[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
+  const [addMemberOpen, setAddMemberOpen] = useState(false);
   // Tracks whether the current ceoRespondentId was auto-derived (vs. user-clicked).
   const [ceoPickSource, setCeoPickSource] = useState<CeoPickSource>(null);
 
@@ -990,6 +1007,30 @@ function ParticipantsStep({
     } else {
       onChange(respondentIds, id);
     }
+  }
+
+  /**
+   * Called by AddMemberModal on successful create.
+   *
+   * Decision: we use the typed `created` payload returned directly from the
+   * modal (rather than a re-fetch + email match) because:
+   *  1. It's synchronous — no extra round-trip before we can check the id.
+   *  2. The `created.id` is authoritative (from the DB response).
+   *  3. The email-match approach would be ambiguous if the same email was
+   *     somehow added twice (e.g., re-opened after a network timeout).
+   *
+   * We still re-fetch the full respondents list so the new member appears in
+   * the picker with correct team grouping and full metadata. The auto-include
+   * sets `respondentIds` immediately (before the re-fetch resolves) so the
+   * CEO-suggestion useEffect fires on the next render with the new id already
+   * in the selection.
+   */
+  async function handleMemberCreated(result: MemberCreatedResult) {
+    const newId = result.created.id;
+    // 1. Auto-include the new member.
+    onChange([...respondentIds, newId], ceoRespondentId);
+    // 2. Re-fetch so the picker row renders with correct metadata + team group.
+    await refresh();
   }
 
   // Build ordered team groups (flattened, with depth) + an "unassigned"
@@ -1102,6 +1143,18 @@ function ParticipantsStep({
           </Link>
           .
         </p>
+        <div className="mt-3">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={loading}
+            onClick={() => setAddMemberOpen(true)}
+          >
+            <UserPlus className="w-4 h-4 mr-2" />
+            Add new member
+          </Button>
+        </div>
       </div>
 
       {loading ? (
@@ -1171,6 +1224,21 @@ function ParticipantsStep({
           Next <ArrowRight className="w-4 h-4 ml-2" />
         </Button>
       </div>
+
+      {/* Quick-add modal — creates the member in the org roster, then auto-includes them */}
+      <AddMemberModal
+        open={addMemberOpen}
+        onClose={() => setAddMemberOpen(false)}
+        onCreated={(result) => {
+          // The modal calls onClose() itself after onCreated(), so we don't
+          // need to close manually here. Just trigger the auto-include + re-fetch.
+          void handleMemberCreated(result);
+        }}
+        orgId={organizationId}
+        teams={teams}
+        defaultTeamId={null}
+        description={`Adds this person to ${orgName || "this company"}'s roster (not just this campaign).`}
+      />
     </div>
   );
 }

--- a/src/src/components/organizations/add-member-modal.tsx
+++ b/src/src/components/organizations/add-member-modal.tsx
@@ -40,9 +40,22 @@ import { RESPONDENT_LEVELS } from "@/lib/assessments/respondent-levels";
 // Types
 // ---------------------------------------------------------------------------
 
+/** Typed shape of the created respondent passed back to callers. */
+export type CreatedRespondent = {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  jobTitle: string | null;
+  teamId: string | null;
+  roleType: string | null;
+};
+
 /** What we call back with on success */
 export type MemberCreatedResult = {
   respondent: Record<string, unknown>;
+  /** Typed shortcut — same data as `respondent` but with a guaranteed shape. */
+  created: CreatedRespondent;
 };
 
 export interface AddMemberModalProps {
@@ -57,6 +70,12 @@ export interface AddMemberModalProps {
   defaultTeamId: string | null;
   /** True while the parent is fetching teams for this org */
   loadingTeams?: boolean;
+  /**
+   * Optional override for the DialogDescription text.
+   * When omitted the default "Add a respondent to this organization." text is used.
+   * Pass from the campaign wizard to show the decision-#8 roster hint.
+   */
+  description?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -80,6 +99,7 @@ export function AddMemberModal({
   teams,
   defaultTeamId,
   loadingTeams = false,
+  description,
 }: AddMemberModalProps) {
   const firstNameId = useId();
   const lastNameId  = useId();
@@ -170,7 +190,17 @@ export function AddMemberModal({
         return;
       }
 
-      onCreated({ respondent: json.data as Record<string, unknown> });
+      const raw = json.data as Record<string, unknown>;
+      const created: CreatedRespondent = {
+        id:        String(raw.id        ?? ""),
+        firstName: String(raw.firstName ?? ""),
+        lastName:  String(raw.lastName  ?? ""),
+        email:     String(raw.email     ?? ""),
+        jobTitle:  raw.jobTitle  != null ? String(raw.jobTitle)  : null,
+        teamId:    raw.teamId    != null ? String(raw.teamId)    : null,
+        roleType:  raw.roleType  != null ? String(raw.roleType)  : null,
+      };
+      onCreated({ respondent: raw, created });
       onClose();
     } catch {
       setError("An unexpected error occurred. Please try again.");
@@ -189,7 +219,7 @@ export function AddMemberModal({
         <DialogHeader>
           <DialogTitle>Add Member</DialogTitle>
           <DialogDescription>
-            Add a respondent to this organization. Fields marked * are required.
+            {description ?? "Add a respondent to this organization. Fields marked * are required."}
           </DialogDescription>
         </DialogHeader>
 

--- a/src/src/components/organizations/import-members-modal.tsx
+++ b/src/src/components/organizations/import-members-modal.tsx
@@ -1,0 +1,388 @@
+"use client";
+
+/**
+ * ImportMembersModal — bulk CSV import of respondents into one organization.
+ *
+ * Calls POST /api/organizations/[id]/respondents/bulk with the pre-parsed rows
+ * and the chosen conflict-resolution mode (skip / merge).
+ *
+ * Mirrors AddMemberModal / AddTeamModal conventions exactly:
+ *   - Dialog + DialogDescription for a11y
+ *   - submitting guard, setError(null) reset on open/attempt
+ *   - res.ok && json.success checks
+ *   - Array.isArray(json.error) ? json.error[0]?.message : ... unwrap
+ *   - awaitable onUpdated() awaited BEFORE onClose()
+ *
+ * PROPS
+ * ─────
+ * open        — controls visibility
+ * onClose     — called when modal should close (cancel or after success + display)
+ * onUpdated   — awaitable callback; called after a successful import so the
+ *               caller can refresh the member list
+ * orgId       — the organization whose /respondents/bulk endpoint we post to
+ * orgName     — displayed in the dialog title for context
+ */
+
+import React, { useState, useEffect, useMemo, useCallback } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  parseRespondentCsv,
+  type ParsedRow,
+  type ParseError,
+} from "@/lib/assessments/respondent-csv";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type ConflictMode = "skip" | "merge";
+
+interface ImportResult {
+  created: Array<{ id: string; email: string }>;
+  updated: Array<{ id: string; email: string }>;
+  skipped: Array<{ email: string }>;
+  errors:  Array<{ row: number; reason: string }>;
+}
+
+export interface ImportMembersModalProps {
+  open:      boolean;
+  onClose:   () => void;
+  onUpdated: () => void | Promise<void>;
+  orgId:     string;
+  orgName:   string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const PREVIEW_ROW_LIMIT = 10;
+const ERROR_DISPLAY_LIMIT = 5;
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function ImportMembersModal({
+  open,
+  onClose,
+  onUpdated,
+  orgId,
+  orgName,
+}: ImportMembersModalProps) {
+  // --------------------------------------------------------------------------
+  // Form state
+  // --------------------------------------------------------------------------
+
+  const [csvText,    setCsvText]    = useState("");
+  const [mode,       setMode]       = useState<ConflictMode>("skip");
+
+  // Submission / result state
+  const [submitting, setSubmitting] = useState(false);
+  const [error,      setError]      = useState<string | null>(null);
+  const [result,     setResult]     = useState<ImportResult | null>(null);
+
+  // --------------------------------------------------------------------------
+  // Reset state on open/close
+  // --------------------------------------------------------------------------
+
+  useEffect(() => {
+    if (open) {
+      setCsvText("");
+      setMode("skip");
+      setError(null);
+      setResult(null);
+    }
+  }, [open]);
+
+  // --------------------------------------------------------------------------
+  // Live parse
+  // --------------------------------------------------------------------------
+
+  const { rows, errors: parseErrors } = useMemo<{ rows: ParsedRow[]; errors: ParseError[] }>(
+    () => {
+      if (!csvText.trim()) return { rows: [], errors: [] };
+      return parseRespondentCsv(csvText);
+    },
+    [csvText]
+  );
+
+  const canImport = rows.length > 0 && parseErrors.length === 0 && !submitting && result === null;
+
+  // --------------------------------------------------------------------------
+  // Submit
+  // --------------------------------------------------------------------------
+
+  const handleSubmit = useCallback(async () => {
+    setError(null);
+
+    if (!canImport) return;
+
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/organizations/${orgId}/respondents/bulk`, {
+        method:  "POST",
+        headers: { "Content-Type": "application/json" },
+        body:    JSON.stringify({ rows, mode }),
+      });
+
+      const json = await res.json() as {
+        success: boolean;
+        data?: ImportResult;
+        error?: unknown;
+      };
+
+      if (!res.ok || !json.success) {
+        const errMsg = Array.isArray(json.error)
+          ? ((json.error as Array<{ message?: string }>)[0]?.message ?? "Import failed. Please try again.")
+          : typeof json.error === "string"
+          ? json.error
+          : "Import failed. Please try again.";
+        setError(errMsg);
+        return;
+      }
+
+      // Success — show summary, then notify + close after brief display
+      const importResult = json.data!;
+      setResult(importResult);
+      await onUpdated();
+
+      // Give the user ~1.5 s to read the summary, then close
+      setTimeout(() => {
+        onClose();
+      }, 1500);
+    } catch {
+      setError("An unexpected error occurred. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }, [canImport, orgId, rows, mode, onUpdated, onClose]);
+
+  // --------------------------------------------------------------------------
+  // Derived display values
+  // --------------------------------------------------------------------------
+
+  const previewRows  = rows.slice(0, PREVIEW_ROW_LIMIT);
+  const shownErrors  = parseErrors.slice(0, ERROR_DISPLAY_LIMIT);
+  const hiddenErrors = parseErrors.length - shownErrors.length;
+
+  const importBtnLabel = (() => {
+    if (submitting)     return "Importing…";
+    if (rows.length > 0) return `Import ${rows.length} respondent${rows.length === 1 ? "" : "s"}`;
+    return "Import";
+  })();
+
+  const importTotal = result
+    ? result.created.length + result.updated.length
+    : 0;
+
+  // --------------------------------------------------------------------------
+  // Render
+  // --------------------------------------------------------------------------
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(isOpen) => { if (!isOpen) onClose(); }}
+    >
+      <DialogContent className="sm:max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Import members — {orgName}</DialogTitle>
+          <DialogDescription>
+            Paste a CSV with one member per row. Required headers:{" "}
+            <code className="text-xs bg-muted px-1 rounded">name</code>,{" "}
+            <code className="text-xs bg-muted px-1 rounded">email</code>
+            {" "}— plus optional{" "}
+            <code className="text-xs bg-muted px-1 rounded">team</code>{" "}
+            (use <code className="text-xs bg-muted px-1 rounded">/</code> to
+            separate nested paths, e.g.{" "}
+            <code className="text-xs bg-muted px-1 rounded">Engineering/Frontend</code>).
+            <br />
+            Example:{" "}
+            <code className="text-xs bg-muted px-1 rounded">
+              Alice Smith,alice@company.com,Engineering/Frontend
+            </code>
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          {/* ---------------------------------------------------------------- */}
+          {/* Paste area                                                        */}
+          {/* ---------------------------------------------------------------- */}
+          <div className="space-y-1.5">
+            <Label htmlFor="csv-paste-area">CSV data</Label>
+            <textarea
+              id="csv-paste-area"
+              rows={10}
+              placeholder={"name,email,team\nAlice Smith,alice@company.com,Engineering\nBob Jones,bob@company.com,"}
+              value={csvText}
+              onChange={(e) => setCsvText(e.target.value)}
+              disabled={submitting || result !== null}
+              className="w-full font-mono text-xs rounded-md border border-input bg-background px-3 py-2 shadow-sm resize-y ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+            />
+          </div>
+
+          {/* ---------------------------------------------------------------- */}
+          {/* Live preview summary + table                                      */}
+          {/* ---------------------------------------------------------------- */}
+          {csvText.trim().length > 0 && (
+            <div className="space-y-2">
+              {/* Summary line — kept as plain text so test matchers work */}
+              <p
+                data-testid="csv-parse-summary"
+                className="text-sm text-muted-foreground"
+              >
+                {parseErrors.length > 0
+                  ? `Parsed ${rows.length} row${rows.length === 1 ? "" : "s"}, ${parseErrors.length} error${parseErrors.length === 1 ? "" : "s"}.`
+                  : `Parsed ${rows.length} row${rows.length === 1 ? "" : "s"}.`}
+              </p>
+
+              {/* Parse errors */}
+              {parseErrors.length > 0 && (
+                <ul className="space-y-1">
+                  {shownErrors.map((e, i) => (
+                    <li
+                      key={i}
+                      className="rounded-md bg-destructive/10 px-3 py-1.5 text-xs text-destructive"
+                    >
+                      <span className="font-medium">Row {e.row}:</span>{" "}
+                      {e.reason}
+                    </li>
+                  ))}
+                  {hiddenErrors > 0 && (
+                    <li className="text-xs text-muted-foreground pl-3">
+                      …and {hiddenErrors} more error{hiddenErrors === 1 ? "" : "s"}.
+                    </li>
+                  )}
+                </ul>
+              )}
+
+              {/* Preview table (first N rows) */}
+              {rows.length > 0 && (
+                <div className="overflow-x-auto rounded-md border border-border">
+                  <table className="w-full text-xs">
+                    <thead>
+                      <tr className="border-b border-border bg-muted/40">
+                        <th className="px-3 py-2 text-left font-medium text-muted-foreground">Name</th>
+                        <th className="px-3 py-2 text-left font-medium text-muted-foreground">Email</th>
+                        <th className="px-3 py-2 text-left font-medium text-muted-foreground">Team</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {previewRows.map((r, i) => (
+                        <tr key={i} className="border-b border-border last:border-0">
+                          <td className="px-3 py-1.5 text-foreground">{r.name}</td>
+                          <td className="px-3 py-1.5 text-muted-foreground">{r.email}</td>
+                          <td className="px-3 py-1.5 text-muted-foreground">
+                            {r.teamPath.length > 0 ? r.teamPath.join(" / ") : "—"}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                  {rows.length > PREVIEW_ROW_LIMIT && (
+                    <p className="px-3 py-2 text-xs text-muted-foreground border-t border-border">
+                      Showing first {PREVIEW_ROW_LIMIT} of {rows.length} rows.
+                    </p>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* ---------------------------------------------------------------- */}
+          {/* Conflict mode                                                     */}
+          {/* ---------------------------------------------------------------- */}
+          <fieldset className="space-y-1.5">
+            <legend className="text-sm font-medium text-foreground">
+              If a member already exists (same email)
+            </legend>
+            <div className="flex items-center gap-4 pt-1">
+              <label className="flex items-center gap-1.5 text-sm cursor-pointer">
+                <input
+                  type="radio"
+                  name="conflict-mode"
+                  value="skip"
+                  checked={mode === "skip"}
+                  onChange={() => setMode("skip")}
+                  disabled={submitting || result !== null}
+                  aria-label="Skip — leave existing untouched"
+                />
+                Skip — leave existing untouched
+              </label>
+              <label className="flex items-center gap-1.5 text-sm cursor-pointer">
+                <input
+                  type="radio"
+                  name="conflict-mode"
+                  value="merge"
+                  checked={mode === "merge"}
+                  onChange={() => setMode("merge")}
+                  disabled={submitting || result !== null}
+                  aria-label="Merge — update name and team"
+                />
+                Merge — update name and team
+              </label>
+            </div>
+          </fieldset>
+
+          {/* ---------------------------------------------------------------- */}
+          {/* Result summary (post-success)                                     */}
+          {/* ---------------------------------------------------------------- */}
+          {result !== null && (
+            <div className="rounded-md bg-success/10 border border-success/20 px-4 py-3 space-y-1">
+              <p className="text-sm font-medium text-success">
+                Imported {importTotal}{" "}
+                {importTotal === 1 ? "respondent" : "respondents"}.
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {result.created.length} created,{" "}
+                {result.updated.length} updated,{" "}
+                {result.skipped.length} skipped,{" "}
+                {result.errors.length} errors.
+              </p>
+            </div>
+          )}
+
+          {/* ---------------------------------------------------------------- */}
+          {/* Inline error (network / server)                                   */}
+          {/* ---------------------------------------------------------------- */}
+          {error && (
+            <p
+              role="alert"
+              className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive"
+            >
+              {error}
+            </p>
+          )}
+        </div>
+
+        <DialogFooter className="mt-4">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onClose}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!canImport}
+          >
+            {importBtnLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/src/components/organizations/import-members-modal.tsx
+++ b/src/src/components/organizations/import-members-modal.tsx
@@ -23,7 +23,7 @@
  * orgName     — displayed in the dialog title for context
  */
 
-import React, { useState, useEffect, useMemo, useCallback } from "react";
+import React, { useState, useEffect, useMemo, useCallback, useRef, useId } from "react";
 import {
   Dialog,
   DialogContent,
@@ -67,6 +67,7 @@ export interface ImportMembersModalProps {
 
 const PREVIEW_ROW_LIMIT = 10;
 const ERROR_DISPLAY_LIMIT = 5;
+const ROW_ERROR_DISPLAY_LIMIT = 20;
 
 // ---------------------------------------------------------------------------
 // Component
@@ -83,6 +84,8 @@ export function ImportMembersModal({
   // Form state
   // --------------------------------------------------------------------------
 
+  const csvId = useId();
+
   const [csvText,    setCsvText]    = useState("");
   const [mode,       setMode]       = useState<ConflictMode>("skip");
 
@@ -90,6 +93,10 @@ export function ImportMembersModal({
   const [submitting, setSubmitting] = useState(false);
   const [error,      setError]      = useState<string | null>(null);
   const [result,     setResult]     = useState<ImportResult | null>(null);
+
+  // Guard against double-close during the 1.5 s auto-close timeout (I2)
+  const closeTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const closedRef       = useRef(false);
 
   // --------------------------------------------------------------------------
   // Reset state on open/close
@@ -101,6 +108,16 @@ export function ImportMembersModal({
       setMode("skip");
       setError(null);
       setResult(null);
+      closedRef.current = false;
+    } else {
+      // If the modal closes (prop goes false) while the auto-close timeout is
+      // pending (e.g. Escape / overlay click), cancel the timeout so onClose
+      // is not called a second time.
+      if (closeTimeoutRef.current !== null) {
+        clearTimeout(closeTimeoutRef.current);
+        closeTimeoutRef.current = null;
+      }
+      closedRef.current = true;
     }
   }, [open]);
 
@@ -151,15 +168,23 @@ export function ImportMembersModal({
         return;
       }
 
-      // Success — show summary, then notify + close after brief display
+      // Success — show summary. If there are row-level errors keep the modal
+      // open so the user can read them; otherwise auto-close after ~1.5 s.
       const importResult = json.data!;
       setResult(importResult);
       await onUpdated();
 
-      // Give the user ~1.5 s to read the summary, then close
-      setTimeout(() => {
-        onClose();
-      }, 1500);
+      if (importResult.errors.length === 0) {
+        // No row errors — give the user ~1.5 s to read the summary, then close
+        closeTimeoutRef.current = setTimeout(() => {
+          closeTimeoutRef.current = null;
+          if (!closedRef.current) {
+            closedRef.current = true;
+            onClose();
+          }
+        }, 1500);
+      }
+      // If there are row errors, stay open; the user must click Cancel/Close manually.
     } catch {
       setError("An unexpected error occurred. Please try again.");
     } finally {
@@ -174,6 +199,10 @@ export function ImportMembersModal({
   const previewRows  = rows.slice(0, PREVIEW_ROW_LIMIT);
   const shownErrors  = parseErrors.slice(0, ERROR_DISPLAY_LIMIT);
   const hiddenErrors = parseErrors.length - shownErrors.length;
+
+  // Row-level errors returned by the server on a partial-success response (C1)
+  const shownRowErrors  = result ? result.errors.slice(0, ROW_ERROR_DISPLAY_LIMIT) : [];
+  const hiddenRowErrors = result ? result.errors.length - shownRowErrors.length : 0;
 
   const importBtnLabel = (() => {
     if (submitting)     return "Importing…";
@@ -219,9 +248,9 @@ export function ImportMembersModal({
           {/* Paste area                                                        */}
           {/* ---------------------------------------------------------------- */}
           <div className="space-y-1.5">
-            <Label htmlFor="csv-paste-area">CSV data</Label>
+            <Label htmlFor={csvId}>CSV data</Label>
             <textarea
-              id="csv-paste-area"
+              id={csvId}
               rows={10}
               placeholder={"name,email,team\nAlice Smith,alice@company.com,Engineering\nBob Jones,bob@company.com,"}
               value={csvText}
@@ -248,7 +277,7 @@ export function ImportMembersModal({
 
               {/* Parse errors */}
               {parseErrors.length > 0 && (
-                <ul className="space-y-1">
+                <ul role="alert" className="space-y-1">
                   {shownErrors.map((e, i) => (
                     <li
                       key={i}
@@ -338,18 +367,47 @@ export function ImportMembersModal({
           {/* Result summary (post-success)                                     */}
           {/* ---------------------------------------------------------------- */}
           {result !== null && (
-            <div className="rounded-md bg-success/10 border border-success/20 px-4 py-3 space-y-1">
-              <p className="text-sm font-medium text-success">
-                Imported {importTotal}{" "}
-                {importTotal === 1 ? "respondent" : "respondents"}.
-              </p>
-              <p className="text-xs text-muted-foreground">
-                {result.created.length} created,{" "}
-                {result.updated.length} updated,{" "}
-                {result.skipped.length} skipped,{" "}
-                {result.errors.length} errors.
-              </p>
-            </div>
+            <>
+              <div
+                role="status"
+                className="rounded-md bg-success/10 border border-success/20 px-4 py-3 space-y-1"
+              >
+                <p className="text-sm font-medium text-success">
+                  Imported {importTotal}{" "}
+                  {importTotal === 1 ? "respondent" : "respondents"}.
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {result.created.length} created,{" "}
+                  {result.updated.length} updated,{" "}
+                  {result.skipped.length} skipped,{" "}
+                  {result.errors.length} errors.
+                </p>
+              </div>
+
+              {/* Row-level partial-success errors (C1) */}
+              {shownRowErrors.length > 0 && (
+                <ul
+                  role="alert"
+                  className="space-y-1 mt-2"
+                  aria-label="Row import errors"
+                >
+                  {shownRowErrors.map((e, i) => (
+                    <li
+                      key={i}
+                      className="rounded-md bg-destructive/10 px-3 py-1.5 text-xs text-destructive"
+                    >
+                      <span className="font-medium">Row {e.row}:</span>{" "}
+                      {e.reason}
+                    </li>
+                  ))}
+                  {hiddenRowErrors > 0 && (
+                    <li className="text-xs text-muted-foreground pl-3">
+                      + {hiddenRowErrors} more…
+                    </li>
+                  )}
+                </ul>
+              )}
+            </>
           )}
 
           {/* ---------------------------------------------------------------- */}
@@ -372,7 +430,7 @@ export function ImportMembersModal({
             onClick={onClose}
             disabled={submitting}
           >
-            Cancel
+            {result !== null && result.errors.length > 0 ? "Close" : "Cancel"}
           </Button>
           <Button
             type="button"

--- a/src/src/components/organizations/members-teams-view.tsx
+++ b/src/src/components/organizations/members-teams-view.tsx
@@ -13,7 +13,7 @@
  */
 
 import React, { useState, useCallback, useRef } from "react";
-import { ChevronRight, ChevronDown, Building2, Users, UserPlus, FolderPlus, Pencil } from "lucide-react";
+import { ChevronRight, ChevronDown, Building2, Users, UserPlus, Upload, FolderPlus, Pencil } from "lucide-react";
 import { levelLabel } from "@/lib/assessments/respondent-levels";
 import { AddTeamModal } from "./add-team-modal";
 import type { CreatedResult } from "./add-team-modal";
@@ -25,6 +25,7 @@ import { EditMemberModal } from "./edit-member-modal";
 import type { EditMemberModalMember } from "./edit-member-modal";
 import { EditOrganizationModal } from "./edit-organization-modal";
 import type { EditOrganizationModalOrg } from "./edit-organization-modal";
+import { ImportMembersModal } from "./import-members-modal";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -176,6 +177,9 @@ export function MembersTeamsView({ initialOrganizations }: MembersTeamsViewProps
 
   // Add Member modal state
   const [addMemberOpen, setAddMemberOpen] = useState(false);
+
+  // Import Members (bulk CSV) modal state
+  const [importMembersOpen, setImportMembersOpen] = useState(false);
 
   // Edit Team modal state — null when closed
   const [editingTeam, setEditingTeam] = useState<EditTeamModalTeam | null>(null);
@@ -576,32 +580,55 @@ export function MembersTeamsView({ initialOrganizations }: MembersTeamsViewProps
           <h2 className="text-sm font-semibold text-foreground uppercase tracking-wide">
             {panelTitle ? `Members — ${panelTitle}` : "Members"}
           </h2>
-          <button
-            type="button"
-            disabled={!selectedNode}
-            onClick={() => {
-              if (!selectedNode) return;
-              // Resolve the org for this node and lazy-load teams if not yet fetched
-              const modalOrgId =
-                selectedNode.kind === "organization" ? selectedNode.id :
-                selectedNode.kind === "team"         ? selectedNode.orgId :
-                /* unassigned */                       selectedNode.orgId;
-              if (orgStates[modalOrgId]?.teams === null && !orgStates[modalOrgId]?.loadingTeams) {
-                loadTeams(modalOrgId);
-              }
-              setAddMemberOpen(true);
-            }}
-            title={selectedNode ? "Add Member" : "Select a company or team first"}
-            className={[
-              "p-1 rounded-md transition-colors",
-              selectedNode
-                ? "text-muted-foreground hover:text-foreground hover:bg-muted"
-                : "text-muted-foreground opacity-40 cursor-not-allowed",
-            ].join(" ")}
-            aria-label={selectedNode ? "Add Member" : "Add Member (select a node first)"}
-          >
-            <UserPlus className="w-4 h-4" />
-          </button>
+          <div className="flex items-center gap-1">
+            {/* Import members (bulk CSV) */}
+            <button
+              type="button"
+              disabled={!selectedNode}
+              onClick={() => {
+                if (!selectedNode) return;
+                setImportMembersOpen(true);
+              }}
+              title={selectedNode ? "Import members" : "Select a company or team first"}
+              className={[
+                "p-1 rounded-md transition-colors",
+                selectedNode
+                  ? "text-muted-foreground hover:text-foreground hover:bg-muted"
+                  : "text-muted-foreground opacity-40 cursor-not-allowed",
+              ].join(" ")}
+              aria-label={selectedNode ? "Import members" : "Import members (select a node first)"}
+            >
+              <Upload className="w-4 h-4" />
+            </button>
+
+            {/* Add single member */}
+            <button
+              type="button"
+              disabled={!selectedNode}
+              onClick={() => {
+                if (!selectedNode) return;
+                // Resolve the org for this node and lazy-load teams if not yet fetched
+                const modalOrgId =
+                  selectedNode.kind === "organization" ? selectedNode.id :
+                  selectedNode.kind === "team"         ? selectedNode.orgId :
+                  /* unassigned */                       selectedNode.orgId;
+                if (orgStates[modalOrgId]?.teams === null && !orgStates[modalOrgId]?.loadingTeams) {
+                  loadTeams(modalOrgId);
+                }
+                setAddMemberOpen(true);
+              }}
+              title={selectedNode ? "Add Member" : "Select a company or team first"}
+              className={[
+                "p-1 rounded-md transition-colors",
+                selectedNode
+                  ? "text-muted-foreground hover:text-foreground hover:bg-muted"
+                  : "text-muted-foreground opacity-40 cursor-not-allowed",
+              ].join(" ")}
+              aria-label={selectedNode ? "Add Member" : "Add Member (select a node first)"}
+            >
+              <UserPlus className="w-4 h-4" />
+            </button>
+          </div>
         </div>
 
         {!selectedNode && (
@@ -739,6 +766,28 @@ export function MembersTeamsView({ initialOrganizations }: MembersTeamsViewProps
         organizations={organizations}
         loadedTeams={loadedTeamsForModal}
       />
+
+      {/* ImportMembersModal — only mount when we have an org context */}
+      {selectedNode && (() => {
+        const importOrgId =
+          selectedNode.kind === "organization" ? selectedNode.id :
+          selectedNode.kind === "team"         ? selectedNode.orgId :
+          /* unassigned */                       selectedNode.orgId;
+        const importOrg = organizations.find((o) => o.id === importOrgId);
+        return (
+          <ImportMembersModal
+            open={importMembersOpen}
+            onClose={() => setImportMembersOpen(false)}
+            onUpdated={async () => {
+              if (selectedNode) {
+                await loadMembers(selectedNode);
+              }
+            }}
+            orgId={importOrgId}
+            orgName={importOrg?.name ?? importOrgId}
+          />
+        );
+      })()}
 
       {/* AddMemberModal — only mount when we have an org context */}
       {selectedNode && (() => {


### PR DESCRIPTION
## Summary
Two task in the Members & Teams lane and the campaign wizard, both wiring UI to existing backend.

- **Bulk CSV import** (`be0c21a` + Critical fix `54c79e1`): new `ImportMembersModal` reachable from an "Import members" button in the right Members panel header. Paste-area + live preview (parses client-side via `parseRespondentCsv`) + skip/merge conflict mode → `POST /api/organizations/[id]/respondents/bulk`. Import disabled while parse errors exist. **Critical caught in review**: server-returned row-level errors on partial success were silently dropped (only the COUNT showed); fixed by rendering each `Row N: reason` in a `role="alert"` list and keeping the modal open until the user closes when failures exist. Plus a double-close guard around the post-success setTimeout, `useId` for the textarea, and `role="status"` / `role="alert"` on the result + parse-error panels.
- **Wizard persistent quick-add** (`3281163`): "Add new member" button in `ParticipantsStep` opens the existing `AddMemberModal` with a DialogDescription override — **"Adds this person to {orgName}'s roster (not just this campaign)"** (per locked decision #8). `AddMemberModal.onCreated` extended (additively, backward-compat) to pass the typed `created` respondent — no email-roundtrip needed. New member auto-included in `respondentIds`; the existing Slice-3 CEO-from-Level state machine handles a quick-added CEO/Founder-Level member naturally (no special-casing).

## Test plan
- [x] **142/142** organizations suites green (11 suites) including the new ImportMembersModal suite + partial-success test
- [x] **17/17** wizard suite (4 new quick-add tests QA1–QA4 covering button visibility, modal description, auto-include + auto-fetch, CEO-from-Level handoff)
- [x] Full suite **2152 passing** + 3 known pre-existing failures only (`no-inline-tolocaledatestring` / `org-survey-exchange` / `assessment-campaigns/detail-route`) — files this branch never touched
- [x] `CI=true npx next build --turbopack` clean under the safety gate
- [x] Zero migrations; zero destructive ops
- [x] `AddMemberModal` API change is BC: the only existing non-test caller (`members-teams-view`) uses `_result: MemberCreatedResult` (intentionally ignored arg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)