### PR TITLE
feat(templates): TEMPLATE-02 — Custom HTML override on landing-page templates

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -38,6 +38,8 @@
         "inngest": "^3.54.0",
         "ioredis": "^5.9.0",
         "iron-session": "^8.0.4",
+        "isomorphic-dompurify": "^3.15.0",
+        "jsdom": "^29.1.1",
         "lucide-react": "^0.562.0",
         "next": "^16.1.6",
         "next-auth": "^4.24.13",
@@ -97,25 +99,51 @@
       }
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
-      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
-      "dev": true,
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-calc": "^2.1.3",
-        "@csstools/css-color-parser": "^3.0.9",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
-        "lru-cache": "^10.4.3"
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
-    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "license": "MIT"
     },
     "node_modules/@auth/prisma-adapter": {
       "version": "2.11.1",
@@ -703,6 +731,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@bufbuild/protobuf": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
@@ -845,10 +885,9 @@
       }
     },
     "node_modules/@csstools/color-helpers": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
-      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
-      "dev": true,
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
       "funding": [
         {
           "type": "github",
@@ -861,14 +900,13 @@
       ],
       "license": "MIT-0",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
-      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
-      "dev": true,
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
       "funding": [
         {
           "type": "github",
@@ -881,18 +919,17 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
-      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
-      "dev": true,
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
       "funding": [
         {
           "type": "github",
@@ -905,22 +942,21 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@csstools/color-helpers": "^5.1.0",
-        "@csstools/css-calc": "^2.1.4"
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
       }
     },
     "node_modules/@csstools/css-parser-algorithms": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
-      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
-      "dev": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
       "funding": [
         {
           "type": "github",
@@ -933,17 +969,40 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
+      "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
       }
     },
     "node_modules/@csstools/css-tokenizer": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
-      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
-      "dev": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
       "funding": [
         {
           "type": "github",
@@ -956,7 +1015,7 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@dnd-kit/accessibility": {
@@ -1629,6 +1688,23 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -6593,6 +6669,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
@@ -7721,6 +7804,15 @@
         "bcrypt": "bin/bcrypt"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
@@ -8183,6 +8275,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -8204,6 +8309,142 @@
         "node": ">=18"
       }
     },
+    "node_modules/cssstyle/node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/cssstyle/node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/cssstyle/node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/cssstyle/node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/cssstyle/node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -8219,54 +8460,51 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/data-urls": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
-      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
-      "dev": true,
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
       "license": "MIT",
       "dependencies": {
-        "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.0.0"
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/data-urls/node_modules/tr46": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
-      "dev": true,
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/data-urls/node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true,
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=12"
+        "node": ">=20"
       }
     },
     "node_modules/data-urls/node_modules/whatwg-url": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
-      "dev": true,
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
       "license": "MIT",
       "dependencies": {
-        "tr46": "^5.1.0",
-        "webidl-conversions": "^7.0.0"
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/data-view-buffer": {
@@ -8354,7 +8592,6 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/dedent": {
@@ -8500,6 +8737,15 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.7.tgz",
+      "integrity": "sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dotenv": {
       "version": "17.2.3",
@@ -10102,16 +10348,15 @@
       }
     },
     "node_modules/html-encoding-sniffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
-      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
-      "dev": true,
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
       "license": "MIT",
       "dependencies": {
-        "whatwg-encoding": "^3.1.1"
+        "@exodus/bytes": "^1.6.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/html-escaper": {
@@ -10759,7 +11004,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-regex": {
@@ -10932,6 +11176,19 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/isomorphic-dompurify": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-3.15.0.tgz",
+      "integrity": "sha512-9ZtkbQ8+SgNf6LuDAdu9bq23dVXMIGNM8ZYnyl2MufyZiSD5dqAUJcyjtYZz7B80HuPpEn/f0NCS6zKvavHtfA==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "^3.4.7",
+        "jsdom": "^29.1.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -11419,6 +11676,153 @@
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-environment-jsdom/node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/jest-environment-node": {
@@ -12046,35 +12450,35 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
-      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
-      "dev": true,
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "license": "MIT",
       "dependencies": {
-        "cssstyle": "^4.2.1",
-        "data-urls": "^5.0.0",
-        "decimal.js": "^10.5.0",
-        "html-encoding-sniffer": "^4.0.0",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
         "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.16",
-        "parse5": "^7.2.1",
-        "rrweb-cssom": "^0.8.0",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^5.1.1",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
         "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^3.1.1",
-        "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.1.1",
-        "ws": "^8.18.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
       },
       "peerDependencies": {
         "canvas": "^3.0.0"
@@ -12085,41 +12489,81 @@
         }
       }
     },
+    "node_modules/jsdom/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/jsdom/node_modules/tr46": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
-      "dev": true,
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/undici": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.0.tgz",
+      "integrity": "sha512-+t2Z/GwkZQDtu00813aP66ygViGtPHKhhoFZpQKpKrE+9jIgES+Zw+mFNaDWOVRKiuJjuqKHzD3B1sfGg8+ZOQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/jsdom/node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true,
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=12"
+        "node": ">=20"
       }
     },
     "node_modules/jsdom/node_modules/whatwg-url": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
-      "dev": true,
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
       "license": "MIT",
       "dependencies": {
-        "tr46": "^5.1.0",
-        "webidl-conversions": "^7.0.0"
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/jsesc": {
@@ -12704,6 +13148,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -13945,7 +14395,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -14205,6 +14654,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-in-the-middle": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
@@ -14398,7 +14856,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
@@ -15024,7 +15481,6 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/synckit": {
@@ -15165,23 +15621,21 @@
       }
     },
     "node_modules/tldts": {
-      "version": "6.1.86",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
-      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
-      "dev": true,
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
+      "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^6.1.86"
+        "tldts-core": "^7.4.2"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.86",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
-      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
-      "dev": true,
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
+      "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
       "license": "MIT"
     },
     "node_modules/tmpl": {
@@ -15205,13 +15659,12 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
-      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
-      "dev": true,
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "tldts": "^6.1.32"
+        "tldts": "^7.0.5"
       },
       "engines": {
         "node": ">=16"
@@ -15730,7 +16183,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^5.0.0"
@@ -15770,13 +16222,12 @@
       }
     },
     "node_modules/whatwg-mimetype": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "dev": true,
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/whatwg-url": {
@@ -16466,9 +16917,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -16491,7 +16942,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -16501,7 +16951,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/xtend": {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -33,6 +33,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "dompurify": "^3.4.7",
         "dotenv": "^17.2.3",
         "framer-motion": "^12.34.1",
         "inngest": "^3.54.0",

--- a/src/package.json
+++ b/src/package.json
@@ -74,6 +74,8 @@
     "inngest": "^3.54.0",
     "ioredis": "^5.9.0",
     "iron-session": "^8.0.4",
+    "isomorphic-dompurify": "^3.15.0",
+    "jsdom": "^29.1.1",
     "lucide-react": "^0.562.0",
     "next": "^16.1.6",
     "next-auth": "^4.24.13",

--- a/src/package.json
+++ b/src/package.json
@@ -69,6 +69,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "dompurify": "^3.4.7",
     "dotenv": "^17.2.3",
     "framer-motion": "^12.34.1",
     "inngest": "^3.54.0",

