### PR TITLE
feat(assessment): Slice 5 — coach landing companies + per-campaign metrics + CampaignDetail Team column + band labels

### DIFF
--- a/src/src/__tests__/components/assessments/CampaignStatusMetrics.test.tsx
+++ b/src/src/__tests__/components/assessments/CampaignStatusMetrics.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * Task 5.2 — CampaignStatusMetrics presentational component (TDD red phase first).
+ *
+ * Tests:
+ *  1. Renders all 5 tiles with correct labels + counts given a non-zero metrics object
+ *  2. Total tile shows the sum count exactly (uses input total, not recomputed)
+ *  3. Each tile has its expected data-testid
+ *  4. Renders zeros when metrics are all zero and emptyHint is NOT provided
+ *  5. Renders the emptyHint instead of tiles when metrics are all zero AND emptyHint IS provided
+ *  6. emptyHint triggers only when total === 0 (non-zero sub-counts still show tiles)
+ *  7. Compact mode applies smaller class names
+ *  8. className passthrough applied on the container
+ */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { CampaignStatusMetrics } from "@/components/assessments/CampaignStatusMetrics";
+import type { CampaignStatusMetrics as CampaignStatusMetricsType } from "@/lib/assessments/campaign-status-metrics";
+
+const nonZeroMetrics: CampaignStatusMetricsType = {
+  total: 12,
+  new: 2,
+  invited: 4,
+  started: 3,
+  completed: 3,
+  revoked: 0,
+};
+
+const zeroMetrics: CampaignStatusMetricsType = {
+  total: 0,
+  new: 0,
+  invited: 0,
+  started: 0,
+  completed: 0,
+  revoked: 0,
+};
+
+describe("CampaignStatusMetrics", () => {
+  it("renders all 5 tiles with correct labels and counts", () => {
+    render(<CampaignStatusMetrics metrics={nonZeroMetrics} />);
+
+    expect(screen.getByText("Total:")).toBeInTheDocument();
+    expect(screen.getByText("New:")).toBeInTheDocument();
+    expect(screen.getByText("Invited:")).toBeInTheDocument();
+    expect(screen.getByText("Started:")).toBeInTheDocument();
+    expect(screen.getByText("Completed:")).toBeInTheDocument();
+
+    expect(screen.getByTestId("campaign-status-metrics-total")).toHaveTextContent("12");
+    expect(screen.getByTestId("campaign-status-metrics-new")).toHaveTextContent("2");
+    expect(screen.getByTestId("campaign-status-metrics-invited")).toHaveTextContent("4");
+    expect(screen.getByTestId("campaign-status-metrics-started")).toHaveTextContent("3");
+    expect(screen.getByTestId("campaign-status-metrics-completed")).toHaveTextContent("3");
+  });
+
+  it("total tile shows the exact total from metrics (not recomputed)", () => {
+    const customMetrics: CampaignStatusMetricsType = {
+      total: 99,
+      new: 10,
+      invited: 20,
+      started: 30,
+      completed: 39,
+      revoked: 5,
+    };
+    render(<CampaignStatusMetrics metrics={customMetrics} />);
+    expect(screen.getByTestId("campaign-status-metrics-total")).toHaveTextContent("99");
+  });
+
+  it("each tile has its expected data-testid", () => {
+    render(<CampaignStatusMetrics metrics={nonZeroMetrics} />);
+
+    expect(screen.getByTestId("campaign-status-metrics-total")).toBeInTheDocument();
+    expect(screen.getByTestId("campaign-status-metrics-new")).toBeInTheDocument();
+    expect(screen.getByTestId("campaign-status-metrics-invited")).toBeInTheDocument();
+    expect(screen.getByTestId("campaign-status-metrics-started")).toBeInTheDocument();
+    expect(screen.getByTestId("campaign-status-metrics-completed")).toBeInTheDocument();
+  });
+
+  it("renders zero counts when all zero and emptyHint is NOT provided", () => {
+    render(<CampaignStatusMetrics metrics={zeroMetrics} />);
+
+    expect(screen.getByTestId("campaign-status-metrics-total")).toHaveTextContent("0");
+    expect(screen.getByTestId("campaign-status-metrics-new")).toHaveTextContent("0");
+    expect(screen.getByTestId("campaign-status-metrics-invited")).toHaveTextContent("0");
+    expect(screen.getByTestId("campaign-status-metrics-started")).toHaveTextContent("0");
+    expect(screen.getByTestId("campaign-status-metrics-completed")).toHaveTextContent("0");
+  });
+
+  it("renders emptyHint instead of tiles when total === 0 and emptyHint is provided", () => {
+    render(<CampaignStatusMetrics metrics={zeroMetrics} emptyHint="No participants yet" />);
+
+    expect(screen.getByText("No participants yet")).toBeInTheDocument();
+    expect(screen.queryByTestId("campaign-status-metrics-total")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("campaign-status-metrics-new")).not.toBeInTheDocument();
+  });
+
+  it("renders tiles (not emptyHint) when total > 0 even if emptyHint is provided", () => {
+    render(<CampaignStatusMetrics metrics={nonZeroMetrics} emptyHint="No participants yet" />);
+
+    expect(screen.queryByText("No participants yet")).not.toBeInTheDocument();
+    expect(screen.getByTestId("campaign-status-metrics-total")).toHaveTextContent("12");
+  });
+
+  it("compact mode adds smaller text class to the container", () => {
+    const { container } = render(
+      <CampaignStatusMetrics metrics={nonZeroMetrics} compact={true} />,
+    );
+    const wrapper = screen.getByTestId("campaign-status-metrics");
+    expect(wrapper.className).toMatch(/text-\[10px\]/);
+  });
+
+  it("non-compact mode does NOT have the compact text class", () => {
+    render(<CampaignStatusMetrics metrics={nonZeroMetrics} />);
+    const wrapper = screen.getByTestId("campaign-status-metrics");
+    expect(wrapper.className).not.toMatch(/text-\[10px\]/);
+  });
+
+  it("className passthrough is applied on the container", () => {
+    render(<CampaignStatusMetrics metrics={nonZeroMetrics} className="my-custom" />);
+    const wrapper = screen.getByTestId("campaign-status-metrics");
+    expect(wrapper.className).toContain("my-custom");
+  });
+
+  it("testIdPrefix override applies to container and all tiles", () => {
+    render(<CampaignStatusMetrics metrics={nonZeroMetrics} testIdPrefix="custom-prefix" />);
+
+    expect(screen.getByTestId("custom-prefix")).toBeInTheDocument();
+    expect(screen.getByTestId("custom-prefix-total")).toBeInTheDocument();
+    expect(screen.getByTestId("custom-prefix-completed")).toBeInTheDocument();
+  });
+});

