### PR TITLE
fix(assessment): add Members to coach portal nav

### DIFF
--- a/src/src/__tests__/lib/coach-nav.test.ts
+++ b/src/src/__tests__/lib/coach-nav.test.ts
@@ -5,6 +5,7 @@ describe("coach navigation config", () => {
     expect(coachPrimaryNavItems.map((item) => item.href)).toEqual([
       "/portal/home",
       "/portal/workshops",
+      "/portal/members",
       "/portal/assessments",
       "/portal/registrations",
       "/portal/request",

--- a/src/src/lib/coach-nav.ts
+++ b/src/src/lib/coach-nav.ts
@@ -1,4 +1,5 @@
 import {
+  Building2,
   Calendar,
   ClipboardList,
   LayoutDashboard,
@@ -17,6 +18,7 @@ export interface CoachNavItem {
 export const coachPrimaryNavItems: CoachNavItem[] = [
   { href: "/portal/home", label: "Dashboard", icon: LayoutDashboard },
   { href: "/portal/workshops", label: "My Workshops", icon: Calendar },
+  { href: "/portal/members", label: "Members", icon: Building2 },
   { href: "/portal/assessments", label: "Assessments", icon: ClipboardList },
   { href: "/portal/registrations", label: "Registrations", icon: Users },
   { href: "/portal/request", label: "Request Workshop", icon: PlusCircle },


### PR DESCRIPTION
## Summary

- Adds **Members** entry to `coachPrimaryNavItems` between *My Workshops* and *Assessments* (Building2 icon)
- Closes a discoverability gap from Slice 2: `/portal/members` shipped but was never linked from the outer coach sidebar (the AssessmentsSidebar repoint was in a sidebar that doesn't render in the coach lane)
- Includes test update to `coach-nav.test.ts`

## Why this is its own PR

The fix was originally committed on the Slice 2 branch (`0452e26`) **47 min after** PR #19 squash-merged. The commit was orphaned and never made it to main. My CLAUDE.md anchor for Slice 2 claimed Members was exposed — this PR makes that true. Cherry-picked the original commit verbatim.

## Test plan

- [x] `npm test -- --testPathPatterns="coach-nav"` — 2/2 passing
- [x] `CI=true npx next build --turbopack` — clean
- [ ] Post-merge: verify Members link visible in coach portal nav on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)