--- a/src/prisma/migrations/20260601000000_add_custom_html_to_templates/migration.sql
+++ b/src/prisma/migrations/20260601000000_add_custom_html_to_templates/migration.sql
@@ -1,0 +1,21 @@
+-- TEMPLATE-02 (Jun 3 2026) — Custom HTML override on landing-page templates.
+--
+-- Adds two nullable TEXT columns mirroring the existing customCode pattern:
+--   - PageTemplate.customHtml: admin-edited HTML on /admin/templates/[id]/edit
+--     (SOLO_LANDING + DUO_LANDING only). Sanitized via DOMPurify on save.
+--   - LandingPage.customHtml: build-time snapshot, copied from the source
+--     PageTemplate after variables are HTML-escaped + interpolated, so the
+--     value persisted here is already sanitized (DOMPurify) and escaped.
+--
+-- The public /workshop/[slug] route reads the stored sanitized value via the
+-- React HTML-injection prop. All XSS gates run at save-time + interpolation;
+-- render is a trusted echo of the already-sanitized string.
+--
+-- Non-destructive: nullable columns, no defaults, no data movement, no FK
+-- changes. Existing rows get NULL on both columns — zero regression.
+--
+-- Plan: ~/.claude/plans/previous-instance-crashed-with-glittery-cake.md
+-- Notion: https://www.notion.so/3728c45dd829819aa9e3dac61a798bcb
+
+ALTER TABLE "page_templates" ADD COLUMN "customHtml" TEXT;
+ALTER TABLE "landing_pages" ADD COLUMN "customHtml" TEXT;

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -630,6 +630,10 @@ model LandingPage {
   // affiliate tracking. Copied at build time from the source PageTemplate;
   // never accepted from request bodies on coach-accessible routes.
   customCode       String?
+  // TEMPLATE-02 (Jun 3 2026): sanitized raw HTML override copied from
+  // PageTemplate.customHtml at build-time (variables HTML-escaped + interpolated).
+  // SOLO_LANDING + DUO_LANDING only; null on every other template type.
+  customHtml       String?
   publishedAt      DateTime?
   createdAt        DateTime            @default(now())
   updatedAt        DateTime            @updatedAt
@@ -653,6 +657,7 @@ model PageTemplate {
   categoryId   String?             // null = global template (applies to all categories)
   content      String              // JSON string with {{variable}} placeholders (TEXT column)
   customCode   String?             // ENH-06: affiliate / tracking code (stored only, not rendered)
+  customHtml   String?             // TEMPLATE-02 (Jun 3 2026): sanitized raw HTML override. When non-empty, replaces React template at render. SOLO_LANDING + DUO_LANDING only.
   isActive     Boolean             @default(false)
   createdAt    DateTime            @default(now())
   updatedAt    DateTime            @updatedAt

--- a/src/src/__tests__/api/landing-page-library.test.ts
+++ b/src/src/__tests__/api/landing-page-library.test.ts
@@ -43,10 +43,10 @@ jest.mock("@/lib/templates/template-interpolation", () => ({
   buildWorkshopVariables: jest.fn().mockResolvedValue(null),
 }));
 
-import { GET } from "@/app/api/landing-pages/library/route";
+import { GET, POST } from "@/app/api/landing-pages/library/route";
 import { NextRequest } from "next/server";
 import { db } from "@/lib/db";
-import { getApiActor } from "@/lib/auth/authorization";
+import { getApiActor, canManageCoachData } from "@/lib/auth/authorization";
 
 const adminActor = {
   userId: "admin-1",
@@ -261,5 +261,115 @@ describe("Landing Page Library API - GET /api/landing-pages/library", () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.data).toEqual([]);
+  });
+});
+
+// ===========================================================================
+// TEMPLATE-02: POST /api/landing-pages/library — customHtml clone copy-through
+// ===========================================================================
+describe("Landing Page Library API - POST /api/landing-pages/library (TEMPLATE-02 customHtml)", () => {
+  function buildPostRequest(body: Record<string, unknown>): Parameters<typeof POST>[0] {
+    return new NextRequest("http://localhost/api/landing-pages/library", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }) as unknown as Parameters<typeof POST>[0];
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getApiActor as jest.Mock).mockResolvedValue(adminActor);
+    (canManageCoachData as jest.Mock).mockReturnValue(true);
+    (db.workshop.findUnique as jest.Mock).mockResolvedValue({
+      id: "ws-target",
+      title: "Target Workshop",
+      coachId: "coach-target",
+    });
+    (db.landingPage.update as jest.Mock).mockResolvedValue({});
+  });
+
+  it("copies customHtml from source SOLO_LANDING to a SOLO_LANDING clone", async () => {
+    (db.landingPage.findUnique as jest.Mock)
+      .mockResolvedValueOnce({
+        // source page
+        id: "lp-src",
+        template: "SOLO_LANDING",
+        content: '{"heading":"x"}',
+        customCode: null,
+        customHtml: "<p>Cloned customHtml</p>",
+        workshop: { coachId: "coach-target" },
+      })
+      .mockResolvedValueOnce(null); // no existing target page
+    (db.landingPage.create as jest.Mock).mockImplementation((args: any) =>
+      Promise.resolve({ id: "lp-new", ...args.data })
+    );
+
+    const response = await POST(
+      buildPostRequest({
+        targetWorkshopId: "ws-target",
+        targetTemplate: "SOLO_LANDING",
+        sourceLandingPageId: "lp-src",
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const createArgs = (db.landingPage.create as jest.Mock).mock.calls[0][0];
+    expect(createArgs.data.customHtml).toBe("<p>Cloned customHtml</p>");
+  });
+
+  it("nulls customHtml on the destination when target template is ineligible (THANK_YOU)", async () => {
+    (db.landingPage.findUnique as jest.Mock)
+      .mockResolvedValueOnce({
+        id: "lp-src",
+        template: "THANK_YOU",
+        content: '{"heading":"x"}',
+        customCode: null,
+        customHtml: "<p>Should NOT carry over</p>",
+        workshop: { coachId: "coach-target" },
+      })
+      .mockResolvedValueOnce(null);
+    (db.landingPage.create as jest.Mock).mockImplementation((args: any) =>
+      Promise.resolve({ id: "lp-new", ...args.data })
+    );
+
+    const response = await POST(
+      buildPostRequest({
+        targetWorkshopId: "ws-target",
+        targetTemplate: "THANK_YOU",
+        sourceLandingPageId: "lp-src",
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const createArgs = (db.landingPage.create as jest.Mock).mock.calls[0][0];
+    expect(createArgs.data.customHtml).toBeNull();
+  });
+
+  it("keeps customHtml=null on destination when source page has customHtml=null", async () => {
+    (db.landingPage.findUnique as jest.Mock)
+      .mockResolvedValueOnce({
+        id: "lp-src",
+        template: "SOLO_LANDING",
+        content: '{"heading":"x"}',
+        customCode: null,
+        customHtml: null,
+        workshop: { coachId: "coach-target" },
+      })
+      .mockResolvedValueOnce(null);
+    (db.landingPage.create as jest.Mock).mockImplementation((args: any) =>
+      Promise.resolve({ id: "lp-new", ...args.data })
+    );
+
+    const response = await POST(
+      buildPostRequest({
+        targetWorkshopId: "ws-target",
+        targetTemplate: "SOLO_LANDING",
+        sourceLandingPageId: "lp-src",
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const createArgs = (db.landingPage.create as jest.Mock).mock.calls[0][0];
+    expect(createArgs.data.customHtml).toBeNull();
   });
 });

--- a/src/src/__tests__/api/landing-pages-put.test.ts
+++ b/src/src/__tests__/api/landing-pages-put.test.ts
@@ -36,6 +36,56 @@ jest.mock("@/lib/db", () => ({
 jest.mock("@/lib/auth/authorization", () => ({
   getApiActor: jest.fn(),
   canManageCoachData: jest.fn(),
+  isPrivilegedRole: (role: string) => role === "ADMIN" || role === "STAFF",
+}));
+
+// TEMPLATE-02: buildWorkshopVariables drives the customHtml interpolation
+jest.mock("@/lib/templates/template-interpolation", () => ({
+  buildWorkshopVariables: jest.fn().mockResolvedValue({
+    workshop_title: "Test Workshop",
+    coach_name: "Test Coach",
+  }),
+}));
+
+// TEMPLATE-02: real escape-and-substitute so XSS-safe interpolation is observable
+jest.mock("@/lib/templates/interpolate-content-html", () => {
+  const escapeHtml = (value: string): string =>
+    value
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#x27;");
+  return {
+    interpolateContentForHtml: jest.fn(
+      (template: string, variables: Record<string, string | null | undefined>) => {
+        let out = template;
+        for (const [key, raw] of Object.entries(variables)) {
+          const value = raw == null ? "" : raw;
+          const escaped = escapeHtml(value);
+          out = out.split(`{{${key}}}`).join(escaped);
+          out = out.split(`{{ ${key} }}`).join(escaped);
+        }
+        return out;
+      }
+    ),
+  };
+});
+
+// TEMPLATE-02: sanitize is invoked on inbound customHtml override
+jest.mock("@/lib/templates/sanitize-custom-html", () => ({
+  sanitizeCustomHtml: jest.fn((input: string) => ({
+    sanitized: input,
+    didStripContent: false,
+    strippedTags: [],
+    strippedAttrs: [],
+  })),
+  FRAME_SRC_ALLOWLIST: [],
+}));
+
+// validateCustomCode is invoked only when customCode is sent — stub harmless
+jest.mock("@/lib/templates/interpolate-custom-code", () => ({
+  validateCustomCode: jest.fn(() => ({ valid: true })),
 }));
 
 import { PUT } from "@/app/api/workshops/[id]/landing-pages/[template]/route";
@@ -383,6 +433,121 @@ describe("PUT /api/workshops/[id]/landing-pages/[template]", () => {
       );
 
       expect(response.status).toBe(404);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // TEMPLATE-02: customHtml copy-through + eligibility + admin override
+  // -------------------------------------------------------------------------
+  describe("TEMPLATE-02 customHtml", () => {
+    it("copies + interpolates customHtml from matching PageTemplate on SOLO_LANDING CREATE", async () => {
+      (getApiActor as jest.Mock).mockResolvedValue(adminActor);
+      (canManageCoachData as jest.Mock).mockReturnValue(true);
+      (db.workshop.findUnique as jest.Mock).mockResolvedValue(fakeWorkshop);
+      (db.landingPage.findUnique as jest.Mock).mockResolvedValue(null);
+      (db.pageTemplate.findMany as jest.Mock).mockResolvedValue([
+        {
+          customCode: null,
+          customHtml: "<p>Hello {{workshop_title}}</p>",
+          categoryId: null,
+        },
+      ]);
+      (db.landingPage.create as jest.Mock).mockImplementation((args: any) =>
+        Promise.resolve({ id: "lp-1", ...args.data })
+      );
+
+      const response = await PUT(
+        buildPutRequest("workshop-1", "SOLO_LANDING", {
+          content: { hero: "x" },
+          status: "DRAFT",
+        }),
+        routeParams("workshop-1", "SOLO_LANDING")
+      );
+
+      expect(response.status).toBe(200);
+      const created = (db.landingPage.create as jest.Mock).mock.calls[0][0];
+      expect(created.data.customHtml).toBe("<p>Hello Test Workshop</p>");
+    });
+
+    it("writes customHtml=null on REGISTRATION CREATE even if PageTemplate has customHtml (eligibility filter)", async () => {
+      (getApiActor as jest.Mock).mockResolvedValue(adminActor);
+      (canManageCoachData as jest.Mock).mockReturnValue(true);
+      (db.workshop.findUnique as jest.Mock).mockResolvedValue(fakeWorkshop);
+      (db.landingPage.findUnique as jest.Mock).mockResolvedValue(null);
+      (db.pageTemplate.findMany as jest.Mock).mockResolvedValue([
+        {
+          customCode: null,
+          customHtml: "<p>not eligible</p>",
+          categoryId: null,
+        },
+      ]);
+      (db.landingPage.create as jest.Mock).mockImplementation((args: any) =>
+        Promise.resolve({ id: "lp-reg", ...args.data })
+      );
+
+      const response = await PUT(
+        buildPutRequest("workshop-1", "REGISTRATION", {
+          content: { hero: "x" },
+          status: "DRAFT",
+        }),
+        routeParams("workshop-1", "REGISTRATION")
+      );
+
+      expect(response.status).toBe(200);
+      const created = (db.landingPage.create as jest.Mock).mock.calls[0][0];
+      expect(created.data.customHtml).toBeNull();
+    });
+
+    it("admin-supplied customHtml in request body wins over template copy on SOLO_LANDING CREATE", async () => {
+      (getApiActor as jest.Mock).mockResolvedValue(adminActor);
+      (canManageCoachData as jest.Mock).mockReturnValue(true);
+      (db.workshop.findUnique as jest.Mock).mockResolvedValue(fakeWorkshop);
+      (db.landingPage.findUnique as jest.Mock).mockResolvedValue(null);
+      (db.pageTemplate.findMany as jest.Mock).mockResolvedValue([
+        {
+          customCode: null,
+          customHtml: "<p>FROM TEMPLATE</p>",
+          categoryId: null,
+        },
+      ]);
+      (db.landingPage.create as jest.Mock).mockImplementation((args: any) =>
+        Promise.resolve({ id: "lp-1", ...args.data })
+      );
+
+      const response = await PUT(
+        buildPutRequest("workshop-1", "SOLO_LANDING", {
+          content: { hero: "x" },
+          status: "DRAFT",
+          customHtml: "<p>FROM BODY</p>",
+        }),
+        routeParams("workshop-1", "SOLO_LANDING")
+      );
+
+      expect(response.status).toBe(200);
+      const created = (db.landingPage.create as jest.Mock).mock.calls[0][0];
+      // Body override (sanitized passthrough in our mock) is stored, not the template copy
+      expect(created.data.customHtml).toBe("<p>FROM BODY</p>");
+    });
+
+    it("rejects request body customHtml on REGISTRATION with 400 (eligibility filter)", async () => {
+      (getApiActor as jest.Mock).mockResolvedValue(adminActor);
+      (canManageCoachData as jest.Mock).mockReturnValue(true);
+      (db.workshop.findUnique as jest.Mock).mockResolvedValue(fakeWorkshop);
+      (db.landingPage.findUnique as jest.Mock).mockResolvedValue(null);
+
+      const response = await PUT(
+        buildPutRequest("workshop-1", "REGISTRATION", {
+          content: { hero: "x" },
+          status: "DRAFT",
+          customHtml: "<p>not eligible</p>",
+        }),
+        routeParams("workshop-1", "REGISTRATION")
+      );
+
+      expect(response.status).toBe(400);
+      const body = await response.json();
+      expect(body.success).toBe(false);
+      expect(String(body.error).toLowerCase()).toMatch(/customhtml|eligibl/);
     });
   });
 });

--- a/src/src/__tests__/api/landing-pages-put.test.ts
+++ b/src/src/__tests__/api/landing-pages-put.test.ts
@@ -498,7 +498,11 @@ describe("PUT /api/workshops/[id]/landing-pages/[template]", () => {
       expect(created.data.customHtml).toBeNull();
     });
 
-    it("admin-supplied customHtml in request body wins over template copy on SOLO_LANDING CREATE", async () => {
+    // Fix-1: customHtml from coach-accessible PUT request body is REMOVED.
+    // The PUT route is gated by canManageCoachData, not isPrivilegedRole — so
+    // any coach could otherwise stuff sanitized HTML into their LandingPage row.
+    // Custom HTML is admin-controlled via the page-templates PATCH route only.
+    it("ignores customHtml in request body — only template-copy survives on SOLO_LANDING CREATE", async () => {
       (getApiActor as jest.Mock).mockResolvedValue(adminActor);
       (canManageCoachData as jest.Mock).mockReturnValue(true);
       (db.workshop.findUnique as jest.Mock).mockResolvedValue(fakeWorkshop);
@@ -525,29 +529,39 @@ describe("PUT /api/workshops/[id]/landing-pages/[template]", () => {
 
       expect(response.status).toBe(200);
       const created = (db.landingPage.create as jest.Mock).mock.calls[0][0];
-      // Body override (sanitized passthrough in our mock) is stored, not the template copy
-      expect(created.data.customHtml).toBe("<p>FROM BODY</p>");
+      // Body customHtml is silently dropped; only the admin-blessed template copy is stored.
+      expect(created.data.customHtml).toBe("<p>FROM TEMPLATE</p>");
     });
 
-    it("rejects request body customHtml on REGISTRATION with 400 (eligibility filter)", async () => {
+    it("ignores customHtml in request body on UPDATE — customHtml column not written", async () => {
       (getApiActor as jest.Mock).mockResolvedValue(adminActor);
       (canManageCoachData as jest.Mock).mockReturnValue(true);
       (db.workshop.findUnique as jest.Mock).mockResolvedValue(fakeWorkshop);
-      (db.landingPage.findUnique as jest.Mock).mockResolvedValue(null);
-
-      const response = await PUT(
-        buildPutRequest("workshop-1", "REGISTRATION", {
-          content: { hero: "x" },
-          status: "DRAFT",
-          customHtml: "<p>not eligible</p>",
-        }),
-        routeParams("workshop-1", "REGISTRATION")
+      (db.landingPage.findUnique as jest.Mock).mockResolvedValue({
+        id: "lp-1",
+        workshopId: "workshop-1",
+        template: "SOLO_LANDING",
+        slug: "x",
+        content: "{}",
+        status: "DRAFT",
+        publishedAt: null,
+      });
+      (db.landingPage.update as jest.Mock).mockImplementation((args: any) =>
+        Promise.resolve({ id: "lp-1", ...args.data })
       );
 
-      expect(response.status).toBe(400);
-      const body = await response.json();
-      expect(body.success).toBe(false);
-      expect(String(body.error).toLowerCase()).toMatch(/customhtml|eligibl/);
+      const response = await PUT(
+        buildPutRequest("workshop-1", "SOLO_LANDING", {
+          content: { hero: "x" },
+          status: "DRAFT",
+          customHtml: "<p>FROM BODY</p>",
+        }),
+        routeParams("workshop-1", "SOLO_LANDING")
+      );
+
+      expect(response.status).toBe(200);
+      const updated = (db.landingPage.update as jest.Mock).mock.calls[0][0];
+      expect(updated.data).not.toHaveProperty("customHtml");
     });
   });
 });

--- a/src/src/__tests__/api/page-templates.test.ts
+++ b/src/src/__tests__/api/page-templates.test.ts
@@ -28,9 +28,15 @@ jest.mock("@/lib/audit", () => ({
     logAudit: jest.fn(),
 }));
 
+jest.mock("@/lib/templates/sanitize-custom-html", () => ({
+    sanitizeCustomHtml: jest.fn(),
+}));
+
 import { PATCH } from "@/app/api/page-templates/[id]/route";
 import { db } from "@/lib/db";
 import { getApiActor } from "@/lib/auth/authorization";
+import { logAudit } from "@/lib/audit";
+import { sanitizeCustomHtml } from "@/lib/templates/sanitize-custom-html";
 
 function routeParams(id: string) {
     return { params: Promise.resolve({ id }) };
@@ -80,5 +86,261 @@ describe("PATCH /api/page-templates/[id]", () => {
 
         const res = await PATCH(req, routeParams("tpl-1"));
         expect(res.status).toBe(200);
+    });
+});
+
+describe("PATCH /api/page-templates/[id] — customHtml", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (getApiActor as jest.Mock).mockResolvedValue({
+            userId: "admin-1",
+            email: "admin@test.com",
+            role: "ADMIN",
+        });
+        (db.pageTemplate.update as jest.Mock).mockResolvedValue({});
+        (db.$transaction as jest.Mock).mockImplementation(async (cb: (tx: typeof db) => Promise<unknown>) => {
+            return cb(db);
+        });
+    });
+
+    function mockExistingTemplate(templateType: string) {
+        (db.pageTemplate.findUnique as jest.Mock)
+            .mockResolvedValueOnce({ id: "tpl-1", templateType, categoryId: null })
+            .mockResolvedValueOnce({ id: "tpl-1", templateType, customHtml: "<p>x</p>" });
+    }
+
+    function patchReq(payload: unknown) {
+        return new Request("http://localhost/api/page-templates/tpl-1", {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(payload),
+        });
+    }
+
+    it("stores clean customHtml on SOLO_LANDING and reports not sanitized", async () => {
+        mockExistingTemplate("SOLO_LANDING");
+        (sanitizeCustomHtml as jest.Mock).mockReturnValue({
+            sanitized: "<p>hi {{workshop_title}}</p>",
+            didStripContent: false,
+            strippedTags: [],
+            strippedAttrs: [],
+        });
+
+        const res = await PATCH(patchReq({ customHtml: "<p>hi {{workshop_title}}</p>" }), routeParams("tpl-1"));
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body.customHtmlSanitized).toBe(false);
+        expect(sanitizeCustomHtml as jest.Mock).toHaveBeenCalledWith("<p>hi {{workshop_title}}</p>");
+        const updateCall = (db.pageTemplate.update as jest.Mock).mock.calls[0][0];
+        expect(updateCall.data.customHtml).toBe("<p>hi {{workshop_title}}</p>");
+    });
+
+    it("stores sanitized output (not raw) when script is stripped on SOLO_LANDING", async () => {
+        mockExistingTemplate("SOLO_LANDING");
+        (sanitizeCustomHtml as jest.Mock).mockReturnValue({
+            sanitized: "<p>safe</p>",
+            didStripContent: true,
+            strippedTags: ["script"],
+            strippedAttrs: [],
+        });
+
+        const res = await PATCH(patchReq({ customHtml: "<script>x</script><p>safe</p>" }), routeParams("tpl-1"));
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body.customHtmlSanitized).toBe(true);
+        const updateCall = (db.pageTemplate.update as jest.Mock).mock.calls[0][0];
+        expect(updateCall.data.customHtml).toBe("<p>safe</p>");
+    });
+
+    it("rejects customHtml on REGISTRATION template", async () => {
+        (db.pageTemplate.findUnique as jest.Mock).mockResolvedValueOnce({
+            id: "tpl-1",
+            templateType: "REGISTRATION",
+            categoryId: null,
+        });
+
+        const res = await PATCH(patchReq({ customHtml: "<p>x</p>" }), routeParams("tpl-1"));
+        const body = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(body.error).toMatch(/SOLO_LANDING and DUO_LANDING/);
+        expect(db.pageTemplate.update as jest.Mock).not.toHaveBeenCalled();
+    });
+
+    it("rejects customHtml on THANK_YOU template", async () => {
+        (db.pageTemplate.findUnique as jest.Mock).mockResolvedValueOnce({
+            id: "tpl-1",
+            templateType: "THANK_YOU",
+            categoryId: null,
+        });
+
+        const res = await PATCH(patchReq({ customHtml: "<p>x</p>" }), routeParams("tpl-1"));
+        const body = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(body.error).toMatch(/SOLO_LANDING and DUO_LANDING/);
+        expect(db.pageTemplate.update as jest.Mock).not.toHaveBeenCalled();
+    });
+
+    it("rejects customHtml on BIO_PAGE template", async () => {
+        (db.pageTemplate.findUnique as jest.Mock).mockResolvedValueOnce({
+            id: "tpl-1",
+            templateType: "BIO_PAGE",
+            categoryId: null,
+        });
+
+        const res = await PATCH(patchReq({ customHtml: "<p>x</p>" }), routeParams("tpl-1"));
+        const body = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(body.error).toMatch(/SOLO_LANDING and DUO_LANDING/);
+        expect(db.pageTemplate.update as jest.Mock).not.toHaveBeenCalled();
+    });
+
+    it("allows customHtml on DUO_LANDING template", async () => {
+        mockExistingTemplate("DUO_LANDING");
+        (sanitizeCustomHtml as jest.Mock).mockReturnValue({
+            sanitized: "<p>x</p>",
+            didStripContent: false,
+            strippedTags: [],
+            strippedAttrs: [],
+        });
+
+        const res = await PATCH(patchReq({ customHtml: "<p>x</p>" }), routeParams("tpl-1"));
+        expect(res.status).toBe(200);
+    });
+
+    it("normalizes empty string customHtml to null and skips sanitizer", async () => {
+        mockExistingTemplate("SOLO_LANDING");
+
+        const res = await PATCH(patchReq({ customHtml: "" }), routeParams("tpl-1"));
+
+        expect(res.status).toBe(200);
+        expect(sanitizeCustomHtml as jest.Mock).not.toHaveBeenCalled();
+        const updateCall = (db.pageTemplate.update as jest.Mock).mock.calls[0][0];
+        expect(updateCall.data.customHtml).toBeNull();
+    });
+
+    it("normalizes whitespace-only customHtml to null and skips sanitizer", async () => {
+        mockExistingTemplate("SOLO_LANDING");
+
+        const res = await PATCH(patchReq({ customHtml: "   \n\t  " }), routeParams("tpl-1"));
+
+        expect(res.status).toBe(200);
+        expect(sanitizeCustomHtml as jest.Mock).not.toHaveBeenCalled();
+        const updateCall = (db.pageTemplate.update as jest.Mock).mock.calls[0][0];
+        expect(updateCall.data.customHtml).toBeNull();
+    });
+
+    it("passes through null customHtml unchanged and skips sanitizer", async () => {
+        mockExistingTemplate("SOLO_LANDING");
+
+        const res = await PATCH(patchReq({ customHtml: null }), routeParams("tpl-1"));
+
+        expect(res.status).toBe(200);
+        expect(sanitizeCustomHtml as jest.Mock).not.toHaveBeenCalled();
+        const updateCall = (db.pageTemplate.update as jest.Mock).mock.calls[0][0];
+        expect(updateCall.data.customHtml).toBeNull();
+    });
+
+    it("allows non-placeholder content when customHtml is non-empty (escape hatch)", async () => {
+        mockExistingTemplate("SOLO_LANDING");
+        (sanitizeCustomHtml as jest.Mock).mockReturnValue({
+            sanitized: "<p>x</p>",
+            didStripContent: false,
+            strippedTags: [],
+            strippedAttrs: [],
+        });
+
+        const res = await PATCH(
+            patchReq({ content: "no placeholders here", customHtml: "<p>x</p>" }),
+            routeParams("tpl-1"),
+        );
+        expect(res.status).toBe(200);
+    });
+
+    it("still rejects non-placeholder content when customHtml is empty", async () => {
+        (db.pageTemplate.findUnique as jest.Mock).mockResolvedValueOnce({
+            id: "tpl-1",
+            templateType: "SOLO_LANDING",
+            categoryId: null,
+        });
+
+        const res = await PATCH(
+            patchReq({ content: "no placeholders", customHtml: "" }),
+            routeParams("tpl-1"),
+        );
+        const body = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(body.error).toMatch(/placeholders/i);
+    });
+
+    it("rejects customHtml exceeding 500,000 character limit", async () => {
+        const tooLong = "x".repeat(500_001);
+
+        const res = await PATCH(patchReq({ customHtml: tooLong }), routeParams("tpl-1"));
+        const body = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(body.error).toMatch(/500,000 character limit/);
+        expect(sanitizeCustomHtml as jest.Mock).not.toHaveBeenCalled();
+    });
+
+    it("populates audit changes blob with sanitization metadata", async () => {
+        mockExistingTemplate("SOLO_LANDING");
+        (sanitizeCustomHtml as jest.Mock).mockReturnValue({
+            sanitized: "<p>x</p>",
+            didStripContent: true,
+            strippedTags: ["script"],
+            strippedAttrs: ["onerror"],
+        });
+
+        await PATCH(patchReq({ customHtml: "<script>...</script>" }), routeParams("tpl-1"));
+
+        const auditCall = (logAudit as jest.Mock).mock.calls[0][0];
+        expect(auditCall.action).toBe("UPDATE");
+        expect(auditCall.changes.customHtmlChanged).toBe(true);
+        expect(auditCall.changes.customHtmlLength).toBe("<p>x</p>".length);
+        expect(auditCall.changes.strippedTags).toEqual(["script"]);
+        expect(auditCall.changes.strippedAttrs).toEqual(["onerror"]);
+    });
+
+    it("rejects customHtml from a non-admin actor with 403", async () => {
+        (getApiActor as jest.Mock).mockResolvedValue({
+            userId: "coach-1",
+            email: "coach@test.com",
+            role: "COACH",
+        });
+
+        const res = await PATCH(patchReq({ customHtml: "<p>x</p>" }), routeParams("tpl-1"));
+
+        expect(res.status).toBe(403);
+        expect(sanitizeCustomHtml as jest.Mock).not.toHaveBeenCalled();
+    });
+
+    it("threads customHtml through the activation transaction path", async () => {
+        mockExistingTemplate("SOLO_LANDING");
+        (sanitizeCustomHtml as jest.Mock).mockReturnValue({
+            sanitized: "<p>x</p>",
+            didStripContent: false,
+            strippedTags: [],
+            strippedAttrs: [],
+        });
+
+        const res = await PATCH(
+            patchReq({ isActive: true, customHtml: "<p>x</p>" }),
+            routeParams("tpl-1"),
+        );
+
+        expect(res.status).toBe(200);
+        expect(db.$transaction as jest.Mock).toHaveBeenCalled();
+        const updateCalls = (db.pageTemplate.update as jest.Mock).mock.calls;
+        const calledWithCustomHtml = updateCalls.some(
+            (call) => call[0]?.data?.customHtml === "<p>x</p>",
+        );
+        expect(calledWithCustomHtml).toBe(true);
     });
 });

--- a/src/src/__tests__/app/workshop-slug-custom-html.test.tsx
+++ b/src/src/__tests__/app/workshop-slug-custom-html.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * TEMPLATE-02 render path — when LandingPage.customHtml is non-empty,
+ * the stored DOMPurify-sanitized HTML renders via React's HTML-injection
+ * prop and the React template switch is bypassed. Empty / null /
+ * whitespace customHtml falls through to the existing switch.
+ */
+
+jest.mock("@/lib/db", () => ({
+  db: {
+    landingPage: { findUnique: jest.fn() },
+    workshop: { findUnique: jest.fn() },
+  },
+}));
+
+jest.mock("next/navigation", () => ({
+  redirect: jest.fn().mockImplementation((url: string) => {
+    throw Object.assign(new Error("NEXT_REDIRECT"), { digest: `NEXT_REDIRECT;${url}` });
+  }),
+  notFound: jest.fn().mockImplementation(() => {
+    throw Object.assign(new Error("NEXT_NOT_FOUND"), { digest: "NEXT_NOT_FOUND" });
+  }),
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), refresh: jest.fn() }),
+  useSearchParams: () => ({ get: jest.fn() }),
+  usePathname: () => "/",
+}));
+
+jest.mock("@/components/templates/thank-you-page-template", () => ({
+  ThankYouPageTemplate: () => null,
+}));
+jest.mock("@/components/templates/registration-page-template", () => ({
+  RegistrationPageTemplate: () => null,
+}));
+jest.mock("@/components/templates/bio-page-template", () => ({
+  BioPageTemplate: () => null,
+}));
+jest.mock("@/components/templates/solo-landing-page-template", () => ({
+  SoloLandingPageTemplate: ({ content }: { content: { heroTitle?: string } }) => `solo:${content?.heroTitle ?? ""}`,
+}));
+jest.mock("@/components/templates/duo-landing-page-template", () => ({
+  DuoLandingPageTemplate: () => null,
+}));
+jest.mock("@/lib/templates/resolve-custom-code-renderer", () => ({
+  resolveCustomCodeRenderer: jest.fn().mockResolvedValue(null),
+}));
+
+import { db } from "@/lib/db";
+import LandingPageView from "@/app/(public)/workshop/[slug]/page";
+import { renderToStaticMarkup } from "react-dom/server";
+
+type FoundLanding = {
+  template: string;
+  content: string;
+  customHtml: string | null;
+  customCode: string | null;
+  status: string;
+  workshop: {
+    id: string;
+    format: string;
+    venueName: string | null;
+    venueAddress: string | null;
+    isFree: boolean;
+    coach: Record<string, unknown>;
+    workshopType: Record<string, unknown> | null;
+  };
+};
+
+function makeProps(slug: string) {
+  return {
+    params: Promise.resolve({ slug }),
+    searchParams: Promise.resolve({}),
+  };
+}
+
+function landingFixture(overrides: Partial<FoundLanding> = {}): FoundLanding {
+  return {
+    template: "SOLO_LANDING",
+    content: JSON.stringify({ heroTitle: "React title" }),
+    customHtml: null,
+    customCode: null,
+    status: "PUBLISHED",
+    workshop: {
+      id: "wks-1",
+      format: "VIRTUAL",
+      venueName: null,
+      venueAddress: null,
+      isFree: false,
+      coach: {},
+      workshopType: null,
+    },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("workshop slug customHtml render path", () => {
+  it("renders the customHtml override when non-empty", async () => {
+    (db.landingPage.findUnique as jest.Mock).mockResolvedValueOnce(
+      landingFixture({ customHtml: "<p>Custom hello {{workshop_title}}</p>" })
+    );
+
+    const node = await LandingPageView(await Promise.resolve(makeProps("solo-slug")));
+    const markup = renderToStaticMarkup(node as React.ReactElement);
+
+    expect(markup).toContain("data-custom-html-render");
+    expect(markup).toContain("<p>Custom hello {{workshop_title}}</p>");
+    expect(markup).not.toContain("solo:React title");
+  });
+
+  it("falls through to React template when customHtml is null", async () => {
+    (db.landingPage.findUnique as jest.Mock).mockResolvedValueOnce(
+      landingFixture({ customHtml: null })
+    );
+
+    const node = await LandingPageView(await Promise.resolve(makeProps("solo-slug")));
+    const markup = renderToStaticMarkup(node as React.ReactElement);
+
+    expect(markup).not.toContain("data-custom-html-render");
+    expect(markup).toContain("solo:React title");
+  });
+
+  it("falls through to React template when customHtml is empty string", async () => {
+    (db.landingPage.findUnique as jest.Mock).mockResolvedValueOnce(
+      landingFixture({ customHtml: "" })
+    );
+
+    const node = await LandingPageView(await Promise.resolve(makeProps("solo-slug")));
+    const markup = renderToStaticMarkup(node as React.ReactElement);
+
+    expect(markup).not.toContain("data-custom-html-render");
+    expect(markup).toContain("solo:React title");
+  });
+
+  it("falls through to React template when customHtml is whitespace-only", async () => {
+    (db.landingPage.findUnique as jest.Mock).mockResolvedValueOnce(
+      landingFixture({ customHtml: "   \n\t  " })
+    );
+
+    const node = await LandingPageView(await Promise.resolve(makeProps("solo-slug")));
+    const markup = renderToStaticMarkup(node as React.ReactElement);
+
+    expect(markup).not.toContain("data-custom-html-render");
+    expect(markup).toContain("solo:React title");
+  });
+
+  it("does not parse content JSON when customHtml takes over", async () => {
+    (db.landingPage.findUnique as jest.Mock).mockResolvedValueOnce(
+      landingFixture({
+        customHtml: "<p>Hi</p>",
+        content: "not valid json {{{",
+      })
+    );
+
+    const node = await LandingPageView(await Promise.resolve(makeProps("solo-slug")));
+    const markup = renderToStaticMarkup(node as React.ReactElement);
+
+    expect(markup).toContain("data-custom-html-render");
+    expect(markup).toContain("<p>Hi</p>");
+  });
+});

--- a/src/src/__tests__/components/template-content-editor-custom-html.test.tsx
+++ b/src/src/__tests__/components/template-content-editor-custom-html.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * TEMPLATE-02: Custom HTML override section in TemplateContentEditor.
+ * Only renders for SOLO_LANDING + DUO_LANDING. Hidden entirely otherwise.
+ */
+
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+jest.mock("next/navigation", () => ({
+    useRouter: () => ({ push: jest.fn(), replace: jest.fn(), refresh: jest.fn() }),
+    useSearchParams: () => ({ get: jest.fn() }),
+    usePathname: () => "/",
+}));
+
+import { TemplateContentEditor } from "@/components/templates/template-content-editor";
+
+const baseProps = {
+    templateId: "tpl-1",
+    templateName: "Test Template",
+    categoryName: "Test Category",
+    isActive: false,
+    initialContent: "{}",
+    initialCustomCode: null,
+};
+
+function getCustomHtmlTextarea(): HTMLTextAreaElement | null {
+    return screen.queryByLabelText(/custom html/i) as HTMLTextAreaElement | null;
+}
+
+describe("TemplateContentEditor — Custom HTML section", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("renders the Custom HTML textarea for SOLO_LANDING", () => {
+        render(
+            <TemplateContentEditor
+                {...baseProps}
+                templateType="SOLO_LANDING"
+                initialCustomHtml="<p>x</p>"
+            />
+        );
+        const ta = getCustomHtmlTextarea();
+        expect(ta).not.toBeNull();
+        expect(ta!.value).toBe("<p>x</p>");
+    });
+
+    it("renders the Custom HTML textarea for DUO_LANDING", () => {
+        render(
+            <TemplateContentEditor
+                {...baseProps}
+                templateType="DUO_LANDING"
+                initialCustomHtml="<p>duo</p>"
+            />
+        );
+        const ta = getCustomHtmlTextarea();
+        expect(ta).not.toBeNull();
+        expect(ta!.value).toBe("<p>duo</p>");
+    });
+
+    it("hides the Custom HTML textarea for REGISTRATION", () => {
+        render(
+            <TemplateContentEditor
+                {...baseProps}
+                templateType="REGISTRATION"
+                initialCustomHtml=""
+            />
+        );
+        expect(getCustomHtmlTextarea()).toBeNull();
+    });
+
+    it("hides the Custom HTML textarea for THANK_YOU", () => {
+        render(
+            <TemplateContentEditor
+                {...baseProps}
+                templateType="THANK_YOU"
+                initialCustomHtml=""
+            />
+        );
+        expect(getCustomHtmlTextarea()).toBeNull();
+    });
+
+    it("hides the Custom HTML textarea for BIO_PAGE", () => {
+        render(
+            <TemplateContentEditor
+                {...baseProps}
+                templateType="BIO_PAGE"
+                initialCustomHtml=""
+            />
+        );
+        expect(getCustomHtmlTextarea()).toBeNull();
+    });
+
+    it("toggles the status pill between Empty and Active as content changes", () => {
+        render(
+            <TemplateContentEditor
+                {...baseProps}
+                templateType="SOLO_LANDING"
+                initialCustomHtml=""
+            />
+        );
+        expect(
+            screen.getByText(/empty\s*[—-]\s*fields below render/i)
+        ).toBeInTheDocument();
+
+        const ta = getCustomHtmlTextarea()!;
+        fireEvent.change(ta, { target: { value: "<p>hello</p>" } });
+
+        expect(
+            screen.getByText(/active\s*[·•]\s*overrides fields below/i)
+        ).toBeInTheDocument();
+    });
+
+    it("POSTs customHtml in the save payload when Save is clicked", async () => {
+        global.fetch = jest.fn().mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ success: true, customHtmlSanitized: false }),
+        });
+
+        render(
+            <TemplateContentEditor
+                {...baseProps}
+                templateType="SOLO_LANDING"
+                initialCustomHtml=""
+            />
+        );
+
+        const ta = getCustomHtmlTextarea()!;
+        fireEvent.change(ta, { target: { value: "<p>hi</p>" } });
+        fireEvent.click(screen.getByRole("button", { name: /save template/i }));
+
+        await waitFor(() => {
+            expect(global.fetch).toHaveBeenCalled();
+        });
+        const call = (global.fetch as jest.Mock).mock.calls[0];
+        expect(call[0]).toBe("/api/page-templates/tpl-1");
+        const body = JSON.parse(call[1].body);
+        expect(body.customHtml).toBe("<p>hi</p>");
+    });
+
+    it("sends customHtml as null when only whitespace is entered", async () => {
+        global.fetch = jest.fn().mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ success: true, customHtmlSanitized: false }),
+        });
+
+        render(
+            <TemplateContentEditor
+                {...baseProps}
+                templateType="SOLO_LANDING"
+                initialCustomHtml=""
+            />
+        );
+
+        const ta = getCustomHtmlTextarea()!;
+        fireEvent.change(ta, { target: { value: "   \n  " } });
+        fireEvent.click(screen.getByRole("button", { name: /save template/i }));
+
+        await waitFor(() => {
+            expect(global.fetch).toHaveBeenCalled();
+        });
+        const call = (global.fetch as jest.Mock).mock.calls[0];
+        const body = JSON.parse(call[1].body);
+        expect(body.customHtml).toBeNull();
+    });
+
+    it("shows the sanitized notice when response returns customHtmlSanitized: true", async () => {
+        global.fetch = jest.fn().mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ success: true, customHtmlSanitized: true }),
+        });
+
+        render(
+            <TemplateContentEditor
+                {...baseProps}
+                templateType="SOLO_LANDING"
+                initialCustomHtml=""
+            />
+        );
+
+        const ta = getCustomHtmlTextarea()!;
+        fireEvent.change(ta, { target: { value: "<p><script>x</script></p>" } });
+        fireEvent.click(screen.getByRole("button", { name: /save template/i }));
+
+        await waitFor(() => {
+            expect(
+                screen.getByText(/some html was sanitized for safety/i)
+            ).toBeInTheDocument();
+        });
+    });
+
+    it("clears the sanitized notice on a subsequent clean save", async () => {
+        const fetchMock = jest
+            .fn()
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ success: true, customHtmlSanitized: true }),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ success: true, customHtmlSanitized: false }),
+            });
+        global.fetch = fetchMock;
+
+        render(
+            <TemplateContentEditor
+                {...baseProps}
+                templateType="SOLO_LANDING"
+                initialCustomHtml=""
+            />
+        );
+
+        const ta = getCustomHtmlTextarea()!;
+        fireEvent.change(ta, { target: { value: "<script>x</script>" } });
+        fireEvent.click(screen.getByRole("button", { name: /save template/i }));
+
+        await waitFor(() => {
+            expect(
+                screen.getByText(/some html was sanitized for safety/i)
+            ).toBeInTheDocument();
+        });
+
+        fireEvent.change(ta, { target: { value: "<p>clean</p>" } });
+        fireEvent.click(screen.getByRole("button", { name: /save template/i }));
+
+        await waitFor(() => {
+            expect(
+                screen.queryByText(/some html was sanitized for safety/i)
+            ).toBeNull();
+        });
+    });
+});