--- a/src/src/__tests__/components/assessments/CampaignsListWithFilter.test.tsx
+++ b/src/src/__tests__/components/assessments/CampaignsListWithFilter.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * Task 5.3 — CampaignsListWithFilter grouped-by-company with per-campaign metrics (TDD).
+ *
+ * Tests:
+ *  1. Renders company sections — both company headers and their campaigns appear under the right company
+ *  2. Hides a company with zero matching campaigns after filter
+ *  3. CampaignStatusMetrics renders per campaign — tile group appears for each campaign
+ *  4. EmptyHint shown for DRAFT-with-zero-metrics, NOT for ACTIVE-with-zero-metrics
+ *  5. Global pill counts are correct — All/Draft/Active/Closed sum across companies
+ *  6. Empty campaigns array — component renders without crashing
+ */
+
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { CampaignsListWithFilter } from "@/components/assessments/CampaignsListWithFilter";
+import type { CampaignListItem } from "@/components/assessments/CampaignsListWithFilter";
+import type { CampaignStatusMetrics } from "@/lib/assessments/campaign-status-metrics";
+
+const zeroMetrics: CampaignStatusMetrics = {
+  total: 0,
+  new: 0,
+  invited: 0,
+  started: 0,
+  completed: 0,
+  revoked: 0,
+};
+
+const nonZeroMetrics: CampaignStatusMetrics = {
+  total: 10,
+  new: 2,
+  invited: 4,
+  started: 3,
+  completed: 1,
+  revoked: 0,
+};
+
+function makeCampaign(
+  overrides: Partial<CampaignListItem> & Pick<CampaignListItem, "id" | "organizationId" | "organizationName">
+): CampaignListItem {
+  return {
+    name: `Campaign ${overrides.id}`,
+    alias: `alias-${overrides.id}`,
+    status: "ACTIVE",
+    templateName: "QSP v2",
+    openAt: "2026-06-01T00:00:00.000Z",
+    metrics: nonZeroMetrics,
+    ...overrides,
+  };
+}
+
+// Two companies, mixed statuses
+const campaignAlphaA = makeCampaign({ id: "c1", organizationId: "org-alpha", organizationName: "Alpha Corp", status: "ACTIVE" });
+const campaignAlphaB = makeCampaign({ id: "c2", organizationId: "org-alpha", organizationName: "Alpha Corp", status: "DRAFT" });
+const campaignBetaA = makeCampaign({ id: "c3", organizationId: "org-beta", organizationName: "Beta Inc", status: "CLOSED" });
+const campaignBetaB = makeCampaign({ id: "c4", organizationId: "org-beta", organizationName: "Beta Inc", status: "ACTIVE" });
+
+const twoCompanyCampaigns: CampaignListItem[] = [
+  campaignAlphaA,
+  campaignAlphaB,
+  campaignBetaA,
+  campaignBetaB,
+];
+
+describe("CampaignsListWithFilter — grouped by company", () => {
+  // Test 1: Renders company sections with correct grouping
+  it("renders a heading for each company and campaigns appear under the right company", () => {
+    render(<CampaignsListWithFilter campaigns={twoCompanyCampaigns} />);
+
+    // Company headers — at least one element contains the company name
+    expect(screen.getAllByText(/Alpha Corp/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/Beta Inc/).length).toBeGreaterThanOrEqual(1);
+
+    // Campaigns appear (by name)
+    expect(screen.getByText("Campaign c1")).toBeInTheDocument();
+    expect(screen.getByText("Campaign c2")).toBeInTheDocument();
+    expect(screen.getByText("Campaign c3")).toBeInTheDocument();
+    expect(screen.getByText("Campaign c4")).toBeInTheDocument();
+  });
+
+  // Test 1b: Campaign count appears in company header
+  it("shows campaign count in company header", () => {
+    render(<CampaignsListWithFilter campaigns={twoCompanyCampaigns} />);
+    // Company name + count appear in the section heading
+    expect(screen.getAllByText(/Alpha Corp/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/Beta Inc/).length).toBeGreaterThanOrEqual(1);
+    // Count text appears near the headings
+    expect(screen.getAllByText(/2 campaigns/).length).toBeGreaterThanOrEqual(2);
+  });
+
+  // Test 2: Filtering hides companies with zero visible campaigns
+  it("hides a company section when all its campaigns are filtered out", () => {
+    render(<CampaignsListWithFilter campaigns={twoCompanyCampaigns} />);
+
+    // Click the CLOSED filter pill — only Beta Inc has a CLOSED campaign
+    fireEvent.click(screen.getByTestId("campaign-filter-pill-closed"));
+
+    // Beta Inc should still be visible (has a CLOSED campaign)
+    expect(screen.getAllByText(/Beta Inc/).length).toBeGreaterThanOrEqual(1);
+    // Alpha Corp has no CLOSED campaigns — should be hidden entirely
+    expect(screen.queryByText(/Alpha Corp/)).not.toBeInTheDocument();
+  });
+
+  // Test 2b: Filtering keeps companies that have matching campaigns
+  it("shows a company when it has campaigns matching the selected filter", () => {
+    render(<CampaignsListWithFilter campaigns={twoCompanyCampaigns} />);
+
+    // Click DRAFT filter — only Alpha Corp has a DRAFT campaign
+    fireEvent.click(screen.getByTestId("campaign-filter-pill-draft"));
+
+    expect(screen.getAllByText(/Alpha Corp/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByText(/Beta Inc/)).not.toBeInTheDocument();
+    expect(screen.getByText("Campaign c2")).toBeInTheDocument(); // the DRAFT one
+    expect(screen.queryByText("Campaign c1")).not.toBeInTheDocument(); // ACTIVE
+  });
+
+  // Test 3: CampaignStatusMetrics renders per campaign
+  it("renders a CampaignStatusMetrics tile group for each campaign", () => {
+    render(<CampaignsListWithFilter campaigns={twoCompanyCampaigns} />);
+
+    // Each campaign should have a metrics wrapper with testIdPrefix = "campaign-metrics-{id}"
+    // The container div has data-testid="campaign-metrics-c1" etc (exact match, not sub-tiles).
+    // Sub-tiles have "-total" "-new" suffix — use an exact array of the 4 container IDs.
+    const c1Group = screen.getByTestId("campaign-metrics-c1");
+    const c2Group = screen.getByTestId("campaign-metrics-c2");
+    const c3Group = screen.getByTestId("campaign-metrics-c3");
+    const c4Group = screen.getByTestId("campaign-metrics-c4");
+    expect(c1Group).toBeInTheDocument();
+    expect(c2Group).toBeInTheDocument();
+    expect(c3Group).toBeInTheDocument();
+    expect(c4Group).toBeInTheDocument();
+  });
+
+  // Test 3b: Metrics counts are wired through correctly
+  it("passes the precomputed metrics to each CampaignStatusMetrics with correct counts", () => {
+    const customMetrics: CampaignStatusMetrics = { total: 5, new: 1, invited: 2, started: 1, completed: 1, revoked: 0 };
+    const campaigns: CampaignListItem[] = [
+      makeCampaign({ id: "cx1", organizationId: "org-x", organizationName: "X Corp", metrics: customMetrics }),
+    ];
+    render(<CampaignsListWithFilter campaigns={campaigns} />);
+
+    // Total tile should show 5
+    const totalTile = screen.getByTestId("campaign-metrics-cx1-total");
+    expect(totalTile).toHaveTextContent("5");
+  });
+
+  // Test 4: EmptyHint shown for DRAFT with zero metrics, NOT for ACTIVE with zero metrics
+  it("shows empty hint for DRAFT campaign with total=0 metrics", () => {
+    const campaigns: CampaignListItem[] = [
+      makeCampaign({ id: "d1", organizationId: "org-a", organizationName: "Org A", status: "DRAFT", metrics: zeroMetrics }),
+    ];
+    render(<CampaignsListWithFilter campaigns={campaigns} />);
+    expect(screen.getByText(/No invitations yet/)).toBeInTheDocument();
+  });
+
+  it("does NOT show empty hint for ACTIVE campaign with total=0 metrics", () => {
+    const campaigns: CampaignListItem[] = [
+      makeCampaign({ id: "a1", organizationId: "org-a", organizationName: "Org A", status: "ACTIVE", metrics: zeroMetrics }),
+    ];
+    render(<CampaignsListWithFilter campaigns={campaigns} />);
+    expect(screen.queryByText(/No invitations yet/)).not.toBeInTheDocument();
+  });
+
+  // Test 5: Global pill counts sum correctly across companies
+  it("shows correct global pill counts summed across all companies", () => {
+    render(<CampaignsListWithFilter campaigns={twoCompanyCampaigns} />);
+
+    // All=4, DRAFT=1 (c2), ACTIVE=2 (c1,c4), CLOSED=1 (c3)
+    expect(screen.getByTestId("campaign-filter-count-all")).toHaveTextContent("4");
+    expect(screen.getByTestId("campaign-filter-count-draft")).toHaveTextContent("1");
+    expect(screen.getByTestId("campaign-filter-count-active")).toHaveTextContent("2");
+    expect(screen.getByTestId("campaign-filter-count-closed")).toHaveTextContent("1");
+  });
+
+  // Test 6: Empty campaigns array — renders without crashing
+  it("renders without crashing when campaigns is empty", () => {
+    const { container } = render(<CampaignsListWithFilter campaigns={[]} />);
+    expect(container).toBeTruthy();
+    // No company sections
+    expect(screen.queryByText(/campaigns$/)).not.toBeInTheDocument();
+  });
+
+  // Test 7: ALL filter restores all company sections
+  it("restores all company sections when ALL filter is selected after filtering", () => {
+    render(<CampaignsListWithFilter campaigns={twoCompanyCampaigns} />);
+
+    // Filter to CLOSED
+    fireEvent.click(screen.getByTestId("campaign-filter-pill-closed"));
+    expect(screen.queryByText(/Alpha Corp/)).not.toBeInTheDocument();
+
+    // Go back to ALL
+    fireEvent.click(screen.getByTestId("campaign-filter-pill-all"));
+    expect(screen.getAllByText(/Alpha Corp/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/Beta Inc/).length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/src/__tests__/components/assessments/campaign-detail-add-existing.test.tsx
+++ b/src/src/__tests__/components/assessments/campaign-detail-add-existing.test.tsx
@@ -68,6 +68,7 @@ const ALICE_ROW: CampaignRespondentRow = {
     email: "alice@acme.com",
     jobTitle: "CEO",
   },
+  teamSnapshot: { pathIds: [], pathLabels: [] },
   invitation: null,
   hasSubmission: false,
   submissionId: null,

--- a/src/src/__tests__/components/assessments/campaign-detail-band-pills.test.tsx
+++ b/src/src/__tests__/components/assessments/campaign-detail-band-pills.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * CampaignDetail — header aggregate metrics strip + per-row band pills (Slice 5, Task 5.5).
+ *
+ * Tests:
+ *  1. Header metrics strip renders with correct testidPrefix and counts for a known respondent set
+ *  2. PENDING + sentAt null → band-pill-new
+ *  3. SENT invitation → band-pill-invited
+ *  4. VIEWED invitation → band-pill-started
+ *  5. SUBMITTED invitation → band-pill-completed
+ *  6. Revoked invitation → band-pill-revoked
+ *  7. No OLD status-pill-pending / status-pill-sent testids in the Status column
+ *     (regression guard — per-row cells now use band labels, not raw enum strings)
+ */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    refresh: jest.fn(),
+    push: jest.fn(),
+    replace: jest.fn(),
+    back: jest.fn(),
+  }),
+}));
+
+jest.mock("@/components/assessments/AssessmentResultView", () => ({
+  AssessmentResultView: () => <div data-testid="mock-result-view" />,
+}));
+
+jest.mock("@/components/ui/use-toast", () => ({
+  useToast: () => ({ toast: jest.fn() }),
+}));
+
+import { CampaignDetail } from "@/components/assessments/CampaignDetail";
+import type {
+  CampaignOverview,
+  CampaignRespondentRow,
+} from "@/lib/assessments/campaign-detail";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+function makeOverview(): CampaignOverview {
+  return {
+    campaign: {
+      id: "camp-1",
+      name: "Band Pill Test Campaign",
+      alias: "band-pill-test",
+      status: "ACTIVE",
+      templateId: "tpl-1",
+      templateName: "QSP",
+      organizationId: "org-1",
+      organizationName: "Acme Corp",
+      openAt: new Date("2026-06-01T00:00:00Z"),
+      closeAt: null,
+      createdAt: new Date("2026-05-01T00:00:00Z"),
+      invitationSubject: null,
+      invitationBodyMarkdown: null,
+    },
+    stats: {
+      totalParticipants: 5,
+      invited: 2,
+      viewed: 1,
+      submitted: 1,
+      completionPct: 20,
+    },
+  };
+}
+
+function respondentRow(
+  id: string,
+  invitation: CampaignRespondentRow["invitation"],
+  hasSubmission = false,
+): CampaignRespondentRow {
+  return {
+    participantId: `part-${id}`,
+    respondent: {
+      id: `resp-${id}`,
+      firstName: "User",
+      lastName: id,
+      email: `${id}@test.com`,
+      jobTitle: null,
+    },
+    teamSnapshot: { pathIds: [], pathLabels: [] },
+    invitation,
+    hasSubmission,
+    submissionId: hasSubmission ? `sub-${id}` : null,
+    submittedAt: hasSubmission ? new Date("2026-06-10T12:00:00Z") : null,
+    isCEO: false,
+  };
+}
+
+const NOW = new Date("2026-06-05T10:00:00Z");
+
+// Five respondents covering all 5 bands:
+//   1 new (no invitation), 1 invited (SENT), 1 started (VIEWED), 1 completed (SUBMITTED), 1 revoked
+const MIXED_RESPONDENTS: CampaignRespondentRow[] = [
+  respondentRow("new", null),
+  respondentRow("invited", { id: "inv-2", status: "SENT", sentAt: NOW, revokedAt: null, resentCount: 0 }),
+  respondentRow("started", { id: "inv-3", status: "VIEWED", sentAt: NOW, revokedAt: null, resentCount: 0 }),
+  respondentRow("completed", { id: "inv-4", status: "SUBMITTED", sentAt: NOW, revokedAt: null, resentCount: 0 }, true),
+  respondentRow("revoked", { id: "inv-5", status: "SENT", sentAt: NOW, revokedAt: NOW, resentCount: 0 }),
+];
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+describe("CampaignDetail — header metrics strip (Task 5.5)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+  });
+
+  it("renders the metrics strip with correct testIdPrefix and counts", () => {
+    render(
+      <CampaignDetail
+        initialOverview={makeOverview()}
+        initialRespondents={MIXED_RESPONDENTS}
+      />,
+    );
+
+    // Strip container
+    expect(screen.getByTestId("campaign-detail-metrics")).toBeInTheDocument();
+
+    // 5 total respondents minus 1 revoked = 4 in the active bands
+    expect(screen.getByTestId("campaign-detail-metrics-total")).toHaveTextContent("4");
+    expect(screen.getByTestId("campaign-detail-metrics-new")).toHaveTextContent("1");
+    expect(screen.getByTestId("campaign-detail-metrics-invited")).toHaveTextContent("1");
+    expect(screen.getByTestId("campaign-detail-metrics-started")).toHaveTextContent("1");
+    expect(screen.getByTestId("campaign-detail-metrics-completed")).toHaveTextContent("1");
+  });
+
+  it("renders metrics strip with all zeros when no respondents", () => {
+    render(
+      <CampaignDetail
+        initialOverview={makeOverview()}
+        initialRespondents={[]}
+      />,
+    );
+
+    expect(screen.getByTestId("campaign-detail-metrics")).toBeInTheDocument();
+    expect(screen.getByTestId("campaign-detail-metrics-total")).toHaveTextContent("0");
+  });
+});
+
+describe("CampaignDetail — per-row band pills (Task 5.5)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+  });
+
+  it("renders band-pill-new for a PENDING invitation with null sentAt", () => {
+    const respondents = [respondentRow("a", null)];
+    render(<CampaignDetail initialOverview={makeOverview()} initialRespondents={respondents} />);
+    expect(screen.getByTestId("band-pill-new")).toBeInTheDocument();
+  });
+
+  it("renders band-pill-invited for a SENT invitation", () => {
+    const respondents = [
+      respondentRow("a", { id: "inv-a", status: "SENT", sentAt: NOW, revokedAt: null, resentCount: 0 }),
+    ];
+    render(<CampaignDetail initialOverview={makeOverview()} initialRespondents={respondents} />);
+    expect(screen.getByTestId("band-pill-invited")).toBeInTheDocument();
+  });
+
+  it("renders band-pill-started for a VIEWED invitation", () => {
+    const respondents = [
+      respondentRow("a", { id: "inv-a", status: "VIEWED", sentAt: NOW, revokedAt: null, resentCount: 0 }),
+    ];
+    render(<CampaignDetail initialOverview={makeOverview()} initialRespondents={respondents} />);
+    expect(screen.getByTestId("band-pill-started")).toBeInTheDocument();
+  });
+
+  it("renders band-pill-completed for a SUBMITTED invitation", () => {
+    const respondents = [
+      respondentRow("a", { id: "inv-a", status: "SUBMITTED", sentAt: NOW, revokedAt: null, resentCount: 0 }, true),
+    ];
+    render(<CampaignDetail initialOverview={makeOverview()} initialRespondents={respondents} />);
+    expect(screen.getByTestId("band-pill-completed")).toBeInTheDocument();
+  });
+
+  it("renders band-pill-revoked for a revoked invitation", () => {
+    const respondents = [
+      respondentRow("a", { id: "inv-a", status: "SENT", sentAt: NOW, revokedAt: NOW, resentCount: 0 }),
+    ];
+    render(<CampaignDetail initialOverview={makeOverview()} initialRespondents={respondents} />);
+    expect(screen.getByTestId("band-pill-revoked")).toBeInTheDocument();
+  });
+
+  it("does NOT render old status-pill-pending or status-pill-sent in the status column", () => {
+    // Regression guard — raw PENDING/SENT enum pills must be gone from the row Status cell.
+    render(
+      <CampaignDetail
+        initialOverview={makeOverview()}
+        initialRespondents={MIXED_RESPONDENTS}
+      />,
+    );
+
+    expect(screen.queryByTestId("status-pill-pending")).toBeNull();
+    expect(screen.queryByTestId("status-pill-sent")).toBeNull();
+    expect(screen.queryByTestId("status-pill-viewed")).toBeNull();
+    expect(screen.queryByTestId("status-pill-submitted")).toBeNull();
+  });
+});

