### PR TITLE
feat(templates): customHtml live preview in editor

### DIFF
--- a/src/src/components/templates/template-content-editor.tsx
+++ b/src/src/components/templates/template-content-editor.tsx
@@ -377,18 +377,38 @@ export function TemplateContentEditor({
                     <div className="col-span-3 sticky top-4 self-start">
                         <Card className="overflow-hidden">
                             <CardHeader className="bg-muted border-b py-2">
-                                <CardTitle className="text-sm font-medium">Live Preview</CardTitle>
+                                <CardTitle className="text-sm font-medium">
+                                    Live Preview
+                                    {showCustomHtmlSection && customHtml.trim() && (
+                                        <span className="ml-2 text-xs font-normal text-primary">· Custom HTML</span>
+                                    )}
+                                </CardTitle>
                             </CardHeader>
                             <CardContent className="p-0">
                                 <div className="max-h-[calc(100vh-200px)] overflow-y-auto">
-                                    {templateType === "SOLO_LANDING" && (
-                                        <SoloPreview data={soloData} />
-                                    )}
-                                    {templateType === "REGISTRATION" && (
-                                        <RegistrationPreview data={regData} />
-                                    )}
-                                    {templateType === "THANK_YOU" && (
-                                        <ThankYouPreview data={tyData} />
+                                    {/* TEMPLATE-02: when customHtml is non-empty (and template is eligible),
+                                        the public render uses it instead of the React templates — preview
+                                        the actual output via a sandboxed iframe with sample-data interpolation. */}
+                                    {showCustomHtmlSection && customHtml.trim() ? (
+                                        <iframe
+                                            title="Custom HTML preview"
+                                            sandbox="allow-same-origin"
+                                            className="w-full border-0"
+                                            style={{ height: "calc(100vh - 220px)", background: "#fff" }}
+                                            srcDoc={`<!doctype html><html><head><meta charset="utf-8"><base target="_blank"></head><body>${previewValue(customHtml)}</body></html>`}
+                                        />
+                                    ) : (
+                                        <>
+                                            {templateType === "SOLO_LANDING" && (
+                                                <SoloPreview data={soloData} />
+                                            )}
+                                            {templateType === "REGISTRATION" && (
+                                                <RegistrationPreview data={regData} />
+                                            )}
+                                            {templateType === "THANK_YOU" && (
+                                                <ThankYouPreview data={tyData} />
+                                            )}
+                                        </>
                                     )}
                                 </div>
                             </CardContent>


### PR DESCRIPTION
## Summary
The editor's Live Preview pane used to ALWAYS render the React-template preview ("Sample: Scaling Up Masterclass / Jane Smith") regardless of customHtml. That's misleading — when customHtml is set, the actual public render bypasses the React templates entirely.

Now: when the Custom HTML textarea is non-empty (SOLO_LANDING / DUO_LANDING only), the preview pane renders the actual customHtml output inside a sandboxed iframe with sample data interpolated. Empty textarea → falls through to the existing React previews (zero regression).

Closes the Slice 6 deferred follow-up; admins can paste HTML and see exactly what visitors will see, without having to approve a workshop first.

## Test plan
- [x] 14/14 template-content-editor tests still green
- [x] `CI=true npx next build --turbopack` clean
- [ ] **Re-verify after deploy**: open Standard Solo Landing Page → preview pane shows brand starter, not Jane Smith Masterclass

🤖 Generated with [Claude Code](https://claude.com/claude-code)