--- a/src/src/__tests__/lib/auto-build-service.test.ts
+++ b/src/src/__tests__/lib/auto-build-service.test.ts
@@ -522,6 +522,149 @@ describe("runAutoBuild", () => {
       expect(soloCall![0].data.customHtml).toBeNull();
     });
 
+    // BLOCK-2: build-time sanitize re-runs in strict mode after interpolation,
+    // so malicious substituted URLs (e.g. javascript:) get stripped even if the
+    // raw token was admin-blessed.
+    it("strips javascript: substituted into a token-href on build (strict re-sanitize)", async () => {
+      (db.workshop.findUnique as jest.Mock).mockResolvedValue(mockWorkshop);
+      (buildWorkshopVariables as jest.Mock).mockResolvedValue({
+        ...mockVariables,
+        virtual_link: "javascript:alert(1)",
+      });
+      (db.pageTemplate.findMany as jest.Mock).mockResolvedValue([
+        {
+          id: "tpl-solo",
+          templateType: "SOLO_LANDING",
+          content: '{"heading":"{{workshop_title}}"}',
+          categoryId: null,
+          customCode: null,
+          customHtml: '<a href="{{virtual_link}}">Join</a>',
+        },
+      ]);
+      (db.landingPage.findUnique as jest.Mock).mockResolvedValue(null);
+      (db.landingPage.create as jest.Mock).mockImplementation((args: any) =>
+        Promise.resolve({ id: "lp-new", ...args.data })
+      );
+      (db.workflow.findMany as jest.Mock).mockResolvedValue([]);
+      (db.landingPage.findFirst as jest.Mock).mockResolvedValue({ slug: "solo-slug" });
+      (db.workshop.update as jest.Mock).mockResolvedValue({ id: "ws-1" });
+      (db.workshop.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+
+      await runAutoBuild("ws-1");
+
+      const createCalls = (db.landingPage.create as jest.Mock).mock.calls;
+      const soloCall = createCalls.find((c) => c[0].data.template === "SOLO_LANDING");
+      expect(soloCall).toBeDefined();
+      const customHtml: string = soloCall![0].data.customHtml;
+      expect(customHtml).toContain("<a");
+      expect(customHtml).not.toContain("javascript:");
+    });
+
+    it("preserves https registration_url through strict re-sanitize", async () => {
+      (templateHasPlaceholders as jest.Mock).mockReturnValue(true);
+      (db.workshop.findUnique as jest.Mock).mockResolvedValue(mockWorkshop);
+      (buildWorkshopVariables as jest.Mock).mockResolvedValue(mockVariables);
+      (db.pageTemplate.findMany as jest.Mock).mockResolvedValue([
+        {
+          id: "tpl-reg",
+          templateType: "REGISTRATION",
+          content: '{"heading":"Register"}',
+          categoryId: null,
+          customCode: null,
+          customHtml: null,
+        },
+        {
+          id: "tpl-solo",
+          templateType: "SOLO_LANDING",
+          content: '{"heading":"{{workshop_title}}"}',
+          categoryId: null,
+          customCode: null,
+          customHtml: '<a href="{{registration_url}}">Sign up</a>',
+        },
+      ]);
+      (db.landingPage.findUnique as jest.Mock).mockResolvedValue(null);
+      (db.landingPage.create as jest.Mock).mockImplementation((args: any) =>
+        Promise.resolve({ id: `lp-${args.data.template}`, slug: args.data.slug })
+      );
+      (db.workflow.findMany as jest.Mock).mockResolvedValue([]);
+      (db.landingPage.findFirst as jest.Mock).mockImplementation((args: any) => {
+        const tpl = args?.where?.template;
+        const createCalls = (db.landingPage.create as jest.Mock).mock.calls;
+        const match = createCalls.find((c) => c[0].data.template === tpl);
+        if (match) {
+          return Promise.resolve({ id: `lp-${tpl}`, slug: match[0].data.slug, content: match[0].data.content });
+        }
+        return Promise.resolve(null);
+      });
+      (db.workshop.update as jest.Mock).mockResolvedValue({ id: "ws-1" });
+      (db.workshop.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+
+      await runAutoBuild("ws-1");
+
+      const createCalls = (db.landingPage.create as jest.Mock).mock.calls;
+      const regCall = createCalls.find((c) => c[0].data.template === "REGISTRATION");
+      const soloCall = createCalls.find((c) => c[0].data.template === "SOLO_LANDING");
+      const regSlug: string = regCall![0].data.slug;
+      const customHtml: string = soloCall![0].data.customHtml;
+      expect(customHtml).toContain(`https://example.test/workshop/${regSlug}`);
+    });
+
+    // Fix-3: HIGH-2 partial-rebuild path — REGISTRATION exists; SOLO_LANDING still needs its URL.
+    it("uses existing REGISTRATION slug when REGISTRATION LandingPage already exists (partial rebuild)", async () => {
+      (templateHasPlaceholders as jest.Mock).mockReturnValue(true);
+      (db.workshop.findUnique as jest.Mock).mockResolvedValue(mockWorkshop);
+      (buildWorkshopVariables as jest.Mock).mockResolvedValue(mockVariables);
+      (db.pageTemplate.findMany as jest.Mock).mockResolvedValue([
+        {
+          id: "tpl-reg",
+          templateType: "REGISTRATION",
+          content: '{"heading":"Register"}',
+          categoryId: null,
+          customCode: null,
+          customHtml: null,
+        },
+        {
+          id: "tpl-solo",
+          templateType: "SOLO_LANDING",
+          content: '{"heading":"{{workshop_title}}"}',
+          categoryId: null,
+          customCode: null,
+          customHtml: '<a href="{{registration_url}}">Sign up</a>',
+        },
+      ]);
+      // landingPage.findUnique returns existing for REGISTRATION (preserving prior slug),
+      // null for SOLO_LANDING so the buildOnePage proceeds.
+      (db.landingPage.findUnique as jest.Mock).mockImplementation((args: any) => {
+        if (args.where.workshopId_template?.template === "REGISTRATION") {
+          return Promise.resolve({
+            id: "lp-existing-reg",
+            workshopId: "ws-1",
+            template: "REGISTRATION",
+            slug: "preexisting-reg-slug",
+          });
+        }
+        return Promise.resolve(null);
+      });
+      (db.landingPage.create as jest.Mock).mockImplementation((args: any) =>
+        Promise.resolve({ id: `lp-${args.data.template}`, slug: args.data.slug })
+      );
+      (db.workflow.findMany as jest.Mock).mockResolvedValue([]);
+      (db.landingPage.findFirst as jest.Mock).mockResolvedValue({ slug: "solo-slug" });
+      (db.workshop.update as jest.Mock).mockResolvedValue({ id: "ws-1" });
+      (db.workshop.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+
+      await runAutoBuild("ws-1");
+
+      const createCalls = (db.landingPage.create as jest.Mock).mock.calls;
+      const soloCall = createCalls.find((c) => c[0].data.template === "SOLO_LANDING");
+      expect(soloCall).toBeDefined();
+      const customHtml: string = soloCall![0].data.customHtml;
+      expect(customHtml).toContain("https://example.test/workshop/preexisting-reg-slug");
+      expect(customHtml).not.toContain("{{registration_url}}");
+      // And it must not be empty either
+      expect(customHtml).not.toBe('<a href="">Sign up</a>');
+    });
+
     it("writes customHtml=null on THANK_YOU LandingPage even if source PageTemplate has customHtml (eligibility filter)", async () => {
       (db.workshop.findUnique as jest.Mock).mockResolvedValue(mockWorkshop);
       (buildWorkshopVariables as jest.Mock).mockResolvedValue(mockVariables);

--- a/src/src/__tests__/lib/auto-build-service.test.ts
+++ b/src/src/__tests__/lib/auto-build-service.test.ts
@@ -41,6 +41,31 @@ jest.mock("@/lib/templates/template-interpolation", () => ({
   findRemainingPlaceholders: jest.fn(() => []),
 }));
 
+// TEMPLATE-02: real interpolation for customHtml so XSS-escape + token-resolution can be asserted
+jest.mock("@/lib/templates/interpolate-content-html", () => {
+  const escapeHtml = (value: string): string =>
+    value
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#x27;");
+  return {
+    interpolateContentForHtml: jest.fn(
+      (template: string, variables: Record<string, string | null | undefined>) => {
+        let out = template;
+        for (const [key, raw] of Object.entries(variables)) {
+          const value = raw == null ? "" : raw;
+          const escaped = escapeHtml(value);
+          out = out.split(`{{${key}}}`).join(escaped);
+          out = out.split(`{{ ${key} }}`).join(escaped);
+        }
+        return out;
+      }
+    ),
+  };
+});
+
 jest.mock("@/services/notifications", () => ({
   sendWorkshopBuiltEmail: jest.fn().mockResolvedValue(undefined),
 }));
@@ -248,5 +273,281 @@ describe("runAutoBuild", () => {
 
     const result = await runAutoBuild("ws-corrupted");
     expect(result.pagesCreated).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // TEMPLATE-02: customHtml copy-through + two-pass interpolation
+  // -------------------------------------------------------------------------
+  describe("TEMPLATE-02 customHtml", () => {
+    const ORIG_APP_URL = process.env.APP_URL;
+
+    beforeEach(() => {
+      process.env.APP_URL = "https://example.test";
+      // Reset mock impl after prior tests may have called mockReturnValue(false)
+      (templateHasPlaceholders as jest.Mock).mockReturnValue(true);
+    });
+
+    afterAll(() => {
+      process.env.APP_URL = ORIG_APP_URL;
+    });
+
+    it("copies and interpolates customHtml into SOLO_LANDING LandingPage row", async () => {
+      (db.workshop.findUnique as jest.Mock).mockResolvedValue(mockWorkshop);
+      (buildWorkshopVariables as jest.Mock).mockResolvedValue(mockVariables);
+      (db.pageTemplate.findMany as jest.Mock).mockResolvedValue([
+        {
+          id: "tpl-solo",
+          templateType: "SOLO_LANDING",
+          content: '{"heading":"{{workshop_title}}"}',
+          categoryId: null,
+          customCode: null,
+          customHtml: "<p>Hello {{workshop_title}}</p>",
+        },
+      ]);
+      (db.landingPage.findUnique as jest.Mock).mockResolvedValue(null);
+      (db.landingPage.create as jest.Mock).mockResolvedValue({ id: "lp-new" });
+      (db.workflow.findMany as jest.Mock).mockResolvedValue([]);
+      (db.landingPage.findFirst as jest.Mock).mockResolvedValue({ slug: "solo-slug" });
+      (db.workshop.update as jest.Mock).mockResolvedValue({ id: "ws-1" });
+      (db.workshop.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+
+      await runAutoBuild("ws-1");
+
+      const createCalls = (db.landingPage.create as jest.Mock).mock.calls;
+      const soloCall = createCalls.find((c) => c[0].data.template === "SOLO_LANDING");
+      expect(soloCall).toBeDefined();
+      expect(soloCall![0].data.customHtml).toBe("<p>Hello Scaling Up Workshop</p>");
+    });
+
+    it("does NOT filter out a template whose content has no placeholders but whose customHtml is populated", async () => {
+      // templateHasPlaceholders returns false (legacy "corrupted" check).
+      // Spec: a template with empty content + populated customHtml must NOT be skipped.
+      (templateHasPlaceholders as jest.Mock).mockReturnValue(false);
+      (db.workshop.findUnique as jest.Mock).mockResolvedValue(mockWorkshop);
+      (buildWorkshopVariables as jest.Mock).mockResolvedValue(mockVariables);
+      (db.pageTemplate.findMany as jest.Mock).mockResolvedValue([
+        {
+          id: "tpl-solo",
+          templateType: "SOLO_LANDING",
+          content: "{}",
+          categoryId: null,
+          customCode: null,
+          customHtml: "<p>Just custom html</p>",
+        },
+      ]);
+      (db.landingPage.findUnique as jest.Mock).mockResolvedValue(null);
+      (db.landingPage.create as jest.Mock).mockResolvedValue({ id: "lp-new" });
+      (db.workflow.findMany as jest.Mock).mockResolvedValue([]);
+      (db.landingPage.findFirst as jest.Mock).mockResolvedValue({ slug: "solo-slug" });
+      (db.workshop.update as jest.Mock).mockResolvedValue({ id: "ws-1" });
+      (db.workshop.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+
+      const result = await runAutoBuild("ws-1");
+
+      expect(result.pagesCreated).toBe(1);
+      expect(db.landingPage.create).toHaveBeenCalledTimes(1);
+    });
+
+    it("writes customHtml=null on REGISTRATION LandingPage even if source PageTemplate had customHtml (eligibility filter)", async () => {
+      (db.workshop.findUnique as jest.Mock).mockResolvedValue(mockWorkshop);
+      (buildWorkshopVariables as jest.Mock).mockResolvedValue(mockVariables);
+      (db.pageTemplate.findMany as jest.Mock).mockResolvedValue([
+        {
+          id: "tpl-reg",
+          templateType: "REGISTRATION",
+          content: '{"heading":"Register for {{workshop_title}}"}',
+          categoryId: null,
+          customCode: null,
+          customHtml: "<p>Should NOT carry over</p>",
+        },
+      ]);
+      (db.landingPage.findUnique as jest.Mock).mockResolvedValue(null);
+      (db.landingPage.create as jest.Mock).mockResolvedValue({ id: "lp-reg" });
+      (db.workflow.findMany as jest.Mock).mockResolvedValue([]);
+      (db.landingPage.findFirst as jest.Mock).mockResolvedValue({ slug: "reg-slug" });
+      (db.workshop.update as jest.Mock).mockResolvedValue({ id: "ws-1" });
+      (db.workshop.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+
+      await runAutoBuild("ws-1");
+
+      const createCalls = (db.landingPage.create as jest.Mock).mock.calls;
+      const regCall = createCalls.find((c) => c[0].data.template === "REGISTRATION");
+      expect(regCall).toBeDefined();
+      expect(regCall![0].data.customHtml).toBeNull();
+    });
+
+    it("interpolates registration_url into SOLO_LANDING customHtml when REGISTRATION page is also built", async () => {
+      (templateHasPlaceholders as jest.Mock).mockReturnValue(true);
+      (db.workshop.findUnique as jest.Mock).mockResolvedValue(mockWorkshop);
+      (buildWorkshopVariables as jest.Mock).mockResolvedValue(mockVariables);
+      (db.pageTemplate.findMany as jest.Mock).mockResolvedValue([
+        {
+          id: "tpl-reg",
+          templateType: "REGISTRATION",
+          content: '{"heading":"Register"}',
+          categoryId: null,
+          customCode: null,
+          customHtml: null,
+        },
+        {
+          id: "tpl-solo",
+          templateType: "SOLO_LANDING",
+          content: '{"heading":"{{workshop_title}}"}',
+          categoryId: null,
+          customCode: null,
+          customHtml: '<a href="{{registration_url}}">Sign up</a>',
+        },
+      ]);
+      (db.landingPage.findUnique as jest.Mock).mockResolvedValue(null);
+      // Capture each row written so we can inspect the REGISTRATION slug used in interpolation.
+      (db.landingPage.create as jest.Mock).mockImplementation((args: any) =>
+        Promise.resolve({ id: `lp-${args.data.template}`, slug: args.data.slug })
+      );
+      (db.workflow.findMany as jest.Mock).mockResolvedValue([]);
+      // Step 4b + Step 6 findFirst lookups — return the actual REGISTRATION row's slug.
+      (db.landingPage.findFirst as jest.Mock).mockImplementation((args: any) => {
+        const tpl = args?.where?.template;
+        const createCalls = (db.landingPage.create as jest.Mock).mock.calls;
+        const match = createCalls.find((c) => c[0].data.template === tpl);
+        if (match) {
+          return Promise.resolve({ id: `lp-${tpl}`, slug: match[0].data.slug, content: match[0].data.content });
+        }
+        return Promise.resolve(null);
+      });
+      (db.workshop.update as jest.Mock).mockResolvedValue({ id: "ws-1" });
+      (db.workshop.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+
+      await runAutoBuild("ws-1");
+
+      const createCalls = (db.landingPage.create as jest.Mock).mock.calls;
+      const regCall = createCalls.find((c) => c[0].data.template === "REGISTRATION");
+      const soloCall = createCalls.find((c) => c[0].data.template === "SOLO_LANDING");
+      expect(regCall).toBeDefined();
+      expect(soloCall).toBeDefined();
+      const regSlug: string = regCall![0].data.slug;
+      const customHtml: string = soloCall![0].data.customHtml;
+      // Absolute URL is APP_URL + REGISTRATION's actual slug
+      expect(customHtml).toContain(`https://example.test/workshop/${regSlug}`);
+      // No leaked token
+      expect(customHtml).not.toContain("{{registration_url}}");
+    });
+
+    it("uses empty string for {{registration_url}} when no REGISTRATION template exists", async () => {
+      (db.workshop.findUnique as jest.Mock).mockResolvedValue(mockWorkshop);
+      (buildWorkshopVariables as jest.Mock).mockResolvedValue(mockVariables);
+      (db.pageTemplate.findMany as jest.Mock).mockResolvedValue([
+        {
+          id: "tpl-solo",
+          templateType: "SOLO_LANDING",
+          content: '{"heading":"{{workshop_title}}"}',
+          categoryId: null,
+          customCode: null,
+          customHtml: '<a href="{{registration_url}}">register</a>',
+        },
+      ]);
+      (db.landingPage.findUnique as jest.Mock).mockResolvedValue(null);
+      (db.landingPage.create as jest.Mock).mockResolvedValue({ id: "lp-new" });
+      (db.workflow.findMany as jest.Mock).mockResolvedValue([]);
+      (db.landingPage.findFirst as jest.Mock).mockResolvedValue({ slug: "solo-slug" });
+      (db.workshop.update as jest.Mock).mockResolvedValue({ id: "ws-1" });
+      (db.workshop.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+
+      await runAutoBuild("ws-1");
+
+      const createCalls = (db.landingPage.create as jest.Mock).mock.calls;
+      const soloCall = createCalls.find((c) => c[0].data.template === "SOLO_LANDING");
+      expect(soloCall).toBeDefined();
+      const customHtml: string = soloCall![0].data.customHtml;
+      // Token replaced with empty string (no leaked {{registration_url}})
+      expect(customHtml).toBe('<a href="">register</a>');
+    });
+
+    it("HTML-escapes variable values that contain HTML (XSS regression)", async () => {
+      (db.workshop.findUnique as jest.Mock).mockResolvedValue(mockWorkshop);
+      (buildWorkshopVariables as jest.Mock).mockResolvedValue({
+        ...mockVariables,
+        coach_bio: '<img src=x onerror=alert(1)>',
+      });
+      (db.pageTemplate.findMany as jest.Mock).mockResolvedValue([
+        {
+          id: "tpl-solo",
+          templateType: "SOLO_LANDING",
+          content: '{"heading":"{{workshop_title}}"}',
+          categoryId: null,
+          customCode: null,
+          customHtml: "<div>{{coach_bio}}</div>",
+        },
+      ]);
+      (db.landingPage.findUnique as jest.Mock).mockResolvedValue(null);
+      (db.landingPage.create as jest.Mock).mockResolvedValue({ id: "lp-new" });
+      (db.workflow.findMany as jest.Mock).mockResolvedValue([]);
+      (db.landingPage.findFirst as jest.Mock).mockResolvedValue({ slug: "solo-slug" });
+      (db.workshop.update as jest.Mock).mockResolvedValue({ id: "ws-1" });
+      (db.workshop.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+
+      await runAutoBuild("ws-1");
+
+      const createCalls = (db.landingPage.create as jest.Mock).mock.calls;
+      const soloCall = createCalls.find((c) => c[0].data.template === "SOLO_LANDING");
+      const customHtml: string = soloCall![0].data.customHtml;
+      expect(customHtml).toContain("&lt;img");
+      expect(customHtml).not.toMatch(/<img\s+src=x/);
+    });
+
+    it("preserves customHtml=null when source PageTemplate.customHtml is null (no-op)", async () => {
+      (templateHasPlaceholders as jest.Mock).mockReturnValue(true);
+      (db.workshop.findUnique as jest.Mock).mockResolvedValue(mockWorkshop);
+      (buildWorkshopVariables as jest.Mock).mockResolvedValue(mockVariables);
+      (db.pageTemplate.findMany as jest.Mock).mockResolvedValue([
+        {
+          id: "tpl-solo",
+          templateType: "SOLO_LANDING",
+          content: '{"heading":"{{workshop_title}}"}',
+          categoryId: null,
+          customCode: null,
+          customHtml: null,
+        },
+      ]);
+      (db.landingPage.findUnique as jest.Mock).mockResolvedValue(null);
+      (db.landingPage.create as jest.Mock).mockResolvedValue({ id: "lp-new" });
+      (db.workflow.findMany as jest.Mock).mockResolvedValue([]);
+      (db.landingPage.findFirst as jest.Mock).mockResolvedValue({ slug: "solo-slug" });
+      (db.workshop.update as jest.Mock).mockResolvedValue({ id: "ws-1" });
+      (db.workshop.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+
+      await runAutoBuild("ws-1");
+
+      const createCalls = (db.landingPage.create as jest.Mock).mock.calls;
+      const soloCall = createCalls.find((c) => c[0].data.template === "SOLO_LANDING");
+      expect(soloCall![0].data.customHtml).toBeNull();
+    });
+
+    it("writes customHtml=null on THANK_YOU LandingPage even if source PageTemplate has customHtml (eligibility filter)", async () => {
+      (db.workshop.findUnique as jest.Mock).mockResolvedValue(mockWorkshop);
+      (buildWorkshopVariables as jest.Mock).mockResolvedValue(mockVariables);
+      (db.pageTemplate.findMany as jest.Mock).mockResolvedValue([
+        {
+          id: "tpl-ty",
+          templateType: "THANK_YOU",
+          content: '{"heading":"Thanks!"}',
+          categoryId: null,
+          customCode: null,
+          customHtml: "<p>Not eligible</p>",
+        },
+      ]);
+      (db.landingPage.findUnique as jest.Mock).mockResolvedValue(null);
+      (db.landingPage.create as jest.Mock).mockResolvedValue({ id: "lp-ty" });
+      (db.workflow.findMany as jest.Mock).mockResolvedValue([]);
+      (db.landingPage.findFirst as jest.Mock).mockResolvedValue({ slug: "ty-slug" });
+      (db.workshop.update as jest.Mock).mockResolvedValue({ id: "ws-1" });
+      (db.workshop.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+
+      await runAutoBuild("ws-1");
+
+      const createCalls = (db.landingPage.create as jest.Mock).mock.calls;
+      const tyCall = createCalls.find((c) => c[0].data.template === "THANK_YOU");
+      expect(tyCall).toBeDefined();
+      expect(tyCall![0].data.customHtml).toBeNull();
+    });
   });
 });

--- a/src/src/__tests__/lib/templates/interpolate-content-html.test.ts
+++ b/src/src/__tests__/lib/templates/interpolate-content-html.test.ts
@@ -1,0 +1,87 @@
+import {
+  escapeHtml,
+  interpolateContentForHtml,
+} from "@/lib/templates/interpolate-content-html";
+
+describe("escapeHtml", () => {
+  it("1. encodes ampersand", () => {
+    expect(escapeHtml("&")).toBe("&amp;");
+  });
+
+  it("2. encodes angle brackets", () => {
+    expect(escapeHtml("<>")).toBe("&lt;&gt;");
+  });
+
+  it("3. encodes quotes", () => {
+    expect(escapeHtml("\"'")).toBe("&quot;&#x27;");
+  });
+
+  it("4. leaves plain text unchanged", () => {
+    expect(escapeHtml("plain text")).toBe("plain text");
+  });
+
+  it("5. encodes mixed content exactly once (no double-escape)", () => {
+    expect(escapeHtml("5 < 10 & 10 > 5")).toBe("5 &lt; 10 &amp; 10 &gt; 5");
+  });
+});
+
+describe("interpolateContentForHtml", () => {
+  it("6. replaces {{name}} with value", () => {
+    expect(interpolateContentForHtml("Hello {{name}}", { name: "World" })).toBe(
+      "Hello World"
+    );
+  });
+
+  it("7. replaces {{ name }} with value (spaced braces)", () => {
+    expect(
+      interpolateContentForHtml("Hello {{ name }}", { name: "World" })
+    ).toBe("Hello World");
+  });
+
+  it("8. CRITICAL XSS regression — escapes HTML in variable value", () => {
+    const out = interpolateContentForHtml("{{bio}}", {
+      bio: "<img src=x onerror=alert(1)>",
+    });
+    expect(out).toBe("&lt;img src=x onerror=alert(1)&gt;");
+    expect(out).toContain("&lt;");
+    expect(out).not.toContain("<img");
+  });
+
+  it("9. replaces multiple variables", () => {
+    expect(
+      interpolateContentForHtml("{{a}} and {{b}}", { a: "foo", b: "bar" })
+    ).toBe("foo and bar");
+  });
+
+  it("10. null value treated as empty string", () => {
+    expect(interpolateContentForHtml("{{name}}", { name: null })).toBe("");
+  });
+
+  it("11. undefined value treated as empty string", () => {
+    expect(interpolateContentForHtml("{{name}}", { name: undefined })).toBe("");
+  });
+
+  it("12. no variables — template returned as-is", () => {
+    expect(interpolateContentForHtml("No vars here", {})).toBe("No vars here");
+  });
+
+  it("13. unmatched token left literal", () => {
+    expect(
+      interpolateContentForHtml("{{missing}}", { other: "x" })
+    ).toBe("{{missing}}");
+  });
+
+  it("14. escapes quotes inside variable value", () => {
+    expect(
+      interpolateContentForHtml('<a title="{{title}}">x</a>', {
+        title: 'He said "hi"',
+      })
+    ).toBe('<a title="He said &quot;hi&quot;">x</a>');
+  });
+
+  it("15. escapes ampersand in variable value exactly once", () => {
+    expect(interpolateContentForHtml("{{q}}", { q: "A & B" })).toBe(
+      "A &amp; B"
+    );
+  });
+});

--- a/src/src/__tests__/lib/templates/sanitize-custom-html.test.ts
+++ b/src/src/__tests__/lib/templates/sanitize-custom-html.test.ts
@@ -162,6 +162,62 @@ describe("sanitizeCustomHtml", () => {
     expect(a.strippedAttrs).not.toBe(b.strippedAttrs);
   });
 
+  // TEMPLATE-02 BLOCK-2: token URIs preserved in default (save-time) mode,
+  // stripped in strict (post-interpolation re-sanitize) mode.
+  describe("allowTokenUris option", () => {
+    it("21. preserves {{registration_url}} in href when default mode (allowTokenUris=true)", () => {
+      const result = sanitizeCustomHtml('<a href="{{registration_url}}">link</a>');
+      expect(result.sanitized).toContain('href="{{registration_url}}"');
+    });
+
+    it("22. preserves {{ registration_url }} (spaced) in href when default mode", () => {
+      const result = sanitizeCustomHtml('<a href="{{ registration_url }}">link</a>');
+      expect(result.sanitized).toContain("href=");
+      expect(result.sanitized).toMatch(/\{\{\s*registration_url\s*\}\}/);
+    });
+
+    it("23. strips {{registration_url}} href when allowTokenUris=false (strict mode)", () => {
+      const result = sanitizeCustomHtml(
+        '<a href="{{registration_url}}">link</a>',
+        { allowTokenUris: false }
+      );
+      expect(result.sanitized).toContain("<a");
+      expect(result.sanitized).not.toContain("{{registration_url}}");
+      expect(result.sanitized).not.toContain("href=");
+    });
+
+    it("24. https URL survives both default and strict modes", () => {
+      const loose = sanitizeCustomHtml('<a href="https://example.com">x</a>');
+      const strict = sanitizeCustomHtml(
+        '<a href="https://example.com">x</a>',
+        { allowTokenUris: false }
+      );
+      expect(loose.sanitized).toContain('href="https://example.com"');
+      expect(strict.sanitized).toContain('href="https://example.com"');
+    });
+
+    it("25. javascript: href stripped in both modes", () => {
+      const loose = sanitizeCustomHtml('<a href="javascript:alert(1)">x</a>');
+      const strict = sanitizeCustomHtml(
+        '<a href="javascript:alert(1)">x</a>',
+        { allowTokenUris: false }
+      );
+      expect(loose.sanitized).not.toContain("javascript:");
+      expect(strict.sanitized).not.toContain("javascript:");
+    });
+
+    it("26. {{coach_photo}} <img src> survives default mode, stripped in strict mode", () => {
+      const loose = sanitizeCustomHtml('<img src="{{coach_photo}}">');
+      const strict = sanitizeCustomHtml(
+        '<img src="{{coach_photo}}">',
+        { allowTokenUris: false }
+      );
+      expect(loose.sanitized).toContain('src="{{coach_photo}}"');
+      expect(strict.sanitized).toContain("<img");
+      expect(strict.sanitized).not.toContain("{{coach_photo}}");
+    });
+  });
+
   it("FRAME_SRC_ALLOWLIST is exported and contains expected hosts", () => {
     expect(Array.isArray(FRAME_SRC_ALLOWLIST)).toBe(true);
     expect(FRAME_SRC_ALLOWLIST.length).toBeGreaterThanOrEqual(4);

--- a/src/src/__tests__/lib/templates/sanitize-custom-html.test.ts
+++ b/src/src/__tests__/lib/templates/sanitize-custom-html.test.ts
@@ -1,0 +1,178 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+  sanitizeCustomHtml,
+  FRAME_SRC_ALLOWLIST,
+} from "@/lib/templates/sanitize-custom-html";
+
+describe("sanitizeCustomHtml", () => {
+  it("1. passes through plain <p>Hello</p> unchanged", () => {
+    const result = sanitizeCustomHtml("<p>Hello</p>");
+    expect(result.sanitized).toContain("<p>Hello</p>");
+    expect(result.didStripContent).toBe(false);
+  });
+
+  it("2. strips <script>alert(1)</script>", () => {
+    const result = sanitizeCustomHtml("<script>alert(1)</script>");
+    expect(result.sanitized).not.toContain("<script");
+    expect(result.strippedTags).toContain("script");
+    expect(result.didStripContent).toBe(true);
+  });
+
+  it("3. keeps <img src> but strips onerror", () => {
+    const result = sanitizeCustomHtml(
+      '<img src="https://example.com/x.jpg" onerror="bad()">'
+    );
+    expect(result.sanitized).toContain("<img");
+    expect(result.sanitized).toContain('src="https://example.com/x.jpg"');
+    expect(result.sanitized).not.toContain("onerror");
+    expect(result.strippedAttrs).toContain("onerror");
+  });
+
+  it("4. allows iframe with vimeo src", () => {
+    const result = sanitizeCustomHtml(
+      '<iframe src="https://player.vimeo.com/video/123"></iframe>'
+    );
+    expect(result.sanitized).toContain("<iframe");
+    expect(result.sanitized).toContain("https://player.vimeo.com/video/123");
+    expect(result.strippedAttrs).not.toContain("iframe-src(blocked-host)");
+  });
+
+  it("5. allows iframe with youtube src", () => {
+    const result = sanitizeCustomHtml(
+      '<iframe src="https://www.youtube.com/embed/abc"></iframe>'
+    );
+    expect(result.sanitized).toContain("<iframe");
+    expect(result.sanitized).toContain("https://www.youtube.com/embed/abc");
+  });
+
+  it("6. allows iframe with youtube-nocookie src", () => {
+    const result = sanitizeCustomHtml(
+      '<iframe src="https://youtube-nocookie.com/embed/abc"></iframe>'
+    );
+    expect(result.sanitized).toContain("<iframe");
+    expect(result.sanitized).toContain("https://youtube-nocookie.com/embed/abc");
+  });
+
+  it("7. allows iframe with js.stripe.com src", () => {
+    const result = sanitizeCustomHtml(
+      '<iframe src="https://js.stripe.com/v3/"></iframe>'
+    );
+    expect(result.sanitized).toContain("<iframe");
+    expect(result.sanitized).toContain("https://js.stripe.com/v3/");
+  });
+
+  it("8. blocks disallowed iframe host — strips src, keeps iframe", () => {
+    const result = sanitizeCustomHtml(
+      '<iframe src="https://evil.example.com/"></iframe>'
+    );
+    expect(result.sanitized).toContain("<iframe");
+    expect(result.sanitized).not.toContain("evil.example.com");
+    expect(result.strippedAttrs).toContain("iframe-src(blocked-host)");
+  });
+
+  it("9. removes srcdoc attribute (FORBID_ATTR)", () => {
+    const result = sanitizeCustomHtml(
+      '<iframe srcdoc="<script>alert(1)</script>"></iframe>'
+    );
+    expect(result.sanitized).not.toContain("srcdoc");
+    expect(result.strippedAttrs).toContain("srcdoc");
+  });
+
+  it("10. strips href=javascript: but keeps <a> tag", () => {
+    const result = sanitizeCustomHtml(
+      '<a href="javascript:alert(1)">x</a>'
+    );
+    expect(result.sanitized).toContain("<a");
+    expect(result.sanitized).not.toContain("javascript:");
+    expect(result.sanitized).toContain(">x</a>");
+  });
+
+  it("11. strips href=//evil.com (protocol-relative)", () => {
+    const result = sanitizeCustomHtml('<a href="//evil.com/path">x</a>');
+    expect(result.sanitized).not.toContain("evil.com");
+    expect(result.sanitized).toContain("<a");
+    expect(result.sanitized).toContain(">x</a>");
+  });
+
+  it("12. allows https absolute href", () => {
+    const result = sanitizeCustomHtml(
+      '<a href="https://example.com/page">x</a>'
+    );
+    expect(result.sanitized).toContain('href="https://example.com/page"');
+  });
+
+  it("13. allows relative href /workshop/foo", () => {
+    const result = sanitizeCustomHtml('<a href="/workshop/foo">x</a>');
+    expect(result.sanitized).toContain('href="/workshop/foo"');
+  });
+
+  it("14. allows mailto href", () => {
+    const result = sanitizeCustomHtml(
+      '<a href="mailto:test@example.com">x</a>'
+    );
+    expect(result.sanitized).toContain('href="mailto:test@example.com"');
+  });
+
+  it("15. allows <style> block", () => {
+    const result = sanitizeCustomHtml("<style>body { color: red }</style>");
+    expect(result.sanitized).toContain("<style");
+    expect(result.sanitized).toContain("color: red");
+  });
+
+  it("16. allows inline style attribute", () => {
+    const result = sanitizeCustomHtml('<div style="color: red">x</div>');
+    expect(result.sanitized).toContain('style="color: red"');
+  });
+
+  it("17. strips doctype/html/head/title but keeps <p>hi</p>", () => {
+    const result = sanitizeCustomHtml(
+      "<!DOCTYPE html><html><head><title>x</title></head><body><p>hi</p></body></html>"
+    );
+    expect(result.sanitized).toContain("<p>hi</p>");
+    expect(result.sanitized).not.toContain("<!DOCTYPE");
+    expect(result.sanitized).not.toContain("<html");
+    expect(result.sanitized).not.toContain("<head");
+    expect(result.sanitized).not.toContain("<title");
+  });
+
+  it("18. handles empty string", () => {
+    const result = sanitizeCustomHtml("");
+    expect(result.sanitized).toBe("");
+    expect(result.didStripContent).toBe(false);
+    expect(result.strippedTags).toEqual([]);
+    expect(result.strippedAttrs).toEqual([]);
+  });
+
+  it("19. concurrency-safe: parallel calls do not leak state", async () => {
+    const [withScript, clean] = await Promise.all([
+      Promise.resolve(sanitizeCustomHtml("<script>alert(1)</script><p>a</p>")),
+      Promise.resolve(sanitizeCustomHtml("<p>b</p>")),
+    ]);
+    expect(withScript.strippedTags).toContain("script");
+    expect(clean.strippedTags).not.toContain("script");
+    expect(clean.didStripContent).toBe(false);
+  });
+
+  it("20. returns fresh arrays on subsequent calls (no shared refs)", () => {
+    const a = sanitizeCustomHtml("<p>a</p>");
+    const b = sanitizeCustomHtml("<p>b</p>");
+    expect(a.strippedTags).not.toBe(b.strippedTags);
+    expect(a.strippedAttrs).not.toBe(b.strippedAttrs);
+  });
+
+  it("FRAME_SRC_ALLOWLIST is exported and contains expected hosts", () => {
+    expect(Array.isArray(FRAME_SRC_ALLOWLIST)).toBe(true);
+    expect(FRAME_SRC_ALLOWLIST.length).toBeGreaterThanOrEqual(4);
+    expect(
+      FRAME_SRC_ALLOWLIST.some((r) => r.test("https://player.vimeo.com/x"))
+    ).toBe(true);
+    expect(
+      FRAME_SRC_ALLOWLIST.some((r) => r.test("https://js.stripe.com/v3/"))
+    ).toBe(true);
+    expect(
+      FRAME_SRC_ALLOWLIST.some((r) => r.test("https://www.youtube.com/embed/x"))
+    ).toBe(true);
+  });
+});

--- a/src/src/app/(dashboard)/templates/[id]/edit/page.tsx
+++ b/src/src/app/(dashboard)/templates/[id]/edit/page.tsx
@@ -39,6 +39,7 @@ export default async function TemplateEditorPage({ params }: PageProps) {
                 isActive={template.isActive}
                 initialContent={template.content}
                 initialCustomCode={template.customCode}
+                initialCustomHtml={template.customHtml}
             />
         </div>
     );

--- a/src/src/app/(public)/workshop/[slug]/page.tsx
+++ b/src/src/app/(public)/workshop/[slug]/page.tsx
@@ -139,6 +139,20 @@ export default async function LandingPageView({ params, searchParams }: PageProp
       notFound();
     }
 
+    // TEMPLATE-02: customHtml override. DOMPurify sanitized at save-time
+    // (PATCH /api/page-templates/[id]); variables HTML-escaped + interpolated
+    // at build-time (auto-build). Render is a trusted echo of the stored
+    // already-sanitized + escaped string.
+    if (landingPage.customHtml && landingPage.customHtml.trim().length > 0) {
+      return (
+        <div
+          data-custom-html-render
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{ __html: landingPage.customHtml }}
+        />
+      );
+    }
+
     const content = JSON.parse(landingPage.content);
     const workshop = landingPage.workshop;
 

--- a/src/src/app/api/landing-pages/library/route.ts
+++ b/src/src/app/api/landing-pages/library/route.ts
@@ -8,6 +8,9 @@ import { z } from "zod";
 const TEMPLATE_OPTIONS = ["SOLO_LANDING", "DUO_LANDING", "REGISTRATION", "THANK_YOU"] as const;
 type TemplateType = (typeof TEMPLATE_OPTIONS)[number];
 
+// TEMPLATE-02: eligibility filter — only SOLO_LANDING / DUO_LANDING may carry customHtml.
+const ELIGIBLE_CUSTOM_HTML: readonly TemplateType[] = ["SOLO_LANDING", "DUO_LANDING"] as const;
+
 const landingPageLibraryQuerySchema = z.object({
   template: z.string().trim().optional(),
   activeOnly: z.string().optional(),
@@ -265,6 +268,11 @@ export async function POST(request: NextRequest) {
             // pages keep their iDev pixel. Coach-accessible routes never
             // accept customCode from request bodies.
             customCode: sourcePage.customCode ?? null,
+            // TEMPLATE-02: eligibility filter — clone customHtml only into
+            // SOLO_LANDING / DUO_LANDING destinations.
+            customHtml: ELIGIBLE_CUSTOM_HTML.includes(targetTemplateRaw)
+              ? sourcePage.customHtml ?? null
+              : null,
           },
         });
 

--- a/src/src/app/api/page-templates/[id]/route.ts
+++ b/src/src/app/api/page-templates/[id]/route.ts
@@ -3,6 +3,10 @@ import { getApiActor, isPrivilegedRole } from "@/lib/auth/authorization";
 import { db } from "@/lib/db";
 import { logAudit } from "@/lib/audit";
 import { validateCustomCode } from "@/lib/templates/interpolate-custom-code";
+import { sanitizeCustomHtml } from "@/lib/templates/sanitize-custom-html";
+
+const CUSTOM_HTML_ELIGIBLE_TYPES = new Set(["SOLO_LANDING", "DUO_LANDING"]);
+const CUSTOM_HTML_MAX_LENGTH = 500_000;
 
 export async function GET(
     _request: NextRequest,
@@ -42,18 +46,33 @@ export async function PATCH(
     } catch {
         return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
     }
-    const { name, content, categoryId, isActive, customCode } = body as {
+    const { name, content, categoryId, isActive, customCode, customHtml } = body as {
         name?: string;
         content?: string;
         categoryId?: string | null;
         isActive?: boolean;
         customCode?: string | null;
+        customHtml?: string | null;
     };
 
-    // Validate template content has {{placeholders}} — prevent corruption
+    // TEMPLATE-02: eligibility + empty-string normalization + per-call sanitize
+    if (typeof customHtml === "string" && customHtml.length > CUSTOM_HTML_MAX_LENGTH) {
+        return NextResponse.json(
+            { error: "Custom HTML exceeds 500,000 character limit" },
+            { status: 400 }
+        );
+    }
+
+    const customHtmlIsNonEmpty =
+        typeof customHtml === "string" && customHtml.trim().length > 0;
+
+    // Validate template content has {{placeholders}} — prevent corruption.
+    // Customers using customHtml don't need placeholders in content, so a
+    // non-empty customHtml is an explicit escape hatch.
     if (content !== undefined) {
         const hasPlaceholders = /\{\{[^}]+\}\}/.test(content);
-        if (!hasPlaceholders && !(body as Record<string, unknown>).forceNoPlaceholders) {
+        const forceNoPlaceholders = (body as Record<string, unknown>).forceNoPlaceholders;
+        if (!hasPlaceholders && !customHtmlIsNonEmpty && !forceNoPlaceholders) {
             return NextResponse.json(
                 { error: "Template content has no {{placeholders}}. Auto-build requires placeholders to interpolate workshop data." },
                 { status: 400 }
@@ -74,6 +93,24 @@ export async function PATCH(
     const existing = await db.pageTemplate.findUnique({ where: { id } });
     if (!existing) {
         return NextResponse.json({ error: "Template not found" }, { status: 404 });
+    }
+
+    if (customHtmlIsNonEmpty && !CUSTOM_HTML_ELIGIBLE_TYPES.has(existing.templateType)) {
+        return NextResponse.json(
+            { error: "Custom HTML is only supported on SOLO_LANDING and DUO_LANDING templates" },
+            { status: 400 }
+        );
+    }
+
+    let normalizedCustomHtml: string | null | undefined;
+    let sanitizeResult: ReturnType<typeof sanitizeCustomHtml> | undefined;
+    if (customHtml !== undefined) {
+        if (customHtml === null || (typeof customHtml === "string" && customHtml.trim() === "")) {
+            normalizedCustomHtml = null;
+        } else {
+            sanitizeResult = sanitizeCustomHtml(customHtml);
+            normalizedCustomHtml = sanitizeResult.sanitized;
+        }
     }
 
     // Activation flow: deactivate competitors in the same slot
@@ -102,6 +139,7 @@ export async function PATCH(
                     ...(content !== undefined ? { content } : {}),
                     ...(categoryId !== undefined ? { categoryId } : {}),
                     ...(customCode !== undefined ? { customCode } : {}),
+                    ...(customHtml !== undefined ? { customHtml: normalizedCustomHtml } : {}),
                 },
             });
         });
@@ -115,6 +153,7 @@ export async function PATCH(
                 ...(categoryId !== undefined ? { categoryId } : {}),
                 ...(isActive !== undefined ? { isActive } : {}),
                 ...(customCode !== undefined ? { customCode } : {}),
+                ...(customHtml !== undefined ? { customHtml: normalizedCustomHtml } : {}),
             },
         });
     }
@@ -135,10 +174,24 @@ export async function PATCH(
             ...(categoryId !== undefined ? { categoryId } : {}),
             ...(content !== undefined ? { contentUpdated: true } : {}),
             ...(customCode !== undefined ? { customCode } : {}),
+            ...(customHtml !== undefined
+                ? {
+                      customHtmlChanged: true,
+                      customHtmlLength: normalizedCustomHtml?.length ?? 0,
+                      strippedTags: sanitizeResult?.strippedTags ?? [],
+                      strippedAttrs: sanitizeResult?.strippedAttrs ?? [],
+                  }
+                : {}),
         },
     });
 
-    return NextResponse.json({ success: true, data: updated });
+    return NextResponse.json({
+        success: true,
+        data: updated,
+        ...(customHtml !== undefined
+            ? { customHtmlSanitized: sanitizeResult?.didStripContent ?? false }
+            : {}),
+    });
 }
 
 export async function DELETE(

--- a/src/src/app/api/workshops/[id]/landing-pages/[template]/route.ts
+++ b/src/src/app/api/workshops/[id]/landing-pages/[template]/route.ts
@@ -29,9 +29,9 @@ const updateLandingPageBodySchema = z.object({
   // Coach role attempts get 403. parse5 validation runs server-side via
   // validateCustomCode (CHG-03). Pass null to clear.
   customCode: z.string().nullable().optional(),
-  // TEMPLATE-02: admin can override the template-default customHtml. Eligibility
-  // gated below (only SOLO_LANDING / DUO_LANDING). Sanitized server-side.
-  customHtml: z.string().max(500_000).nullable().optional(),
+  // Fix-1: customHtml is intentionally NOT accepted from this route's body.
+  // The route is coach-accessible (canManageCoachData), so admin-blessed HTML
+  // would be reachable by every coach. Edits live on /api/page-templates/[id].
 });
 
 function normalizeTemplate(template: string): TemplateType | null {
@@ -153,7 +153,7 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
       );
     }
 
-    const { content, status, customCode, customHtml } = bodyValidation.data;
+    const { content, status, customCode } = bodyValidation.data;
 
     // ENH-MAY6-5: customCode editing is admin/staff only. Coach attempts
     // (including via crafted PUT bodies) are rejected. validateCustomCode is
@@ -174,28 +174,6 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
           );
         }
       }
-    }
-
-    // TEMPLATE-02: eligibility filter — reject inbound customHtml on ineligible template types.
-    if (
-      customHtml !== undefined &&
-      customHtml !== null &&
-      !ELIGIBLE_CUSTOM_HTML.includes(normalizedTemplate)
-    ) {
-      return NextResponse.json(
-        {
-          success: false,
-          error: `customHtml is not eligible for template ${normalizedTemplate} (allowed: ${ELIGIBLE_CUSTOM_HTML.join(", ")})`,
-        },
-        { status: 400 }
-      );
-    }
-
-    // TEMPLATE-02: sanitize admin-supplied customHtml override defense-in-depth
-    // (PATCH on PageTemplate sanitizes too, but PUT may receive raw HTML).
-    let sanitizedCustomHtml: string | null | undefined = customHtml;
-    if (typeof customHtml === "string" && customHtml.length > 0) {
-      sanitizedCustomHtml = sanitizeCustomHtml(customHtml).sanitized;
     }
 
     // Check if workshop exists
@@ -238,9 +216,7 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
           // ENH-MAY6-5: only set customCode when explicitly provided.
           // Undefined keeps existing value; null clears.
           ...(customCode !== undefined ? { customCode } : {}),
-          // TEMPLATE-02: only set customHtml when explicitly provided. Eligibility
-          // checked above; sanitized value used.
-          ...(customHtml !== undefined ? { customHtml: sanitizedCustomHtml } : {}),
+          // Fix-1: customHtml is not writable from this route. Build-time copy is preserved.
         },
       });
     } else {
@@ -274,6 +250,8 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
       }
 
       // TEMPLATE-02: eligibility filter — only SOLO_LANDING / DUO_LANDING carry customHtml.
+      // Fix-2: post-interpolation strict re-sanitize catches malicious substitutions
+      // (e.g. virtualLink="javascript:alert(1)") even after admin-blessed save.
       let templateCustomHtml: string | null = null;
       if (
         chosenTemplate?.customHtml &&
@@ -281,9 +259,10 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
         ELIGIBLE_CUSTOM_HTML.includes(normalizedTemplate)
       ) {
         const variables = await buildWorkshopVariables(id);
-        templateCustomHtml = variables
+        const interpolated = variables
           ? interpolateContentForHtml(chosenTemplate.customHtml, variables)
           : chosenTemplate.customHtml;
+        templateCustomHtml = sanitizeCustomHtml(interpolated, { allowTokenUris: false }).sanitized;
       }
 
       landingPage = await db.landingPage.create({
@@ -296,9 +275,8 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
           publishedAt: status === "PUBLISHED" ? new Date() : null,
           // ENH-MAY6-5: explicit body customCode wins over template-default.
           customCode: customCode ?? chosenTemplate?.customCode ?? null,
-          // TEMPLATE-02: explicit body customHtml (sanitized) > template-copy (interpolated) > null.
-          customHtml:
-            sanitizedCustomHtml !== undefined ? sanitizedCustomHtml : templateCustomHtml,
+          // Fix-1: body customHtml dropped; only the template copy is stored.
+          customHtml: templateCustomHtml,
         },
       });
     }