--- a/src/src/__tests__/lib/assessments/campaign-detail.test.ts
+++ b/src/src/__tests__/lib/assessments/campaign-detail.test.ts
@@ -29,11 +29,18 @@ function participant(
   id: string,
   respondentId: string,
   firstName: string,
-  opts: { isCEO?: boolean; jobTitle?: string | null } = {},
+  opts: {
+    isCEO?: boolean;
+    jobTitle?: string | null;
+    teamPathAtAdd?: string[] | null;
+    teamLabelsAtAdd?: string[] | null;
+  } = {},
 ) {
   return {
     id,
     isCEO: opts.isCEO ?? false,
+    teamPathAtAdd: opts.teamPathAtAdd ?? null,
+    teamLabelsAtAdd: opts.teamLabelsAtAdd ?? null,
     respondent: {
       id: respondentId,
       firstName,
@@ -321,5 +328,48 @@ describe("getCampaignRespondents", () => {
     });
     const rows = await getCampaignRespondents(db, "c1");
     expect(rows[0].invitation?.revokedAt).toEqual(revokedAt);
+  });
+
+  it("teamSnapshot: null snapshot fields → empty arrays", async () => {
+    const db = buildDb({
+      participants: [participant("p1", "r1", "Alice")],
+      invitations: [],
+    });
+    const rows = await getCampaignRespondents(db, "c1");
+    expect(rows[0].teamSnapshot).toEqual({ pathIds: [], pathLabels: [] });
+  });
+
+  it("teamSnapshot: single-segment path → one label", async () => {
+    const db = buildDb({
+      participants: [
+        participant("p1", "r1", "Alice", {
+          teamPathAtAdd: ["org-1"],
+          teamLabelsAtAdd: ["Acme Corp"],
+        }),
+      ],
+      invitations: [],
+    });
+    const rows = await getCampaignRespondents(db, "c1");
+    expect(rows[0].teamSnapshot).toEqual({
+      pathIds: ["org-1"],
+      pathLabels: ["Acme Corp"],
+    });
+  });
+
+  it("teamSnapshot: multi-segment path → ids and labels preserved in order", async () => {
+    const db = buildDb({
+      participants: [
+        participant("p1", "r1", "Alice", {
+          teamPathAtAdd: ["t1", "t2", "t3"],
+          teamLabelsAtAdd: ["ABC Corp", "Engineering", "Backend"],
+        }),
+      ],
+      invitations: [],
+    });
+    const rows = await getCampaignRespondents(db, "c1");
+    expect(rows[0].teamSnapshot).toEqual({
+      pathIds: ["t1", "t2", "t3"],
+      pathLabels: ["ABC Corp", "Engineering", "Backend"],
+    });
   });
 });

--- a/src/src/__tests__/lib/assessments/campaign-status-metrics.test.ts
+++ b/src/src/__tests__/lib/assessments/campaign-status-metrics.test.ts
@@ -1,5 +1,6 @@
 import {
   computeCampaignStatusMetrics,
+  getInvitationBand,
   CampaignStatusMetricsInput,
 } from "../../../lib/assessments/campaign-status-metrics";
 
@@ -184,5 +185,56 @@ describe("computeCampaignStatusMetrics", () => {
     expect(result.new + result.invited + result.started + result.completed).toBe(
       result.total,
     );
+  });
+});
+
+describe("getInvitationBand", () => {
+  test("1. null invitation → 'new'", () => {
+    expect(getInvitationBand(null)).toBe("new");
+  });
+
+  test("2. PENDING + sentAt null → 'new'", () => {
+    expect(getInvitationBand(inv("PENDING", null))).toBe("new");
+  });
+
+  test("3. PENDING + sentAt set (defensive edge) → 'invited'", () => {
+    expect(getInvitationBand(inv("PENDING", new Date()))).toBe("invited");
+  });
+
+  test("4. SENT + sentAt set → 'invited'", () => {
+    expect(getInvitationBand(inv("SENT", new Date()))).toBe("invited");
+  });
+
+  test("5. VIEWED + sentAt set → 'started'", () => {
+    expect(getInvitationBand(inv("VIEWED", new Date()))).toBe("started");
+  });
+
+  test("6. SUBMITTED + sentAt set → 'completed'", () => {
+    expect(getInvitationBand(inv("SUBMITTED", new Date()))).toBe("completed");
+  });
+
+  test("7. revokedAt set (SENT) → 'revoked'", () => {
+    expect(getInvitationBand(inv("SENT", new Date(), new Date()))).toBe("revoked");
+  });
+
+  test("8. aggregator and per-row helper agree on a mixed batch", () => {
+    const rows: CampaignStatusMetricsInput[] = [
+      row("p-new-1", null),
+      row("p-inv-1", inv("SENT", new Date())),
+      row("p-start-1", inv("VIEWED", new Date())),
+      row("p-done-1", inv("SUBMITTED", new Date())),
+      row("p-rev-1", inv("SENT", new Date(), new Date())),
+    ];
+
+    // Per-row helper returns the same classifications as the aggregator.
+    const bands = rows.map((r) => getInvitationBand(r.invitation));
+    expect(bands).toEqual(["new", "invited", "started", "completed", "revoked"]);
+
+    const metrics = computeCampaignStatusMetrics(rows);
+    expect(metrics.new).toBe(1);
+    expect(metrics.invited).toBe(1);
+    expect(metrics.started).toBe(1);
+    expect(metrics.completed).toBe(1);
+    expect(metrics.revoked).toBe(1);
   });
 });

--- a/src/src/__tests__/lib/assessments/campaign-status-metrics.test.ts
+++ b/src/src/__tests__/lib/assessments/campaign-status-metrics.test.ts
@@ -1,0 +1,188 @@
+import {
+  computeCampaignStatusMetrics,
+  CampaignStatusMetricsInput,
+} from "../../../lib/assessments/campaign-status-metrics";
+
+function row(
+  participantId: string,
+  invitation: CampaignStatusMetricsInput["invitation"],
+): CampaignStatusMetricsInput {
+  return { participantId, invitation };
+}
+
+function inv(
+  status: "PENDING" | "SENT" | "VIEWED" | "SUBMITTED",
+  sentAt: Date | null,
+  revokedAt: Date | null = null,
+): CampaignStatusMetricsInput["invitation"] {
+  return { status, sentAt, revokedAt };
+}
+
+describe("computeCampaignStatusMetrics", () => {
+  test("1. empty array → all zeros", () => {
+    expect(computeCampaignStatusMetrics([])).toEqual({
+      total: 0,
+      new: 0,
+      invited: 0,
+      started: 0,
+      completed: 0,
+      revoked: 0,
+    });
+  });
+
+  test("2. single PENDING + sentAt null → new", () => {
+    const result = computeCampaignStatusMetrics([
+      row("p1", inv("PENDING", null)),
+    ]);
+    expect(result).toEqual({
+      total: 1,
+      new: 1,
+      invited: 0,
+      started: 0,
+      completed: 0,
+      revoked: 0,
+    });
+  });
+
+  test("3. single SENT → invited", () => {
+    const result = computeCampaignStatusMetrics([
+      row("p1", inv("SENT", new Date())),
+    ]);
+    expect(result).toEqual({
+      total: 1,
+      new: 0,
+      invited: 1,
+      started: 0,
+      completed: 0,
+      revoked: 0,
+    });
+  });
+
+  test("4. single VIEWED → started", () => {
+    const result = computeCampaignStatusMetrics([
+      row("p1", inv("VIEWED", new Date())),
+    ]);
+    expect(result).toEqual({
+      total: 1,
+      new: 0,
+      invited: 0,
+      started: 1,
+      completed: 0,
+      revoked: 0,
+    });
+  });
+
+  test("5. single SUBMITTED → completed", () => {
+    const result = computeCampaignStatusMetrics([
+      row("p1", inv("SUBMITTED", new Date())),
+    ]);
+    expect(result).toEqual({
+      total: 1,
+      new: 0,
+      invited: 0,
+      started: 0,
+      completed: 1,
+      revoked: 0,
+    });
+  });
+
+  test("6a. revoked+PENDING excluded from bands; revoked count goes up; total unaffected", () => {
+    const result = computeCampaignStatusMetrics([
+      row("p1", inv("PENDING", null, new Date())),
+    ]);
+    expect(result).toEqual({
+      total: 0,
+      new: 0,
+      invited: 0,
+      started: 0,
+      completed: 0,
+      revoked: 1,
+    });
+  });
+
+  test("6b. revoked+SUBMITTED also excluded from bands", () => {
+    const result = computeCampaignStatusMetrics([
+      row("p1", inv("SUBMITTED", new Date(), new Date())),
+    ]);
+    expect(result).toEqual({
+      total: 0,
+      new: 0,
+      invited: 0,
+      started: 0,
+      completed: 0,
+      revoked: 1,
+    });
+  });
+
+  test("7. participant with invitation null → counts as new", () => {
+    const result = computeCampaignStatusMetrics([row("p1", null)]);
+    expect(result).toEqual({
+      total: 1,
+      new: 1,
+      invited: 0,
+      started: 0,
+      completed: 0,
+      revoked: 0,
+    });
+  });
+
+  test("8. PENDING with sentAt non-null (edge case) → counts as invited", () => {
+    const result = computeCampaignStatusMetrics([
+      row("p1", inv("PENDING", new Date())),
+    ]);
+    expect(result).toEqual({
+      total: 1,
+      new: 0,
+      invited: 1,
+      started: 0,
+      completed: 0,
+      revoked: 0,
+    });
+  });
+
+  test("9. mixed batch: 1 new + 2 invited + 3 started + 4 completed + 1 revoked", () => {
+    const rows: CampaignStatusMetricsInput[] = [
+      // 1 new (no invitation)
+      row("p-new-1", null),
+      // 2 invited
+      row("p-inv-1", inv("SENT", new Date())),
+      row("p-inv-2", inv("SENT", new Date())),
+      // 3 started
+      row("p-start-1", inv("VIEWED", new Date())),
+      row("p-start-2", inv("VIEWED", new Date())),
+      row("p-start-3", inv("VIEWED", new Date())),
+      // 4 completed
+      row("p-done-1", inv("SUBMITTED", new Date())),
+      row("p-done-2", inv("SUBMITTED", new Date())),
+      row("p-done-3", inv("SUBMITTED", new Date())),
+      row("p-done-4", inv("SUBMITTED", new Date())),
+      // 1 revoked
+      row("p-rev-1", inv("SENT", new Date(), new Date())),
+    ];
+
+    const result = computeCampaignStatusMetrics(rows);
+
+    expect(result.new).toBe(1);
+    expect(result.invited).toBe(2);
+    expect(result.started).toBe(3);
+    expect(result.completed).toBe(4);
+    expect(result.revoked).toBe(1);
+    expect(result.total).toBe(10);
+  });
+
+  test("10. bands sum to total invariant", () => {
+    const rows: CampaignStatusMetricsInput[] = [
+      row("p-new-1", null),
+      row("p-inv-1", inv("SENT", new Date())),
+      row("p-start-1", inv("VIEWED", new Date())),
+      row("p-done-1", inv("SUBMITTED", new Date())),
+      row("p-rev-1", inv("PENDING", null, new Date())),
+    ];
+
+    const result = computeCampaignStatusMetrics(rows);
+
+    expect(result.new + result.invited + result.started + result.completed).toBe(
+      result.total,
+    );
+  });
+});