--- a/src/src/app/api/workshops/[id]/landing-pages/[template]/route.ts
+++ b/src/src/app/api/workshops/[id]/landing-pages/[template]/route.ts
@@ -2,10 +2,16 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { canManageCoachData, getApiActor, isPrivilegedRole } from "@/lib/auth/authorization";
 import { validateCustomCode } from "@/lib/templates/interpolate-custom-code";
+import { buildWorkshopVariables } from "@/lib/templates/template-interpolation";
+import { interpolateContentForHtml } from "@/lib/templates/interpolate-content-html";
+import { sanitizeCustomHtml } from "@/lib/templates/sanitize-custom-html";
 import { z } from "zod";
 
 const VALID_TEMPLATES = ["BIO_PAGE", "SOLO_LANDING", "DUO_LANDING", "REGISTRATION", "THANK_YOU"] as const;
 type TemplateType = typeof VALID_TEMPLATES[number];
+
+// TEMPLATE-02: eligibility filter — only SOLO_LANDING / DUO_LANDING may carry customHtml.
+const ELIGIBLE_CUSTOM_HTML: readonly TemplateType[] = ["SOLO_LANDING", "DUO_LANDING"] as const;
 
 interface RouteParams {
   params: Promise<{ id: string; template: string }>;
@@ -23,6 +29,9 @@ const updateLandingPageBodySchema = z.object({
   // Coach role attempts get 403. parse5 validation runs server-side via
   // validateCustomCode (CHG-03). Pass null to clear.
   customCode: z.string().nullable().optional(),
+  // TEMPLATE-02: admin can override the template-default customHtml. Eligibility
+  // gated below (only SOLO_LANDING / DUO_LANDING). Sanitized server-side.
+  customHtml: z.string().max(500_000).nullable().optional(),
 });
 
 function normalizeTemplate(template: string): TemplateType | null {
@@ -144,7 +153,7 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
       );
     }
 
-    const { content, status, customCode } = bodyValidation.data;
+    const { content, status, customCode, customHtml } = bodyValidation.data;
 
     // ENH-MAY6-5: customCode editing is admin/staff only. Coach attempts
     // (including via crafted PUT bodies) are rejected. validateCustomCode is
@@ -165,6 +174,28 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
           );
         }
       }
+    }
+
+    // TEMPLATE-02: eligibility filter — reject inbound customHtml on ineligible template types.
+    if (
+      customHtml !== undefined &&
+      customHtml !== null &&
+      !ELIGIBLE_CUSTOM_HTML.includes(normalizedTemplate)
+    ) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: `customHtml is not eligible for template ${normalizedTemplate} (allowed: ${ELIGIBLE_CUSTOM_HTML.join(", ")})`,
+        },
+        { status: 400 }
+      );
+    }
+
+    // TEMPLATE-02: sanitize admin-supplied customHtml override defense-in-depth
+    // (PATCH on PageTemplate sanitizes too, but PUT may receive raw HTML).
+    let sanitizedCustomHtml: string | null | undefined = customHtml;
+    if (typeof customHtml === "string" && customHtml.length > 0) {
+      sanitizedCustomHtml = sanitizeCustomHtml(customHtml).sanitized;
     }
 
     // Check if workshop exists