--- a/src/src/app/(portal)/portal/assessments/page.tsx
+++ b/src/src/app/(portal)/portal/assessments/page.tsx
@@ -1,7 +1,11 @@
 /**
- * Assessment v7.6 — Coach assessments landing page.
- * Lists campaigns the coach created. Top-right CTA → wizard.
- * Status filter pills (Task I) are handled in a client child component.
+ * Assessment v7.6 — Coach assessments landing page (Slice 5 Task 5.3).
+ *
+ * Lists campaigns the coach created, grouped by company (Organization).
+ * Each campaign carries precomputed staged-progress metrics
+ * (total / new / invited / started / completed) via computeCampaignStatusMetrics.
+ *
+ * Top-right CTA → wizard. Status filter pills are handled client-side.
  */
 
 import Link from "next/link";
@@ -13,28 +17,74 @@ import {
   CampaignsListWithFilter,
   type CampaignListItem,
 } from "@/components/assessments/CampaignsListWithFilter";
+import {
+  computeCampaignStatusMetrics,
+  type CampaignStatusMetricsInput,
+} from "@/lib/assessments/campaign-status-metrics";
 
 export default async function CoachAssessmentsPage() {
   const { coach } = await requireCoach();
 
+  // Single round-trip: include participants (for respondentId → invitation join)
+  // and invitations (for staged-progress metrics).
   const campaigns = await db.assessmentCampaign.findMany({
     where: { createdByCoachId: coach.id },
     include: {
       organization: { select: { id: true, name: true } },
       template: { select: { id: true, name: true } },
+      participants: {
+        select: { id: true, respondentId: true },
+      },
+      invitations: {
+        select: {
+          respondentId: true,
+          status: true,
+          sentAt: true,
+          revokedAt: true,
+        },
+      },
     },
     orderBy: { createdAt: "desc" },
   });
 
-  const items: CampaignListItem[] = campaigns.map((c) => ({
-    id: c.id,
-    name: c.name,
-    alias: c.alias,
-    status: c.status,
-    templateName: c.template.name,
-    organizationName: c.organization.name,
-    openAt: c.openAt.toISOString(),
-  }));
+  const items: CampaignListItem[] = campaigns.map((c) => {
+    // Build a lookup from respondentId → invitation row (1-to-1 per campaign)
+    const invByRespondentId = new Map(
+      c.invitations.map((inv) => [inv.respondentId, inv])
+    );
+
+    // Build the metrics input: one row per participant.
+    // AssessmentInvitationStatus enum values are a superset of the helper's
+    // PENDING | SENT | VIEWED | SUBMITTED — cast is safe because those are
+    // the only values the DB can hold for active (non-revoked) invitations.
+    const metricsInput: CampaignStatusMetricsInput[] = c.participants.map((p) => {
+      const inv = invByRespondentId.get(p.respondentId) ?? null;
+      return {
+        participantId: p.id,
+        invitation: inv
+          ? {
+              status: inv.status as "PENDING" | "SENT" | "VIEWED" | "SUBMITTED",
+              sentAt: inv.sentAt,
+              revokedAt: inv.revokedAt,
+            }
+          : null,
+      };
+    });
+
+    const metrics = computeCampaignStatusMetrics(metricsInput);
+
+    return {
+      id: c.id,
+      name: c.name,
+      alias: c.alias,
+      status: c.status,
+      templateName: c.template.name,
+      organizationId: c.organization.id,
+      organizationName: c.organization.name,
+      openAt: c.openAt.toISOString(),
+      metrics,
+    };
+  });
 
   return (
     <div className="space-y-6">

--- a/src/src/components/assessments/CampaignDetail.tsx
+++ b/src/src/components/assessments/CampaignDetail.tsx
@@ -16,7 +16,7 @@
  *  - public/wireframes-phase2/revisions/08-revised-individual-results.html
  */
 
-import { Fragment, useCallback, useEffect, useState } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import {
@@ -40,11 +40,16 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { AssessmentResultView } from "./AssessmentResultView";
+import { CampaignStatusMetrics } from "./CampaignStatusMetrics";
 import type {
   CampaignOverview,
   CampaignRespondentRow,
 } from "@/lib/assessments/campaign-detail";
 import type { ScoreResult } from "@/lib/assessments/scoring";
+import {
+  computeCampaignStatusMetrics,
+  getInvitationBand,
+} from "@/lib/assessments/campaign-status-metrics";
 
 const REASON_MAX_LENGTH = 500;
 
@@ -78,14 +83,25 @@ const CAMPAIGN_STATUS_TONE: Record<string, string> = {
   CLOSED: "bg-secondary/10 text-secondary-foreground ring-border",
 };
 
-const INV_STATUS_TONE: Record<string, string> = {
-  PENDING: "bg-muted text-muted-foreground ring-border",
-  SENT: "bg-primary/10 text-primary ring-primary/20",
-  VIEWED: "bg-warning/10 text-warning ring-warning/20",
-  SUBMITTED: "bg-success/10 text-success ring-success/20",
+const RESENDABLE = new Set(["PENDING", "SENT", "VIEWED"]);
+
+// Band tones and labels for per-row status display — must match
+// the CampaignStatusMetrics tile colours exactly.
+const BAND_TONE: Record<string, string> = {
+  new: "bg-muted text-muted-foreground ring-border",
+  invited: "bg-primary/10 text-primary ring-primary/20",
+  started: "bg-warning/10 text-warning ring-warning/20",
+  completed: "bg-success/10 text-success ring-success/20",
+  revoked: "bg-destructive/10 text-destructive ring-destructive/20",
 };
 
-const RESENDABLE = new Set(["PENDING", "SENT", "VIEWED"]);
+const BAND_LABEL: Record<string, string> = {
+  new: "New",
+  invited: "Invited",
+  started: "Started",
+  completed: "Completed",
+  revoked: "Revoked",
+};
 
 function formatDateTimeLocal(d: Date): string {
   const pad = (n: number) => n.toString().padStart(2, "0");
@@ -205,6 +221,26 @@ export function CampaignDetail({
   const campaign = overview.campaign;
   const isDraft = campaign.status === "DRAFT";
   const isClosed = campaign.status === "CLOSED";
+
+  // Derive header aggregate metrics from the current respondents list.
+  // Recomputes automatically whenever respondents changes (add/remove/refresh).
+  const headerMetrics = useMemo(
+    () =>
+      computeCampaignStatusMetrics(
+        respondents.map((r) => ({
+          participantId: r.participantId,
+          invitation: r.invitation
+            ? {
+                status: r.invitation.status,
+                sentAt: r.invitation.sentAt,
+                revokedAt: r.invitation.revokedAt,
+              }
+            : null,
+        })),
+      ),
+    [respondents],
+  );
+
   const closeActionLabel = isDraft ? "Discard Draft" : "Close Campaign";
   const closeDialogTitle = isDraft
     ? "Discard this draft?"
@@ -1057,6 +1093,13 @@ export function CampaignDetail({
         </div>
       )}
 
+      {/* Header aggregate metrics strip (Slice 5 Task 5.5) */}
+      <CampaignStatusMetrics
+        metrics={headerMetrics}
+        testIdPrefix="campaign-detail-metrics"
+        className="mb-3"
+      />
+
       {/* Respondents table */}
       <div
         className="bg-card border border-border rounded-xl overflow-hidden"
@@ -1258,10 +1301,27 @@ export function CampaignDetail({
                         )}
                       </td>
                       <td className="px-4 py-3">
-                        <StatusPill
-                          status={invStatus}
-                          toneMap={INV_STATUS_TONE}
-                        />
+                        {(() => {
+                          const band = getInvitationBand(
+                            row.invitation
+                              ? {
+                                  status: row.invitation.status,
+                                  sentAt: row.invitation.sentAt,
+                                  revokedAt: row.invitation.revokedAt,
+                                }
+                              : null,
+                          );
+                          const label = BAND_LABEL[band];
+                          const tone = BAND_TONE[band];
+                          return (
+                            <span
+                              className={`inline-flex items-center text-xs font-medium px-2 py-0.5 rounded ring-1 ${tone}`}
+                              data-testid={`band-pill-${band}`}
+                            >
+                              {label}
+                            </span>
+                          );
+                        })()}
                       </td>
                       <td className="px-4 py-3 text-sm text-muted-foreground">
                         {formatDateTime(row.invitation?.sentAt)}

--- a/src/src/components/assessments/CampaignDetail.tsx
+++ b/src/src/components/assessments/CampaignDetail.tsx
@@ -1146,6 +1146,9 @@ export function CampaignDetail({
                   Email
                 </th>
                 <th className="text-left px-4 py-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  Team
+                </th>
+                <th className="text-left px-4 py-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
                   Status
                 </th>
                 <th className="text-left px-4 py-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
@@ -1235,6 +1238,25 @@ export function CampaignDetail({
                       <td className="px-4 py-3 text-sm text-muted-foreground">
                         {row.respondent.email}
                       </td>
+                      <td
+                        className="px-4 py-3 text-sm"
+                        data-testid={`team-cell-${row.respondent.id}`}
+                      >
+                        {row.teamSnapshot.pathLabels.length === 0 ? (
+                          <span className="text-muted-foreground italic">—</span>
+                        ) : (
+                          <>
+                            <span className="text-foreground">
+                              {row.teamSnapshot.pathLabels[row.teamSnapshot.pathLabels.length - 1]}
+                            </span>
+                            {row.teamSnapshot.pathLabels.length > 1 && (
+                              <div className="text-xs text-muted-foreground">
+                                {row.teamSnapshot.pathLabels.join(" › ")}
+                              </div>
+                            )}
+                          </>
+                        )}
+                      </td>
                       <td className="px-4 py-3">
                         <StatusPill
                           status={invStatus}
@@ -1308,7 +1330,7 @@ export function CampaignDetail({
                     </tr>
                     {expanded && cached && (
                       <tr className="bg-muted/10">
-                        <td colSpan={6} className="px-4 py-4">
+                        <td colSpan={7} className="px-4 py-4">
                           <AssessmentResultView
                             result={cached.result}
                             version={cached.version}

--- a/src/src/components/assessments/CampaignStatusMetrics.tsx
+++ b/src/src/components/assessments/CampaignStatusMetrics.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { Users, Clock, Mail, Eye, CheckCircle2 } from "lucide-react";
+import type { CampaignStatusMetrics } from "@/lib/assessments/campaign-status-metrics";
+
+export interface CampaignStatusMetricsProps {
+  metrics: CampaignStatusMetrics;
+  emptyHint?: string;
+  className?: string;
+  compact?: boolean;
+  testIdPrefix?: string;
+}
+
+const TILES = [
+  {
+    band: "total",
+    label: "Total",
+    Icon: Users,
+    tileClass: "bg-muted text-foreground ring-border",
+  },
+  {
+    band: "new",
+    label: "New",
+    Icon: Clock,
+    tileClass: "bg-muted text-muted-foreground ring-border",
+  },
+  {
+    band: "invited",
+    label: "Invited",
+    Icon: Mail,
+    tileClass: "bg-primary/10 text-primary ring-primary/20",
+  },
+  {
+    band: "started",
+    label: "Started",
+    Icon: Eye,
+    tileClass: "bg-warning/10 text-warning ring-warning/20",
+  },
+  {
+    band: "completed",
+    label: "Completed",
+    Icon: CheckCircle2,
+    tileClass: "bg-success/10 text-success ring-success/20",
+  },
+] as const;
+
+export function CampaignStatusMetrics({
+  metrics,
+  emptyHint,
+  className,
+  compact = false,
+  testIdPrefix = "campaign-status-metrics",
+}: CampaignStatusMetricsProps): React.JSX.Element {
+  const containerClass = [
+    "flex flex-wrap gap-2",
+    compact ? "text-[10px]" : "text-xs",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  if (metrics.total === 0 && emptyHint) {
+    return (
+      <div data-testid={testIdPrefix} className={containerClass}>
+        <span className="text-muted-foreground">{emptyHint}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid={testIdPrefix} className={containerClass}>
+      {TILES.map(({ band, label, Icon, tileClass }) => (
+        <div
+          key={band}
+          data-testid={`${testIdPrefix}-${band}`}
+          className={`inline-flex items-center gap-1 font-medium px-2 py-1 rounded-md ring-1 ${tileClass}`}
+        >
+          <Icon className={compact ? "h-3 w-3" : "h-3.5 w-3.5"} />
+          <span>{label}:</span>
+          <span>{metrics[band]}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/src/components/assessments/CampaignsListWithFilter.tsx
+++ b/src/src/components/assessments/CampaignsListWithFilter.tsx
@@ -1,15 +1,22 @@
 "use client";
 
 /**
- * Assessment v7.6 — Coach campaigns landing list with status filter pills (Task I).
+ * Assessment v7.6 — Coach campaigns landing list grouped by company (Task 5.3 / Slice 5).
  *
- * Server component fetches the full campaign list; this client wrapper
- * renders the filter pills + the table and handles client-side filtering.
- * URL state is intentionally NOT persisted in this slice — keep it simple.
+ * Server component fetches the full campaign list with pre-computed metrics;
+ * this client wrapper renders:
+ *  - Global status filter pills (All / Draft / Active / Closed) with global counts.
+ *  - One section per company (Organization), alphabetically ordered.
+ *    Each section has a company header + per-campaign rows with staged-progress metrics.
+ *  - Companies with zero campaigns after filtering are hidden entirely.
+ *
+ * URL state is intentionally NOT persisted — keep it simple.
  */
 
 import { useMemo, useState } from "react";
 import Link from "next/link";
+import { CampaignStatusMetrics } from "@/components/assessments/CampaignStatusMetrics";
+import type { CampaignStatusMetrics as CampaignStatusMetricsType } from "@/lib/assessments/campaign-status-metrics";
 
 export type CampaignStatus = "DRAFT" | "ACTIVE" | "CLOSED";
 
@@ -19,8 +26,10 @@ export interface CampaignListItem {
   alias: string;
   status: CampaignStatus | string;
   templateName: string;
+  organizationId: string;
   organizationName: string;
   openAt: string; // ISO date so server -> client serializes safely
+  metrics: CampaignStatusMetricsType;
 }
 
 type FilterValue = "ALL" | CampaignStatus;
@@ -47,6 +56,87 @@ function formatDate(iso: string): string {
   });
 }
 
+// A company section — campaigns filtered by the active pill
+interface CompanySectionProps {
+  organizationName: string;
+  campaigns: CampaignListItem[];
+}
+
+function CompanySection({ organizationName, campaigns }: CompanySectionProps) {
+  const count = campaigns.length;
+  return (
+    <section className="space-y-2">
+      {/* Company header */}
+      <h2 className="text-sm font-semibold text-foreground flex items-center gap-2">
+        <span>{organizationName}</span>
+        <span className="text-muted-foreground font-normal">
+          &middot; {count} {count === 1 ? "campaign" : "campaigns"}
+        </span>
+      </h2>
+
+      {/* Campaign rows */}
+      <div className="bg-card border border-border rounded-xl overflow-hidden">
+        <div className="divide-y divide-border">
+          {campaigns.map((c) => {
+            const isDraftNoInvites = c.status === "DRAFT" && c.metrics.total === 0;
+            return (
+              <div
+                key={c.id}
+                className="px-4 py-3 space-y-2 hover:bg-muted/30 transition-colors"
+                data-testid={`campaign-row-${c.id}`}
+              >
+                {/* Top row: name + template + status + date + action */}
+                <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+                  <div className="min-w-0 flex-1">
+                    <Link
+                      href={`/portal/assessments/${c.id}`}
+                      className="font-medium text-foreground hover:text-primary text-sm"
+                    >
+                      {c.name}
+                    </Link>
+                    <div className="text-xs text-muted-foreground">{c.alias}</div>
+                  </div>
+                  <span className="text-xs text-muted-foreground hidden sm:inline">
+                    {c.templateName}
+                  </span>
+                  <span
+                    className={`inline-flex items-center text-xs font-medium px-2 py-0.5 rounded border ${
+                      STATUS_TONE[c.status] ?? "bg-muted text-muted-foreground border-border"
+                    }`}
+                  >
+                    {STATUS_LABELS[c.status] ?? c.status}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    Opens {formatDate(c.openAt)}
+                  </span>
+                  <Link
+                    href={`/portal/assessments/${c.id}`}
+                    className="text-xs text-primary hover:underline ml-auto"
+                  >
+                    View
+                  </Link>
+                </div>
+
+                {/* Metrics row */}
+                <CampaignStatusMetrics
+                  metrics={c.metrics}
+                  emptyHint={
+                    isDraftNoInvites
+                      ? "No invitations yet — activate the campaign to send."
+                      : undefined
+                  }
+                  compact
+                  testIdPrefix={`campaign-metrics-${c.id}`}
+                />
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}
+
 export function CampaignsListWithFilter({
   campaigns,
 }: {
@@ -54,6 +144,7 @@ export function CampaignsListWithFilter({
 }) {
   const [filter, setFilter] = useState<FilterValue>("ALL");
 
+  // Global counts across all companies
   const counts = useMemo(() => {
     const acc = { ALL: campaigns.length, DRAFT: 0, ACTIVE: 0, CLOSED: 0 };
     for (const c of campaigns) {
@@ -64,10 +155,38 @@ export function CampaignsListWithFilter({
     return acc;
   }, [campaigns]);
 
-  const visible = useMemo(() => {
-    if (filter === "ALL") return campaigns;
-    return campaigns.filter((c) => c.status === filter);
+  // Build company groups from the full (unfiltered) campaign list, then apply filter per section
+  const companyGroups = useMemo(() => {
+    // Group all campaigns by organizationId, preserving server order within each group
+    const groupMap = new Map<string, { name: string; campaigns: CampaignListItem[] }>();
+    for (const c of campaigns) {
+      if (!groupMap.has(c.organizationId)) {
+        groupMap.set(c.organizationId, { name: c.organizationName, campaigns: [] });
+      }
+      groupMap.get(c.organizationId)!.campaigns.push(c);
+    }
+
+    // Sort companies alphabetically by name
+    const groups = Array.from(groupMap.entries()).sort(([, a], [, b]) =>
+      a.name.localeCompare(b.name)
+    );
+
+    // Apply the active filter within each company
+    return groups.map(([orgId, group]) => ({
+      orgId,
+      name: group.name,
+      campaigns:
+        filter === "ALL"
+          ? group.campaigns
+          : group.campaigns.filter((c) => c.status === filter),
+    }));
   }, [campaigns, filter]);
+
+  // Only companies with at least one visible campaign
+  const visibleGroups = useMemo(
+    () => companyGroups.filter((g) => g.campaigns.length > 0),
+    [companyGroups]
+  );
 
   const pills: Array<{ value: FilterValue; label: string; count: number }> = [
     { value: "ALL", label: "All", count: counts.ALL },
@@ -78,6 +197,7 @@ export function CampaignsListWithFilter({
 
   return (
     <div className="space-y-4">
+      {/* Status filter pills */}
       <div
         className="flex flex-wrap items-center gap-2"
         role="group"
@@ -115,92 +235,25 @@ export function CampaignsListWithFilter({
         })}
       </div>
 
-      <div className="bg-card border border-border rounded-xl overflow-hidden">
-        <table className="w-full">
-          <thead className="bg-muted/50 border-b border-border">
-            <tr>
-              <th className="text-left px-4 py-3 text-sm font-semibold text-foreground">
-                Name
-              </th>
-              <th className="text-left px-4 py-3 text-sm font-semibold text-foreground">
-                Template
-              </th>
-              <th className="text-left px-4 py-3 text-sm font-semibold text-foreground">
-                Organization
-              </th>
-              <th className="text-left px-4 py-3 text-sm font-semibold text-foreground">
-                Status
-              </th>
-              <th className="text-left px-4 py-3 text-sm font-semibold text-foreground">
-                Opens
-              </th>
-              <th className="text-right px-4 py-3 text-sm font-semibold text-foreground">
-                Actions
-              </th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-border">
-            {visible.length === 0 ? (
-              <tr>
-                <td
-                  colSpan={6}
-                  className="px-4 py-12 text-center text-sm text-muted-foreground"
-                  data-testid="campaign-filter-empty"
-                >
-                  No campaigns in this status.
-                </td>
-              </tr>
-            ) : (
-              visible.map((c) => (
-                <tr
-                  key={c.id}
-                  className="hover:bg-muted/30 transition-colors"
-                  data-testid={`campaign-row-${c.id}`}
-                >
-                  <td className="px-4 py-3 text-sm">
-                    <Link
-                      href={`/portal/assessments/${c.id}`}
-                      className="font-medium text-foreground hover:text-primary"
-                    >
-                      {c.name}
-                    </Link>
-                    <div className="text-xs text-muted-foreground">
-                      {c.alias}
-                    </div>
-                  </td>
-                  <td className="px-4 py-3 text-sm text-muted-foreground">
-                    {c.templateName}
-                  </td>
-                  <td className="px-4 py-3 text-sm text-muted-foreground">
-                    {c.organizationName}
-                  </td>
-                  <td className="px-4 py-3 text-sm">
-                    <span
-                      className={`inline-flex items-center text-xs font-medium px-2 py-1 rounded border ${
-                        STATUS_TONE[c.status] ??
-                        "bg-muted text-muted-foreground border-border"
-                      }`}
-                    >
-                      {STATUS_LABELS[c.status] ?? c.status}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3 text-sm text-muted-foreground">
-                    {formatDate(c.openAt)}
-                  </td>
-                  <td className="px-4 py-3 text-sm text-right">
-                    <Link
-                      href={`/portal/assessments/${c.id}`}
-                      className="text-primary hover:underline"
-                    >
-                      View
-                    </Link>
-                  </td>
-                </tr>
-              ))
-            )}
-          </tbody>
-        </table>
-      </div>
+      {/* Company sections */}
+      {visibleGroups.length === 0 ? (
+        <div
+          className="px-4 py-12 text-center text-sm text-muted-foreground bg-card border border-border rounded-xl"
+          data-testid="campaign-filter-empty"
+        >
+          No campaigns in this status.
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {visibleGroups.map((group) => (
+            <CompanySection
+              key={group.orgId}
+              organizationName={group.name}
+              campaigns={group.campaigns}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/src/lib/assessments/campaign-detail.ts
+++ b/src/src/lib/assessments/campaign-detail.ts
@@ -42,6 +42,10 @@ export interface CampaignRespondentRow {
     email: string;
     jobTitle: string | null;
   };
+  teamSnapshot: {
+    pathIds: string[];
+    pathLabels: string[];
+  };
   isCEO: boolean;
   invitation: {
     id: string;
@@ -131,6 +135,8 @@ interface CampaignWithRels {
 interface ParticipantWithRespondent {
   id: string;
   isCEO: boolean;
+  teamPathAtAdd: string[] | null;
+  teamLabelsAtAdd: string[] | null;
   respondent: {
     id: string;
     firstName: string;
@@ -319,6 +325,10 @@ export async function getCampaignRespondents(
     return {
       participantId: p.id,
       respondent: p.respondent,
+      teamSnapshot: {
+        pathIds: p.teamPathAtAdd ?? [],
+        pathLabels: p.teamLabelsAtAdd ?? [],
+      },
       isCEO: p.isCEO,
       invitation: inv
         ? {

--- a/src/src/lib/assessments/campaign-status-metrics.ts
+++ b/src/src/lib/assessments/campaign-status-metrics.ts
@@ -1,0 +1,69 @@
+export interface CampaignStatusMetricsInput {
+  participantId: string;
+  invitation: {
+    status: "PENDING" | "SENT" | "VIEWED" | "SUBMITTED";
+    sentAt: Date | null;
+    revokedAt: Date | null;
+  } | null;
+}
+
+export interface CampaignStatusMetrics {
+  total: number;
+  new: number;
+  invited: number;
+  started: number;
+  completed: number;
+  revoked: number;
+}
+
+export function computeCampaignStatusMetrics(
+  rows: ReadonlyArray<CampaignStatusMetricsInput>,
+): CampaignStatusMetrics {
+  const metrics: CampaignStatusMetrics = {
+    total: 0,
+    new: 0,
+    invited: 0,
+    started: 0,
+    completed: 0,
+    revoked: 0,
+  };
+
+  for (const row of rows) {
+    const inv = row.invitation;
+
+    if (inv === null) {
+      metrics.new += 1;
+      metrics.total += 1;
+      continue;
+    }
+
+    // revoked invitations are excluded from all status bands
+    if (inv.revokedAt !== null) {
+      metrics.revoked += 1;
+      continue;
+    }
+
+    // sentAt is the source of truth for whether the invitation was sent;
+    // a PENDING row with sentAt set is treated as invited (defensive)
+    if (inv.status === "PENDING" && inv.sentAt === null) {
+      metrics.new += 1;
+    } else {
+      switch (inv.status) {
+        case "PENDING":
+        case "SENT":
+          metrics.invited += 1;
+          break;
+        case "VIEWED":
+          metrics.started += 1;
+          break;
+        case "SUBMITTED":
+          metrics.completed += 1;
+          break;
+      }
+    }
+
+    metrics.total += 1;
+  }
+
+  return metrics;
+}

--- a/src/src/lib/assessments/campaign-status-metrics.ts
+++ b/src/src/lib/assessments/campaign-status-metrics.ts
@@ -16,6 +16,45 @@ export interface CampaignStatusMetrics {
   revoked: number;
 }
 
+export type InvitationBand =
+  | "new"
+  | "invited"
+  | "started"
+  | "completed"
+  | "revoked";
+
+/**
+ * Classify a single invitation row into its staged-progress band.
+ * This is the single source of truth — `computeCampaignStatusMetrics`
+ * calls this internally so per-row display and aggregate counts can
+ * never drift.
+ *
+ * Rules (in priority order):
+ *  1. null invitation                          → "new"
+ *  2. revokedAt is set                         → "revoked"  (excluded from total)
+ *  3. PENDING + sentAt null                    → "new"
+ *  4. PENDING + sentAt set (defensive edge)    → "invited"
+ *  5. SENT                                     → "invited"
+ *  6. VIEWED                                   → "started"
+ *  7. SUBMITTED                                → "completed"
+ */
+export function getInvitationBand(
+  invitation: CampaignStatusMetricsInput["invitation"],
+): InvitationBand {
+  if (invitation === null) return "new";
+  if (invitation.revokedAt !== null) return "revoked";
+  if (invitation.status === "PENDING" && invitation.sentAt === null) return "new";
+  switch (invitation.status) {
+    case "PENDING":
+    case "SENT":
+      return "invited";
+    case "VIEWED":
+      return "started";
+    case "SUBMITTED":
+      return "completed";
+  }
+}
+
 export function computeCampaignStatusMetrics(
   rows: ReadonlyArray<CampaignStatusMetricsInput>,
 ): CampaignStatusMetrics {
@@ -29,39 +68,12 @@ export function computeCampaignStatusMetrics(
   };
 
   for (const row of rows) {
-    const inv = row.invitation;
-
-    if (inv === null) {
-      metrics.new += 1;
-      metrics.total += 1;
-      continue;
-    }
-
-    // revoked invitations are excluded from all status bands
-    if (inv.revokedAt !== null) {
+    const band = getInvitationBand(row.invitation);
+    if (band === "revoked") {
       metrics.revoked += 1;
       continue;
     }
-
-    // sentAt is the source of truth for whether the invitation was sent;
-    // a PENDING row with sentAt set is treated as invited (defensive)
-    if (inv.status === "PENDING" && inv.sentAt === null) {
-      metrics.new += 1;
-    } else {
-      switch (inv.status) {
-        case "PENDING":
-        case "SENT":
-          metrics.invited += 1;
-          break;
-        case "VIEWED":
-          metrics.started += 1;
-          break;
-        case "SUBMITTED":
-          metrics.completed += 1;
-          break;
-      }
-    }
-
+    metrics[band] += 1;
     metrics.total += 1;
   }
 


### PR DESCRIPTION
## Summary

Closes the v7.6 setup-first flip. Coach assessments landing and `CampaignDetail` now both speak the same staged-progress vocabulary (`New / Invited / Started / Completed / Revoked`) sourced from a single canonical mapping. This is the dashboard / visibility layer Jeff stressed in the May 26 Zoom.

5 commits, all TDD, all subagent-driven (one foreground helper-extraction by the human controller). Per-task gate: targeted tests + `CI=true npx next build --turbopack`. Zero migrations.

### Commits

| SHA | Task | What |
|-----|------|------|
| `91e73f1` | 5.1 | `lib/assessments/campaign-status-metrics.ts` — pure aggregator (`new=PENDING & !sentAt · invited=SENT · started=VIEWED · completed=SUBMITTED · revoked excluded from total`). 11 tests. |
| `f629e78` | 5.2 | `components/assessments/CampaignStatusMetrics.tsx` — shared 5-tile strip (Total/New/Invited/Started/Completed) with brand tones matching `INV_STATUS_TONE`. Compact mode, emptyHint, className passthrough. 10 tests. |
| `9bb21e6` | 5.3 | Rewires `/portal/assessments` — campaigns grouped under a company section header; each campaign row now carries the precomputed metrics tiles. Filter pills stay global; empty company sections collapse. 11 new tests. |
| `7b2ec06` | 5.4 | `CampaignDetail` participant table gains a **Team** column sourced from the immutable `AssessmentCampaignParticipant.teamPathAtAdd / teamLabelsAtAdd` snapshot (NOT live `OrgRespondent.team` — so closed campaigns stay locked to who was where at add-time). Multi-segment paths render leaf label + muted breadcrumb. 4 new tests. |
| `1500fb9` | 5.5 | `CampaignDetail` header gains the `CampaignStatusMetrics` strip; per-row Status cell switches from raw enum labels to band labels (`New / Invited / Started / Completed / Revoked`). `getInvitationBand` extracted as single source of truth — `computeCampaignStatusMetrics` now calls it internally so per-row and aggregate views can never drift. Resend / remove logic still keyed on the raw `invitation.status`. 8 new tests. |

### Why the band rename

Before Slice 5 the coach saw `PENDING / SENT / VIEWED / SUBMITTED` on every detail row and nothing aggregate. The landing said nothing about progress at all. After Slice 5 both surfaces (landing + detail) share the same five buckets and the same tones — Jeff's "where's everyone at?" question answers itself in one glance.

### Out of scope (deferred to Slice 6+)

- Revoked tile on the metrics strip (we count revoked separately but don't render it — adding it would be a small follow-up if Jeff wants the ops visibility).
- Per-row mini-step progression indicator (4 dots highlighting as the participant moves through bands). The simple band pill captures the same info more cleanly for a table.
- URL state persistence for the status-filter pills on the coach landing (matches the explicit "intentionally not persisted" comment in the existing component).

## Test plan

- [x] `npm test -- --testPathPatterns="campaign-status-metrics|CampaignStatusMetrics|CampaignsListWithFilter|CampaignDetail|campaign-detail"` — **77/77 passing across 7 suites**
- [x] `CI=true npx next build --turbopack` — clean
- [ ] Post-merge: load `/portal/assessments` as a coach with at least one company → confirm grouping + metrics tiles render
- [ ] Post-merge: open a campaign detail page → confirm header tiles + Team column + band labels on participant rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)