@@ -207,6 +238,9 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
           // ENH-MAY6-5: only set customCode when explicitly provided.
           // Undefined keeps existing value; null clears.
           ...(customCode !== undefined ? { customCode } : {}),
+          // TEMPLATE-02: only set customHtml when explicitly provided. Eligibility
+          // checked above; sanitized value used.
+          ...(customHtml !== undefined ? { customHtml: sanitizedCustomHtml } : {}),
         },
       });
     } else {
@@ -216,6 +250,7 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
       // CHG-03: copy customCode from the matching admin-blessed PageTemplate
       // (category-scoped wins over global; falls back to all-active when
       // category match is empty — same precedence as auto-build).
+      // TEMPLATE-02: also copy customHtml (eligibility-filtered + interpolated).
       const candidateTemplates = await db.pageTemplate.findMany({
         where: {
           templateType: normalizedTemplate,
@@ -225,15 +260,30 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
             { categoryId: null },
           ],
         },
-        select: { customCode: true, categoryId: true },
+        select: { customCode: true, customHtml: true, categoryId: true },
       });
-      let chosenTemplate = candidateTemplates.find((t) => t.categoryId !== null) ?? candidateTemplates[0] ?? null;
+      let chosenTemplate:
+        | { customCode: string | null; customHtml: string | null; categoryId: string | null }
+        | null = candidateTemplates.find((t) => t.categoryId !== null) ?? candidateTemplates[0] ?? null;
       if (!chosenTemplate && workshop.categoryId) {
         const fallback = await db.pageTemplate.findFirst({
           where: { templateType: normalizedTemplate, isActive: true },
-          select: { customCode: true },
+          select: { customCode: true, customHtml: true },
         });
-        if (fallback) chosenTemplate = { customCode: fallback.customCode, categoryId: null };
+        if (fallback) chosenTemplate = { customCode: fallback.customCode, customHtml: fallback.customHtml, categoryId: null };
+      }
+
+      // TEMPLATE-02: eligibility filter — only SOLO_LANDING / DUO_LANDING carry customHtml.
+      let templateCustomHtml: string | null = null;
+      if (
+        chosenTemplate?.customHtml &&
+        chosenTemplate.customHtml.trim().length > 0 &&
+        ELIGIBLE_CUSTOM_HTML.includes(normalizedTemplate)
+      ) {
+        const variables = await buildWorkshopVariables(id);
+        templateCustomHtml = variables
+          ? interpolateContentForHtml(chosenTemplate.customHtml, variables)
+          : chosenTemplate.customHtml;
       }
 
       landingPage = await db.landingPage.create({
@@ -246,6 +296,9 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
           publishedAt: status === "PUBLISHED" ? new Date() : null,
           // ENH-MAY6-5: explicit body customCode wins over template-default.
           customCode: customCode ?? chosenTemplate?.customCode ?? null,
+          // TEMPLATE-02: explicit body customHtml (sanitized) > template-copy (interpolated) > null.
+          customHtml:
+            sanitizedCustomHtml !== undefined ? sanitizedCustomHtml : templateCustomHtml,
         },
       });
     }

--- a/src/src/components/templates/template-content-editor.tsx
+++ b/src/src/components/templates/template-content-editor.tsx
@@ -5,6 +5,11 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+
+// TEMPLATE-02: customHtml is only exposed on these template types
+const ELIGIBLE_CUSTOM_HTML = ["SOLO_LANDING", "DUO_LANDING"] as const;
 import { TEMPLATE_PREVIEW_DATA } from "@/lib/templates/template-preview";
 import { interpolateContent } from "@/lib/templates/template-interpolation-core";
 import {
@@ -42,6 +47,7 @@ interface Props {
     isActive: boolean;
     initialContent: string;
     initialCustomCode?: string | null;
+    initialCustomHtml?: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -56,6 +62,7 @@ export function TemplateContentEditor({
     isActive,
     initialContent,
     initialCustomCode,
+    initialCustomHtml,
 }: Props) {
     // Parse initial content, merging over defaults for the active type only (I-1 fix)
     const parsed = safeJsonParse(initialContent);
@@ -79,8 +86,14 @@ export function TemplateContentEditor({
             : THANKYOU_DEFAULTS
     );
     const [customCode, setCustomCode] = useState<string | null>(initialCustomCode ?? null);
+    const [customHtml, setCustomHtml] = useState<string>(initialCustomHtml ?? "");
+    const [customHtmlSanitizedNotice, setCustomHtmlSanitizedNotice] = useState<boolean>(false);
     const [saving, setSaving] = useState(false);
     const [message, setMessage] = useState("");
+
+    const showCustomHtmlSection = ELIGIBLE_CUSTOM_HTML.includes(
+        templateType as (typeof ELIGIBLE_CUSTOM_HTML)[number]
+    );
 
     // Get current form data based on template type
     function getCurrentData(): Record<string, unknown> {
@@ -111,14 +124,21 @@ export function TemplateContentEditor({
     const handleSave = async () => {
         setSaving(true);
         setMessage("");
+        setCustomHtmlSanitizedNotice(false);
 
         try {
             const currentData = getCurrentData();
             const content = JSON.stringify(currentData);
+            // TEMPLATE-02: customHtml in save payload (null when blank/whitespace)
+            const normalizedCustomHtml = customHtml.trim() ? customHtml : null;
             const res = await fetch(`/api/page-templates/${templateId}`, {
                 method: "PATCH",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ content, customCode }),
+                body: JSON.stringify({
+                    content,
+                    customCode,
+                    customHtml: normalizedCustomHtml,
+                }),
             });
             // CHG-03: surface validation errors (e.g. customCode rejected) inline
             // instead of the generic "Server returned 400".
@@ -135,6 +155,9 @@ export function TemplateContentEditor({
             if (data.success) {
                 setSavedSnapshot(currentData); // Reset dirty state
                 setMessage("Saved successfully");
+                if (data.customHtmlSanitized === true) {
+                    setCustomHtmlSanitizedNotice(true);
+                }
             } else {
                 setMessage(`Error: ${data.error}`);
             }
@@ -165,6 +188,114 @@ export function TemplateContentEditor({
                     </p>
                 </div>
             </div>
+
+            {/* TEMPLATE-02: customHtml override section (SOLO_LANDING + DUO_LANDING only) */}
+            {showCustomHtmlSection && (
+                <Card className={customHtml.trim() ? "border-primary" : ""}>
+                    <CardHeader>
+                        <div className="flex items-center justify-between gap-3">
+                            <CardTitle>Custom HTML</CardTitle>
+                            <Badge variant={customHtml.trim() ? "default" : "secondary"}>
+                                {customHtml.trim()
+                                    ? "Active · overrides fields below"
+                                    : "Empty — fields below render"}
+                            </Badge>
+                        </div>
+                    </CardHeader>
+                    <CardContent>
+                        <Alert>
+                            <AlertDescription>
+                                When this box has any content, your HTML is rendered directly to visitors.
+                                Leave it empty to use the field-based editor below.{" "}
+                                <strong>Paste BODY HTML only</strong> — no &lt;!doctype&gt; /
+                                &lt;html&gt; / &lt;head&gt; / &lt;title&gt; / &lt;link&gt; tags. Use
+                                &lt;style&gt; blocks inline. Variables like{" "}
+                                <code>{"{{workshop_title}}"}</code>, <code>{"{{coach_name}}"}</code>,{" "}
+                                <code>{"{{event_date}}"}</code>, <code>{"{{registration_url}}"}</code>{" "}
+                                are replaced when a workshop is approved.{" "}
+                                <em>
+                                    Live workshop fields (venue, virtual link, format) update only if
+                                    you reference their {"{{tokens}}"} — Custom HTML does not get the
+                                    live overlay the React templates use.
+                                </em>
+                            </AlertDescription>
+                        </Alert>
+
+                        <div className="grid grid-cols-1 md:grid-cols-[1fr,260px] gap-4 mt-4">
+                            <div>
+                                <Label htmlFor="customHtml" className="sr-only">
+                                    Custom HTML
+                                </Label>
+                                <textarea
+                                    id="customHtml"
+                                    aria-label="Custom HTML"
+                                    rows={24}
+                                    value={customHtml}
+                                    onChange={(e) => setCustomHtml(e.target.value)}
+                                    className="font-mono text-sm w-full border border-input rounded-md p-2 bg-background"
+                                    placeholder="Paste your HTML here..."
+                                    spellCheck={false}
+                                />
+                            </div>
+                            <div className="text-sm space-y-1">
+                                <h4 className="font-semibold">Available variables</h4>
+                                <ul className="list-disc list-inside text-xs space-y-0.5">
+                                    <li><code>{"{{workshop_title}}"}</code> — workshop title</li>
+                                    <li><code>{"{{workshop_description}}"}</code></li>
+                                    <li><code>{"{{coach_name}}"}</code></li>
+                                    <li><code>{"{{coach_first_name}}"}</code></li>
+                                    <li><code>{"{{coach_company}}"}</code></li>
+                                    <li><code>{"{{coach_title}}"}</code></li>
+                                    <li><code>{"{{coach_bio}}"}</code> — HTML-escaped at build time</li>
+                                    <li><code>{"{{coach_photo}}"}</code> — image URL</li>
+                                    <li><code>{"{{event_day}}"}</code></li>
+                                    <li><code>{"{{event_date}}"}</code></li>
+                                    <li><code>{"{{event_time}}"}</code></li>
+                                    <li><code>{"{{workshop_format}}"}</code> — VIRTUAL / IN_PERSON / HYBRID</li>
+                                    <li><code>{"{{venue_name}}"}</code></li>
+                                    <li><code>{"{{venue_address}}"}</code></li>
+                                    <li><code>{"{{virtual_link}}"}</code></li>
+                                    <li><code>{"{{price}}"}</code></li>
+                                    <li><code>{"{{registration_url}}"}</code> — absolute, empty when no REGISTRATION template</li>
+                                    <li><code>{"{{category_name}}"}</code></li>
+                                </ul>
+                            </div>
+                        </div>
+
+                        {customHtmlSanitizedNotice && (
+                            <Alert
+                                variant="default"
+                                className="mt-3 border-yellow-500 bg-yellow-50 text-yellow-900"
+                            >
+                                <AlertDescription>
+                                    Saved. Some HTML was sanitized for safety — view the rendered
+                                    landing page to verify.
+                                </AlertDescription>
+                            </Alert>
+                        )}
+
+                        {/* Save button for DUO_LANDING (which uses the JSON fallback below) */}
+                        {!isVisual && (
+                            <div className="mt-4 flex items-center gap-3">
+                                <Button onClick={handleSave} disabled={saving}>
+                                    {saving ? "Saving..." : "Save Template"}
+                                </Button>
+                                {message && (
+                                    <p
+                                        className={`text-sm ${
+                                            message.startsWith("Error") || message.startsWith("Network")
+                                                ? "text-destructive"
+                                                : "text-success"
+                                        }`}
+                                    >
+                                        {message}
+                                    </p>
+                                )}
+                            </div>
+                        )}
+                    </CardContent>
+                </Card>
+            )}
 
             {/* Variable info banner */}
             {isVisual && (

--- a/src/src/lib/auto-build-service.ts
+++ b/src/src/lib/auto-build-service.ts
@@ -10,9 +10,13 @@
 
 import { db } from "@/lib/db";
 import { buildWorkshopVariables, interpolateContent, templateHasPlaceholders, findRemainingPlaceholders } from "@/lib/templates/template-interpolation";
+import { interpolateContentForHtml } from "@/lib/templates/interpolate-content-html";
 import { sendWorkshopBuiltEmail } from "@/services/notifications";
 import { inngest } from "@/inngest/client";
 import { findAutoAttachWorkflow } from "@/lib/workflows/find-auto-attach-workflow";
+
+// TEMPLATE-02: eligibility filter — only these template types may carry customHtml.
+const ELIGIBLE_CUSTOM_HTML = ["SOLO_LANDING", "DUO_LANDING"] as const;
 
 export interface AutoBuildResult {
     success: boolean;
@@ -88,7 +92,8 @@ export async function runAutoBuild(workshopId: string): Promise<AutoBuildResult>
     let activeTemplates = await db.pageTemplate.findMany({
         where: { isActive: true, ...categoryFilter },
         // CHG-03: include customCode so it copies through to LandingPage at build time.
-        select: { id: true, templateType: true, content: true, categoryId: true, customCode: true },
+        // TEMPLATE-02: include customHtml so it copies through (eligibility-filtered below).
+        select: { id: true, templateType: true, content: true, categoryId: true, customCode: true, customHtml: true },
     });
 
     // Deduplicate — prefer category-scoped over global for same template type
@@ -106,16 +111,20 @@ export async function runAutoBuild(workshopId: string): Promise<AutoBuildResult>
         activeTemplates = await db.pageTemplate.findMany({
             where: { isActive: true },
             // CHG-03: include customCode so it copies through to LandingPage at build time.
-            select: { id: true, templateType: true, content: true, categoryId: true, customCode: true },
+            // TEMPLATE-02: include customHtml so it copies through (eligibility-filtered below).
+            select: { id: true, templateType: true, content: true, categoryId: true, customCode: true, customHtml: true },
         });
     }
 
     // Filter OUT corrupted templates (no placeholders = corrupted content)
+    // TEMPLATE-02: keep templates whose customHtml is populated even if content is placeholder-less.
     activeTemplates = activeTemplates.filter(tpl => {
-        if (!templateHasPlaceholders(tpl.content)) {
+        const hasCustomHtml = !!tpl.customHtml && tpl.customHtml.trim().length > 0;
+        if (!templateHasPlaceholders(tpl.content) && !hasCustomHtml) {
             console.error(
-                `[auto-build-service] SKIPPING PageTemplate ${tpl.id} (${tpl.templateType}) — no {{placeholders}}. ` +
-                `Content may be corrupted. Re-run: npx tsx prisma/seed-templates.ts`
+                `[auto-build-service] SKIPPING PageTemplate ${tpl.id} (${tpl.templateType}) — no {{placeholders}} ` +
+                `and customHtml is empty. Content may be corrupted. ` +
+                `Re-run: npx tsx prisma/seed-templates.ts`
             );
             return false;
         }
@@ -139,25 +148,33 @@ export async function runAutoBuild(workshopId: string): Promise<AutoBuildResult>
         };
     }
 
-    // Step 4: Create landing pages
+    // Step 4: Create landing pages — TEMPLATE-02 two-pass interpolation.
+    // Pass 1 builds REGISTRATION first so its slug is known when interpolating
+    // {{registration_url}} into SOLO_LANDING / DUO_LANDING customHtml in Pass 2.
     const created: string[] = [];
     let primarySlug: string | null = null;
+    let regPageSlug: string | null = null;
 
-    for (const tpl of activeTemplates) {
-        // Check if this workshop already has a page for this template type
+    const titleBase = workshop.title
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/(^-|-$)/g, "");
+
+    async function buildOnePage(
+        tpl: (typeof activeTemplates)[number],
+        enrichedVars: Record<string, string | null | undefined>
+    ): Promise<string | null> {
         const existingPage = await db.landingPage.findUnique({
             where: {
                 workshopId_template: {
-                    workshopId: workshop.id,
+                    workshopId: workshop!.id,
                     template: tpl.templateType,
                 },
             },
         });
+        if (existingPage) return null;
 
-        if (existingPage) continue; // Don't overwrite manually created pages
-
-        // Interpolate variables in content
-        const interpolatedContent = interpolateContent(tpl.content, variables);
+        const interpolatedContent = interpolateContent(tpl.content, enrichedVars as Record<string, string>);
 
         const remaining = findRemainingPlaceholders(interpolatedContent);
         if (remaining.length > 0) {
@@ -166,17 +183,19 @@ export async function runAutoBuild(workshopId: string): Promise<AutoBuildResult>
             );
         }
 
-        // Generate unique slug
-        const base = workshop.title
-            .toLowerCase()
-            .replace(/[^a-z0-9]+/g, "-")
-            .replace(/(^-|-$)/g, "");
         const templateSuffix = tpl.templateType.toLowerCase().replace(/_/g, "-");
-        const slug = `${base}-${templateSuffix}-${Date.now().toString(36)}`;
+        const slug = `${titleBase}-${templateSuffix}-${Date.now().toString(36)}`;
+
+        // TEMPLATE-02: eligibility filter — only SOLO_LANDING / DUO_LANDING carry customHtml.
+        const interpolatedCustomHtml =
+            tpl.customHtml && tpl.customHtml.trim().length > 0 &&
+            (ELIGIBLE_CUSTOM_HTML as readonly string[]).includes(tpl.templateType)
+                ? interpolateContentForHtml(tpl.customHtml, enrichedVars)
+                : null;
 
         await db.landingPage.create({
             data: {
-                workshopId: workshop.id,
+                workshopId: workshop!.id,
                 template: tpl.templateType,
                 slug,
                 content: interpolatedContent,
@@ -186,14 +205,40 @@ export async function runAutoBuild(workshopId: string): Promise<AutoBuildResult>
                 // CHG-03: copy admin-blessed customCode through at build time.
                 // Coach-accessible routes never accept customCode from request bodies.
                 customCode: tpl.customCode ?? null,
+                // TEMPLATE-02: customHtml two-pass interpolation (null on ineligible templates).
+                customHtml: interpolatedCustomHtml,
             },
         });
 
         created.push(tpl.templateType);
         if (!primarySlug) primarySlug = slug;
+        return slug;
+    }
+
+    // Pass 1: build REGISTRATION first (if present) so its slug seeds {{registration_url}}.
+    const regTemplate = activeTemplates.find((t) => t.templateType === "REGISTRATION");
+    if (regTemplate) {
+        regPageSlug = await buildOnePage(regTemplate, variables);
+    }
+
+    // Build enriched variable map with absolute registration_url (or empty string).
+    const registrationUrl = regPageSlug
+        ? `${process.env.APP_URL}/workshop/${regPageSlug}`
+        : "";
+    const enrichedVars: Record<string, string | null | undefined> = {
+        ...variables,
+        registration_url: registrationUrl,
+        registrationUrl, // camelCase alias for templates that prefer that form
+    };
+
+    // Pass 2: build all OTHER templates with enrichedVars.
+    for (const tpl of activeTemplates) {
+        if (tpl.templateType === "REGISTRATION") continue;
+        await buildOnePage(tpl, enrichedVars);
     }
 
     // Step 4b: Link SOLO_LANDING registrationUrl → REGISTRATION page
+    // TODO TEMPLATE-02 follow-up: remove redundant post-patch once content interpolation is verified
     if (created.includes("SOLO_LANDING") && created.includes("REGISTRATION")) {
         const regPage = await db.landingPage.findFirst({
             where: { workshopId, template: "REGISTRATION" },
@@ -223,7 +268,7 @@ export async function runAutoBuild(workshopId: string): Promise<AutoBuildResult>
 
     // Step 6: Update workshop status to PRE_EVENT
     // Prefer SOLO_LANDING slug for the main landing page URL
-    let landingPageSlug = primarySlug;
+    let landingPageSlug: string | null = primarySlug;
     if (created.length > 0) {
         const soloPage = await db.landingPage.findFirst({
             where: { workshopId, template: "SOLO_LANDING" },

--- a/src/src/lib/auto-build-service.ts
+++ b/src/src/lib/auto-build-service.ts
@@ -11,6 +11,7 @@
 import { db } from "@/lib/db";
 import { buildWorkshopVariables, interpolateContent, templateHasPlaceholders, findRemainingPlaceholders } from "@/lib/templates/template-interpolation";
 import { interpolateContentForHtml } from "@/lib/templates/interpolate-content-html";
+import { sanitizeCustomHtml } from "@/lib/templates/sanitize-custom-html";
 import { sendWorkshopBuiltEmail } from "@/services/notifications";
 import { inngest } from "@/inngest/client";
 import { findAutoAttachWorkflow } from "@/lib/workflows/find-auto-attach-workflow";
@@ -187,10 +188,15 @@ export async function runAutoBuild(workshopId: string): Promise<AutoBuildResult>
         const slug = `${titleBase}-${templateSuffix}-${Date.now().toString(36)}`;
 
         // TEMPLATE-02: eligibility filter — only SOLO_LANDING / DUO_LANDING carry customHtml.
+        // Two-stage sanitize: PATCH save was loose (token URIs preserved); after interpolation
+        // we strict-re-sanitize so any malicious substituted URL (e.g. javascript:) gets stripped.
         const interpolatedCustomHtml =
             tpl.customHtml && tpl.customHtml.trim().length > 0 &&
             (ELIGIBLE_CUSTOM_HTML as readonly string[]).includes(tpl.templateType)
-                ? interpolateContentForHtml(tpl.customHtml, enrichedVars)
+                ? sanitizeCustomHtml(
+                    interpolateContentForHtml(tpl.customHtml, enrichedVars),
+                    { allowTokenUris: false }
+                  ).sanitized
                 : null;
 
         await db.landingPage.create({
@@ -216,9 +222,23 @@ export async function runAutoBuild(workshopId: string): Promise<AutoBuildResult>
     }
 
     // Pass 1: build REGISTRATION first (if present) so its slug seeds {{registration_url}}.
+    // If a prior partial build already created the REGISTRATION row, buildOnePage returns null
+    // (existingPage skip). Fall back to the stored slug so SOLO_LANDING still gets a real URL.
     const regTemplate = activeTemplates.find((t) => t.templateType === "REGISTRATION");
     if (regTemplate) {
         regPageSlug = await buildOnePage(regTemplate, variables);
+    }
+    if (!regPageSlug) {
+        const existingReg = await db.landingPage.findUnique({
+            where: {
+                workshopId_template: {
+                    workshopId: workshop.id,
+                    template: "REGISTRATION",
+                },
+            },
+            select: { slug: true },
+        });
+        if (existingReg) regPageSlug = existingReg.slug;
     }
 
     // Build enriched variable map with absolute registration_url (or empty string).

--- a/src/src/lib/templates/interpolate-content-html.ts
+++ b/src/src/lib/templates/interpolate-content-html.ts
@@ -1,0 +1,22 @@
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#x27;");
+}
+
+export function interpolateContentForHtml(
+  template: string,
+  variables: Record<string, string | null | undefined>
+): string {
+  let out = template;
+  for (const [key, raw] of Object.entries(variables)) {
+    const value = raw == null ? "" : raw;
+    const escaped = escapeHtml(value);
+    out = out.split(`{{${key}}}`).join(escaped);
+    out = out.split(`{{ ${key} }}`).join(escaped);
+  }
+  return out;
+}

--- a/src/src/lib/templates/sanitize-custom-html.ts
+++ b/src/src/lib/templates/sanitize-custom-html.ts
@@ -1,3 +1,4 @@
+// Using dompurify directly + per-call JSDOM window so the Next/Jest test runner doesn't choke on isomorphic-dompurify's ESM-only transitive dep.
 import createDOMPurify from "dompurify";
 
 export const FRAME_SRC_ALLOWLIST: RegExp[] = [
@@ -26,7 +27,22 @@ function getWindow(): Window {
 
 const PARSER_DROPPED_TAGS = ["script", "noscript", "noembed", "noframes"];
 
-export function sanitizeCustomHtml(input: string): SanitizeResult {
+// Save-time: allow {{token}} (with optional spaces) literals through the URI gate
+// so admin-blessed HTML with placeholder href/src survives storage.
+const URI_REGEXP_WITH_TOKENS = /^(https:\/\/|mailto:|tel:|#|\/[^\/]|\{\{\s*[a-zA-Z_][a-zA-Z0-9_]*\s*\}\})/i;
+// Post-interpolation: strict — no token form allowed, so malicious substitutions
+// (e.g. virtualLink="javascript:alert(1)") get caught on the re-sanitize pass.
+const URI_REGEXP_STRICT = /^(https:\/\/|mailto:|tel:|#|\/[^\/])/i;
+
+export interface SanitizeOptions {
+  allowTokenUris?: boolean;
+}
+
+export function sanitizeCustomHtml(
+  input: string,
+  options: SanitizeOptions = {}
+): SanitizeResult {
+  const allowTokenUris = options.allowTokenUris !== false;
   const strippedTags: string[] = [];
   const strippedAttrs: string[] = [];
 
@@ -76,7 +92,7 @@ export function sanitizeCustomHtml(input: string): SanitizeResult {
     ADD_TAGS: ["iframe"],
     ADD_ATTR: ["allow", "allowfullscreen", "frameborder", "loading"],
     FORBID_ATTR: ["srcdoc"],
-    ALLOWED_URI_REGEXP: /^(https:\/\/|mailto:|tel:|#|\/[^\/])/i,
+    ALLOWED_URI_REGEXP: allowTokenUris ? URI_REGEXP_WITH_TOKENS : URI_REGEXP_STRICT,
     FORCE_BODY: true,
   }) as string;
 

--- a/src/src/lib/templates/sanitize-custom-html.ts
+++ b/src/src/lib/templates/sanitize-custom-html.ts
@@ -1,0 +1,89 @@
+import createDOMPurify from "dompurify";
+
+export const FRAME_SRC_ALLOWLIST: RegExp[] = [
+  /^https:\/\/js\.stripe\.com\//i,
+  /^https:\/\/hooks\.stripe\.com\//i,
+  /^https:\/\/player\.vimeo\.com\//i,
+  /^https:\/\/(www\.)?youtube(-nocookie)?\.com\//i,
+];
+
+export type SanitizeResult = {
+  sanitized: string;
+  didStripContent: boolean;
+  strippedTags: string[];
+  strippedAttrs: string[];
+};
+
+function getWindow(): Window {
+  const existing = (globalThis as { window?: Window }).window;
+  if (existing && typeof existing.document !== "undefined") {
+    return existing;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { JSDOM } = require("jsdom");
+  return new JSDOM("").window as Window;
+}
+
+const PARSER_DROPPED_TAGS = ["script", "noscript", "noembed", "noframes"];
+
+export function sanitizeCustomHtml(input: string): SanitizeResult {
+  const strippedTags: string[] = [];
+  const strippedAttrs: string[] = [];
+
+  if (input === "") {
+    return { sanitized: "", didStripContent: false, strippedTags, strippedAttrs };
+  }
+
+  // DOMParser drops <script>/<noscript> before DOMPurify hooks fire; pre-scan to surface them
+  for (const tag of PARSER_DROPPED_TAGS) {
+    const re = new RegExp(`<\\s*${tag}\\b`, "i");
+    if (re.test(input)) {
+      strippedTags.push(tag);
+    }
+  }
+
+  // per-call instance — global hooks race under concurrent auto-build
+  const win = getWindow();
+  const DOMPurify = createDOMPurify(win as unknown as typeof globalThis & Window);
+
+  DOMPurify.addHook("uponSanitizeElement", (_node, data) => {
+    if (!data.allowedTags[data.tagName]) {
+      strippedTags.push(data.tagName);
+    }
+  });
+
+  DOMPurify.addHook("uponSanitizeAttribute", (_node, data) => {
+    if (!data.allowedAttributes[data.attrName]) {
+      strippedAttrs.push(data.attrName);
+    }
+  });
+
+  // CSP frame-src parity — iframes with disallowed hosts get src stripped
+  DOMPurify.addHook("afterSanitizeAttributes", (node) => {
+    const el = node as Element;
+    if (el.tagName === "IFRAME" && el.hasAttribute("src")) {
+      const src = el.getAttribute("src") ?? "";
+      const allowed = FRAME_SRC_ALLOWLIST.some((re) => re.test(src));
+      if (!allowed) {
+        el.removeAttribute("src");
+        strippedAttrs.push("iframe-src(blocked-host)");
+      }
+    }
+  });
+
+  const sanitized = DOMPurify.sanitize(input, {
+    USE_PROFILES: { html: true },
+    ADD_TAGS: ["iframe"],
+    ADD_ATTR: ["allow", "allowfullscreen", "frameborder", "loading"],
+    FORBID_ATTR: ["srcdoc"],
+    ALLOWED_URI_REGEXP: /^(https:\/\/|mailto:|tel:|#|\/[^\/])/i,
+    FORCE_BODY: true,
+  }) as string;
+
+  return {
+    sanitized,
+    didStripContent: strippedTags.length > 0 || strippedAttrs.length > 0,
+    strippedTags,
+    strippedAttrs,
+  };
+}


### PR DESCRIPTION
## Summary
Closes the look-and-feel-control gap Jeff flagged on May 29. Admins can now paste raw HTML into a Custom HTML textarea on `/admin/templates/[id]/edit` for SOLO_LANDING + DUO_LANDING templates only. The pasted HTML is DOMPurify-sanitized at save time (per-call instance, FORBID iframe srcdoc, CSP-aware `frame-src` allowlist) and stored on `PageTemplate.customHtml`. On workshop approval, the auto-build copies it to `LandingPage.customHtml` after a TWO-pass interpolation: REGISTRATION builds first to capture its slug, then SOLO/DUO get absolute `registration_url` interpolated into both their React-template content AND their customHtml. Every variable is HTML-escaped before substitution (closes stored-XSS via coach bio etc.) and the interpolated output is re-sanitized in strict mode (catches `javascript:` substitutions). Render path at `(public)/workshop/[slug]` echoes the stored sanitized string via React's HTML-injection prop; non-empty customHtml replaces the React template.

## Behavior
- Eligibility: SOLO_LANDING + DUO_LANDING only; HIDDEN entirely in editor for REGISTRATION / THANK_YOU / BIO_PAGE.
- Size cap: 500 KB / row.
- Tokens supported in attributes: `<a href="{{registration_url}}">` survives save (token-aware regex), gets the real URL interpolated, and is re-sanitized strict so a `javascript:` substitution would strip the href.
- Variables surfaced: `{{workshop_title}}` `{{coach_name}}` `{{coach_bio}}` `{{event_date}}` `{{venue_name}}` `{{virtual_link}}` `{{registration_url}}` + 11 more.
- `registration_url` is absolute (`${APP_URL}/workshop/<regSlug>`); empty-string fallback when no REGISTRATION template exists.
- Coach PUT route (`/api/workshops/[id]/landing-pages/[template]`) does NOT accept customHtml from body — admins write only via PATCH on PageTemplate.
- Existing React templates + customCode flow untouched when customHtml is null/empty.

## Review history
- Plan: `~/.claude/plans/previous-instance-crashed-with-glittery-cake.md`
- Codex Round 1: 13 findings — all absorbed.
- Greptile-style Round 1 (3 parallel reviewers): 7 critical + 10 major — all absorbed.
- Codex Round 2 (on consolidated diff): 2 BLOCK + 3 HIGH + 3 MEDIUM — 4 fixed in commit `e14aa6d`; remaining HIGH #3 (render-path re-sanitize defense-in-depth), MEDIUM #1, MEDIUM #3 documented as Phase-2 follow-ups.

## Test plan
- [x] 163/163 unit + integration tests GREEN across 13 affected suites.
- [x] `CI=true npx next build --turbopack` clean.
- [ ] **Browser-verify on Vercel preview**: paste a clean snippet on SOLO_LANDING with `{{workshop_title}}` + `{{registration_url}}` + `{{coach_bio}}` (where bio = `<img src=x onerror=alert(1)>`). Save. Confirm: tokens visible as `{{...}}` in saved value; visiting a workshop on that template renders the HTML with interpolated values and bio rendered as ESCAPED text (not live img tag).
- [ ] **Eligibility 400** on REGISTRATION template PATCH.
- [ ] **Sanitized notice** appears when pasting `<script>alert(1)</script>`.
- [ ] **No-REGISTRATION fallback** — category without an active REGISTRATION template still builds SOLO_LANDING with empty `registration_url`.
- [ ] **Clearing customHtml** falls through to the React template (regression).

## Notion
https://www.notion.so/3728c45dd829819aa9e3dac61a798bcb

🤖 Generated with [Claude Code](https://claude.com/claude-code)