### PR TITLE
fix(assessment): selectable Likert control (min value was unselectable) + branded survey polish

### DIFF
--- a/src/src/__tests__/assessments/org-survey-pager.test.tsx
+++ b/src/src/__tests__/assessments/org-survey-pager.test.tsx
@@ -121,8 +121,8 @@ describe("OrgSurveyClient — SectionPager wiring + hidden-orphan fix", () => {
     expect(screen.getByText("Q1")).toBeInTheDocument();
     expect(screen.queryByText("Orphan Q")).not.toBeInTheDocument();
 
-    // Answer the required slider, then advance.
-    fireEvent.change(screen.getByLabelText(/Q1/i), { target: { value: "2" } });
+    // Answer the required scale by clicking the radio for value 2, then advance.
+    fireEvent.click(screen.getByRole("radio", { name: "2" }));
     fireEvent.click(screen.getByRole("button", { name: /next/i }));
 
     // The "Other" page now renders the orphan question (previously invisible).
@@ -137,7 +137,7 @@ describe("OrgSurveyClient — SectionPager wiring + hidden-orphan fix", () => {
     await reachPager();
 
     await screen.findByText(/section 1 of 2/i);
-    fireEvent.change(screen.getByLabelText(/Q1/i), { target: { value: "2" } });
+    fireEvent.click(screen.getByRole("radio", { name: "2" }));
     fireEvent.click(screen.getByRole("button", { name: /next/i }));
 
     await screen.findByText(/section 2 of 2/i);
@@ -180,10 +180,11 @@ describe("OrgSurveyClient — SectionPager wiring + hidden-orphan fix", () => {
     await reachPager();
     await screen.findByText(/section 1 of 2/i);
 
-    // The slider reflects the restored value 3 (draft hydrated once /me loaded
-    // the respondentKey and the draftKey transitioned null → value).
-    const slider = screen.getByLabelText(/Q1/i) as HTMLInputElement;
-    expect(slider.value).toBe("3");
+    // The scale reflects the restored value 3 (draft hydrated once /me loaded
+    // the respondentKey and the draftKey transitioned null → value): the radio
+    // for value 3 (max, anchored "hi") is checked.
+    const radio3 = screen.getByRole("radio", { name: /^3/ }) as HTMLInputElement;
+    expect(radio3.checked).toBe(true);
 
     // Advance to the Other page and confirm the orphan textarea restored.
     fireEvent.click(screen.getByRole("button", { name: /next/i }));
@@ -204,9 +205,10 @@ describe("OrgSurveyClient — SectionPager wiring + hidden-orphan fix", () => {
     await reachPager();
     await screen.findByText(/section 1 of 2/i);
 
-    // The slider stays empty — the alias-keyed draft was NOT loaded.
-    const slider = screen.getByLabelText(/Q1/i) as HTMLInputElement;
-    expect(slider.value).not.toBe("3");
+    // The scale stays empty — the alias-keyed draft was NOT loaded, so the
+    // radio for value 3 is not checked (nothing is selected).
+    const radio3 = screen.getByRole("radio", { name: /^3/ }) as HTMLInputElement;
+    expect(radio3.checked).toBe(false);
   });
 
   it("keys the autosaved draft by the per-respondent invitedDraftKey(respondentKey)", async () => {
@@ -214,7 +216,7 @@ describe("OrgSurveyClient — SectionPager wiring + hidden-orphan fix", () => {
     await screen.findByText(/section 1 of 2/i);
 
     // Answer and let the 500ms debounced autosave flush.
-    fireEvent.change(screen.getByLabelText(/Q1/i), { target: { value: "2" } });
+    fireEvent.click(screen.getByRole("radio", { name: "2" }));
 
     await waitFor(() => {
       expect(localStorage.getItem(invitedDraftKey(RESPONDENT_KEY))).not.toBeNull();

--- a/src/src/__tests__/assessments/public-quiz-pager.test.tsx
+++ b/src/src/__tests__/assessments/public-quiz-pager.test.tsx
@@ -116,15 +116,13 @@ describe("PublicQuizClient — SectionPager wiring", () => {
 
     reachFormStep();
 
-    // Section 1 — answer q1 via the shared range input, then Next.
-    const q1Input = screen.getByLabelText(/Question One/i) as HTMLInputElement;
-    fireEvent.change(q1Input, { target: { value: "2" } });
+    // Section 1 — answer q1 by clicking the discrete radio for value 2, then Next.
+    fireEvent.click(screen.getByRole("radio", { name: "2" }));
     fireEvent.click(screen.getByRole("button", { name: /next/i }));
 
-    // Section 2 — answer q2, then Submit.
+    // Section 2 — answer q2 (max value 3, anchored "hi"), then Submit.
     expect(screen.getByText(/section 2 of 2/i)).toBeInTheDocument();
-    const q2Input = screen.getByLabelText(/Question Two/i) as HTMLInputElement;
-    fireEvent.change(q2Input, { target: { value: "3" } });
+    fireEvent.click(screen.getByRole("radio", { name: /^3/ }));
     fireEvent.click(screen.getByRole("button", { name: /submit/i }));
 
     await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));

--- a/src/src/__tests__/assessments/section-pager.test.tsx
+++ b/src/src/__tests__/assessments/section-pager.test.tsx
@@ -64,10 +64,25 @@ describe("SectionPager", () => {
     expect(bar).toHaveAttribute("aria-valuemax", "1");
   });
 
-  it("renders the SLIDER_LIKERT with an accessible name equal to the question label", () => {
+  it("renders the SLIDER_LIKERT as a radiogroup with an accessible name equal to the question label", () => {
     setup();
     fireEvent.click(screen.getByRole("button", { name: /start/i }));
-    expect(screen.getByRole("slider", { name: "Q1" })).toBeInTheDocument();
+    expect(screen.getByRole("radiogroup", { name: "Q1" })).toBeInTheDocument();
+  });
+
+  it("selecting the MINIMUM value (0) reports it and satisfies the required gate", () => {
+    const { onSubmit, onAnswerChange, rerender } = setup();
+    fireEvent.click(screen.getByRole("button", { name: /start/i }));
+    // Click the radio for the minimum value 0 — the previously-unselectable case.
+    fireEvent.click(screen.getByRole("radio", { name: /^0/ }));
+    // The change is reported with the literal 0 (not undefined / no-op).
+    expect(onAnswerChange).toHaveBeenCalledWith("q1", 0);
+    // SectionPager is controlled: the parent now feeds the recorded answer back.
+    const pages = buildSectionPages(sections, questions);
+    rerender(<SectionPager pages={pages} answers={{ q1: 0 }} onAnswerChange={onAnswerChange} onSubmit={onSubmit} submitting={false} />);
+    // 0 satisfies the required gate → Submit fires.
+    fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
   });
 
   it("Back across an empty welcome section lands on that section's intro", () => {

--- a/src/src/__tests__/assessments/section-pager.test.tsx
+++ b/src/src/__tests__/assessments/section-pager.test.tsx
@@ -96,9 +96,9 @@ describe("SectionPager", () => {
   });
 
   it("a section with BOTH a description and questions: intro → Start → questions → Back → intro", () => {
-    const secs = [{ stableKey: "S1", sortOrder: 1, name: "Strategy", description: "Strategy intro" }];
-    const qs = [{ stableKey: "q1", sortOrder: 1, sectionStableKey: "S1", type: "SLIDER_LIKERT", label: "Q1", isRequired: true, scale: { min: 0, max: 3, step: 1, anchorMin: "lo", anchorMax: "hi" } }];
-    const pages = buildSectionPages(secs as any, qs as any);
+    const secs: PagerSection[] = [{ stableKey: "S1", sortOrder: 1, name: "Strategy", description: "Strategy intro" }];
+    const qs: PagerQuestion[] = [{ stableKey: "q1", sortOrder: 1, sectionStableKey: "S1", type: "SLIDER_LIKERT", label: "Q1", isRequired: true, scale: { min: 0, max: 3, step: 1, anchorMin: "lo", anchorMax: "hi" } }];
+    const pages = buildSectionPages(secs, qs);
     render(<SectionPager pages={pages} answers={{}} onAnswerChange={jest.fn()} onSubmit={jest.fn()} submitting={false} />);
     // intro shown
     expect(screen.getByText("Strategy intro")).toBeInTheDocument();

--- a/src/src/__tests__/components/assessments/question-input.test.tsx
+++ b/src/src/__tests__/components/assessments/question-input.test.tsx
@@ -2,7 +2,8 @@
  * Phase C — QuestionInput component (TDD red phase first).
  *
  * Tests:
- *  1. Renders SLIDER_LIKERT with range input + anchor labels
+ *  1. Renders SLIDER_LIKERT as a discrete radiogroup (named by label) with one
+ *     radio per scale value + anchor labels
  *  2. Renders TEXT with textarea
  *  3. Renders NUMBER with number input
  *  4. Renders MULTI_CHOICE with checkboxes
@@ -10,6 +11,8 @@
  *  6. MULTI_CHOICE onChange fires with correct string[] value
  *  7. TEXT onChange fires with string value
  *  8. NUMBER onChange fires with number value
+ *  9. SLIDER_LIKERT min value (0) is selectable — clicking it fires onChange(key, 0)
+ *     [regression lock for the unselectable-minimum bug]
  */
 
 import React from "react";
@@ -20,8 +23,17 @@ import type { QuestionForInput } from "@/components/assessments/question-input";
 const sliderQuestion: QuestionForInput = {
   stableKey: "S1_Q1",
   type: "SLIDER_LIKERT",
+  label: "How true is this?",
   isRequired: true,
   scale: { min: 1, max: 5, step: 1, anchorMin: "Never", anchorMax: "Always" },
+};
+
+const zeroBasedSliderQuestion: QuestionForInput = {
+  stableKey: "S1_Q0",
+  type: "SLIDER_LIKERT",
+  label: "Zero-based question",
+  isRequired: true,
+  scale: { min: 0, max: 10, step: 1, anchorMin: "Not true", anchorMax: "Always true" },
 };
 
 const textQuestion: QuestionForInput = {
@@ -49,7 +61,7 @@ const multiQuestion: QuestionForInput = {
 };
 
 describe("QuestionInput", () => {
-  test("1. renders SLIDER_LIKERT with range input + anchor labels", () => {
+  test("1. renders SLIDER_LIKERT as a discrete radiogroup with one radio per value + anchors", () => {
     render(
       <QuestionInput
         question={sliderQuestion}
@@ -57,14 +69,19 @@ describe("QuestionInput", () => {
         onChange={jest.fn()}
       />
     );
-    const slider = screen.getByRole("slider");
-    expect(slider).toBeInTheDocument();
-    expect(slider).toHaveAttribute("type", "range");
-    expect(slider).toHaveAttribute("min", "1");
-    expect(slider).toHaveAttribute("max", "5");
+    // The control is a radiogroup named by the question label.
+    const group = screen.getByRole("radiogroup", { name: "How true is this?" });
+    expect(group).toBeInTheDocument();
+    // One radio per scale value (1..5 step 1 = 5 radios).
+    const radios = screen.getAllByRole("radio");
+    expect(radios).toHaveLength(5);
+    // The radio matching the current value (3) is checked.
+    const selected = radios.find((r) => (r as HTMLInputElement).checked);
+    expect(selected).toBeChecked();
+    expect(selected).toHaveAttribute("value", "3");
+    // Anchor labels render.
     expect(screen.getByText("Never")).toBeInTheDocument();
     expect(screen.getByText("Always")).toBeInTheDocument();
-    expect(screen.getByText("3")).toBeInTheDocument();
   });
 
   test("2. renders TEXT with textarea", () => {
@@ -166,5 +183,22 @@ describe("QuestionInput", () => {
     const input = screen.getByRole("spinbutton");
     fireEvent.change(input, { target: { value: "7" } });
     expect(onChange).toHaveBeenCalledWith("S1_Q3", 7);
+  });
+
+  test("9. SLIDER_LIKERT minimum value (0) is selectable — clicking it fires onChange(key, 0)", () => {
+    const onChange = jest.fn();
+    render(
+      <QuestionInput
+        question={zeroBasedSliderQuestion}
+        value={undefined}
+        onChange={onChange}
+      />
+    );
+    // Regression lock: the minimum (0) was unreachable on the old range slider
+    // because the thumb defaulted to min and "changing" to min fired nothing.
+    // Anchor regex to the start so it doesn't also match "10 — Always true".
+    const zeroRadio = screen.getByRole("radio", { name: /^0 —/ });
+    fireEvent.click(zeroRadio);
+    expect(onChange).toHaveBeenCalledWith("S1_Q0", 0);
   });
 });

--- a/src/src/__tests__/components/assessments/question-input.test.tsx
+++ b/src/src/__tests__/components/assessments/question-input.test.tsx
@@ -39,18 +39,21 @@ const zeroBasedSliderQuestion: QuestionForInput = {
 const textQuestion: QuestionForInput = {
   stableKey: "S1_Q2",
   type: "TEXT",
+  label: "Text question",
   isRequired: false,
 };
 
 const numberQuestion: QuestionForInput = {
   stableKey: "S1_Q3",
   type: "NUMBER",
+  label: "Number question",
   isRequired: false,
 };
 
 const multiQuestion: QuestionForInput = {
   stableKey: "S1_Q4",
   type: "MULTI_CHOICE",
+  label: "Multi question",
   isRequired: false,
   options: [
     { key: "opt_a", label: "Option A" },

--- a/src/src/app/(public)/org-survey/layout.tsx
+++ b/src/src/app/(public)/org-survey/layout.tsx
@@ -11,7 +11,7 @@ export default function OrgSurveyLayout({
   // Kept off <body> and off .wf-scope's tokens — scoped to the participant lane.
   return (
     <div
-      className={`wf-scope ${assessmentRoboto.variable}`}
+      className={`wf-scope su-assessment-brand ${assessmentRoboto.variable}`}
       style={{ minHeight: "100vh" }}
     >
       {children}

--- a/src/src/app/(public)/quiz/layout.tsx
+++ b/src/src/app/(public)/quiz/layout.tsx
@@ -19,7 +19,7 @@ export default function PublicQuizLayout({
   // Kept off <body> and off .wf-scope's tokens — scoped to the participant lane.
   return (
     <div
-      className={`wf-scope ${assessmentRoboto.variable}`}
+      className={`wf-scope su-assessment-brand ${assessmentRoboto.variable}`}
       style={{ minHeight: "100vh" }}
     >
       {children}

--- a/src/src/components/assessments/question-input.tsx
+++ b/src/src/components/assessments/question-input.tsx
@@ -4,7 +4,7 @@
  * Phase C — QuestionInput shared component.
  *
  * Renders the appropriate input control for each question type:
- *   SLIDER_LIKERT  → <input type="range"> with anchor labels
+ *   SLIDER_LIKERT  → discrete radiogroup (one radio per scale value) with anchor labels
  *   TEXT           → <textarea>
  *   NUMBER         → <input type="number">
  *   MULTI_CHOICE   → checkbox group (respects maxChoices)
@@ -48,31 +48,42 @@ export function QuestionInput({
   disabled,
 }: QuestionInputProps) {
   if (q.type === "SLIDER_LIKERT" && q.scale) {
-    const numVal = typeof value === "number" ? value : q.scale.min;
+    const { min, max, step, anchorMin, anchorMax } = q.scale;
+    const values: number[] = [];
+    for (let v = min; v <= max; v += step) values.push(v);
+    const selected = typeof value === "number" ? value : undefined;
     return (
-      <>
-        <input
-          id={`q-${q.stableKey}`}
-          type="range"
-          min={q.scale.min}
-          max={q.scale.max}
-          step={q.scale.step}
-          value={numVal}
-          onChange={(e) => onChange(q.stableKey, Number(e.target.value))}
-          className="survey-slider"
-          aria-valuemin={q.scale.min}
-          aria-valuemax={q.scale.max}
-          aria-valuenow={numVal}
-          disabled={disabled}
-        />
-        <div className="survey-slider-anchors">
-          <span>{q.scale.anchorMin}</span>
-          <span className="survey-slider-value">
-            {typeof value === "number" ? value : "—"}
-          </span>
-          <span>{q.scale.anchorMax}</span>
+      <div className="survey-scale" role="radiogroup" aria-label={q.label}>
+        <div className="survey-scale-options">
+          {values.map((v) => {
+            const isSel = selected === v;
+            const ariaLabel =
+              v === min ? `${v} — ${anchorMin}` : v === max ? `${v} — ${anchorMax}` : String(v);
+            return (
+              <label
+                key={v}
+                className={`survey-scale-option${isSel ? " is-selected" : ""}`}
+              >
+                <input
+                  type="radio"
+                  name={`q-${q.stableKey}`}
+                  className="survey-scale-radio"
+                  value={v}
+                  checked={isSel}
+                  aria-label={ariaLabel}
+                  onChange={() => onChange(q.stableKey, v)}
+                  disabled={disabled}
+                />
+                <span className="survey-scale-num" aria-hidden="true">{v}</span>
+              </label>
+            );
+          })}
         </div>
-      </>
+        <div className="survey-scale-anchors">
+          <span>{anchorMin}</span>
+          <span>{anchorMax}</span>
+        </div>
+      </div>
     );
   }
 

--- a/src/src/styles/wireframes-scoped.css
+++ b/src/src/styles/wireframes-scoped.css
@@ -1038,19 +1038,6 @@
   color: hsl(var(--muted-foreground));
   margin: 0;
 }
-.wf-scope .survey-slider {
-  width: 100%;
-}
-.wf-scope .survey-slider-anchors {
-  display: flex;
-  justify-content: space-between;
-  font-size: 0.75rem;
-  color: hsl(var(--muted-foreground));
-}
-.wf-scope .survey-slider-value {
-  font-weight: 600;
-  color: hsl(var(--foreground));
-}
 .wf-scope .survey-submit-row {
   display: flex;
   justify-content: center;
@@ -1180,10 +1167,11 @@
 /* Discrete Likert scale control (replaces the range slider in the branded participant UI) */
 .su-assessment-brand .survey-scale { margin-top: 0.6rem; }
 .su-assessment-brand .survey-scale-options {
-  display: grid; grid-auto-flow: column; grid-auto-columns: 1fr; gap: 0.5rem;
+  display: flex; flex-wrap: wrap; gap: 0.5rem;
 }
 .su-assessment-brand .survey-scale-option {
   position: relative; display: flex; align-items: center; justify-content: center;
+  flex: 1 1 44px; min-width: 44px;
   min-height: 48px; padding: 0 0.25rem;
   border: 1.5px solid hsl(var(--border)); border-radius: 10px; background: #fff;
   font-weight: 600; font-size: 1rem; color: hsl(var(--foreground)); cursor: pointer;

--- a/src/src/styles/wireframes-scoped.css
+++ b/src/src/styles/wireframes-scoped.css
@@ -1176,3 +1176,42 @@
    hardcodes a blue; inside the brand scope we darken the purple --primary instead. */
 .su-assessment-brand .wf-btn-primary:hover { background: hsl(269 56% 27%); }
 .wf-scope .survey-error { color: hsl(var(--destructive)); font-size: 0.875rem; margin-top: 0.75rem; }
+
+/* Discrete Likert scale control (replaces the range slider in the branded participant UI) */
+.su-assessment-brand .survey-scale { margin-top: 0.6rem; }
+.su-assessment-brand .survey-scale-options {
+  display: grid; grid-auto-flow: column; grid-auto-columns: 1fr; gap: 0.5rem;
+}
+.su-assessment-brand .survey-scale-option {
+  position: relative; display: flex; align-items: center; justify-content: center;
+  min-height: 48px; padding: 0 0.25rem;
+  border: 1.5px solid hsl(var(--border)); border-radius: 10px; background: #fff;
+  font-weight: 600; font-size: 1rem; color: hsl(var(--foreground)); cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease, color 120ms ease, box-shadow 120ms ease;
+  user-select: none;
+}
+.su-assessment-brand .survey-scale-option:hover {
+  border-color: hsl(var(--primary)); background: hsl(var(--primary) / 0.06);
+}
+.su-assessment-brand .survey-scale-option.is-selected {
+  background: hsl(var(--primary)); border-color: hsl(var(--primary)); color: #fff;
+  box-shadow: 0 1px 4px hsl(var(--primary) / 0.35);
+}
+.su-assessment-brand .survey-scale-option:has(.survey-scale-radio:focus-visible) {
+  outline: 2px solid hsl(var(--ring)); outline-offset: 2px;
+}
+.su-assessment-brand .survey-scale-radio {
+  position: absolute; opacity: 0; width: 1px; height: 1px; margin: 0; pointer-events: none;
+}
+.su-assessment-brand .survey-scale-anchors {
+  display: flex; justify-content: space-between; margin-top: 0.45rem;
+  font-size: 0.8rem; color: hsl(var(--muted-foreground));
+}
+/* Question cards — group + space the per-section questions (currently a flat cramped stack) */
+.su-assessment-brand .survey-question-list { list-style: none; margin: 0; padding: 0; }
+.su-assessment-brand .survey-question {
+  background: #fff; border: 1px solid hsl(var(--border)); border-radius: 14px;
+  padding: 1.15rem 1.25rem 1.1rem; margin-bottom: 1rem;
+}
+.su-assessment-brand .survey-question-label { display: block; font-weight: 600; margin-bottom: 0.4rem; }
+.su-assessment-brand .survey-question-help { margin: 0.1rem 0 0.2rem; }


### PR DESCRIPTION
## Why
Follow-up to PR #32 (now live). Two issues surfaced on the live one-section survey:

1. **🔴 Functional blocker:** the SLIDER_LIKERT control was a native `<input type=range>` that defaults its thumb to the minimum and only records on a *change* event — so the lowest value (`0` = "Not true") was **unselectable** (already at 0 → no change → never recorded), and the per-section required gate then blocked submission. A continuous slider is the wrong control for a discrete Likert scale.
2. **Visual:** slider thumbs were still blue, the intro "SURVEY" eyebrow was blue, and questions were a flat cramped stack.

## What
- **Discrete radiogroup control** (`question-input.tsx`): one selectable segment per scale value (`min..max`), native radios named per-question (free arrow-key nav, single tab stop), group named by the question label, endpoints' accessible names include the anchor text. **Clicking `0` now records it** (`onChange(key,0)`); `isAnswered(0)` is true; the gate passes. Works for 0–3, 0–5, and 1–10 scales; wraps on mobile with ≥44px targets.
- **Brand polish** (scoped under `.su-assessment-brand`, ADR-0005 — no admin/coach leak): purple `#522583` selected state, questions in branded cards, and the intro card now branded (added `su-assessment-brand` to the two participant layouts so the `--primary`-token eyebrow turns purple).
- Removed the dead `.survey-slider*` CSS; lint/tsc-cleaned the touched test files.

## Tests / gates
TDD: a bug-lock test (click `0` → `onChange(key,0)`) + a gate test (select min → advance), plus the pager/control suites updated from slider→radiogroup. 26 control/pager tests + 40 regression tests green; `CI=true npx next build --turbopack` clean. Reviewed: spec-compliance ✅ + code-quality ✅ (no Critical/Important).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a functional regression in the SLIDER_LIKERT control where the minimum scale value (e.g. `0`) was unselectable because a native `<input type=range>` defaults its thumb to `min` and only fires a `change` event when the value actually changes — so selecting `0` from an already-0 thumb was a no-op. The fix replaces the slider with a discrete radiogroup (one radio per scale step), ensuring every value including `0` fires `onChange` and is correctly recognized by the `isAnswered` gate.

- **`question-input.tsx`**: Renders a `role="radiogroup"` div with one hidden-but-focusable `<input type=radio>` per step value; endpoint radios carry anchor text in their `aria-label`; controlled via `checked={selected === v}` so zero is never falsy-blocked.
- **`wireframes-scoped.css`**: Removes dead `.survey-slider*` rules and adds `.su-assessment-brand .survey-scale*` styles for branded pill-button appearance, 44 px touch targets, and `:has(:focus-visible)` keyboard outline.
- **Layouts + tests**: Both participant layouts gain `su-assessment-brand` for purple `--primary` token propagation; all pager and control tests migrate from `fireEvent.change` on a range input to `fireEvent.click` on the appropriate radio, with a new regression-lock test for the zero-minimum case.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the functional fix is sound and well-tested; the only concern is a style-level hardening suggestion in the loop that builds the scale values array.

The radiogroup replacement cleanly closes the unselectable-minimum bug: onChange now fires for every value, isAnswered(0) already returns true in section-pages.ts, and 66 passing tests cover the critical paths. The one open item is the floating-point loop in question-input.tsx — harmless today with integer steps but fragile if a future scale uses a decimal increment.

src/src/components/assessments/question-input.tsx — the values array loop is the only spot worth a second look before this component is reused with non-integer step values.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/src/components/assessments/question-input.tsx | Core fix: replaces the range input with a controlled radiogroup; onChange now fires for every value including 0; floating-point loop may be fragile for non-integer steps. |
| src/src/styles/wireframes-scoped.css | Removes dead survey-slider rules and adds su-assessment-brand survey-scale styles; scoped correctly per ADR-0005. |
| src/src/__tests__/components/assessments/question-input.test.tsx | Adds regression lock for the 0-minimum bug and updates all slider assertions to radiogroup/radio semantics. |
| src/src/__tests__/assessments/section-pager.test.tsx | Updated slider assertions to radiogroup, added the min-value gate test, replaced as-any casts with typed fixtures. |
| src/src/app/(public)/org-survey/layout.tsx | Adds su-assessment-brand to root div for purple --primary token propagation; one-line change. |
| src/src/app/(public)/quiz/layout.tsx | Same su-assessment-brand addition as org-survey layout. |
| src/src/__tests__/assessments/org-survey-pager.test.tsx | fireEvent.change on slider replaced with fireEvent.click on radios; draft-restore assertions updated. |
| src/src/__tests__/assessments/public-quiz-pager.test.tsx | Multi-section flow updated from range input interactions to radio clicks; clean migration. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User sees SLIDER_LIKERT question] --> B{Control type}
    B -->|Old: range input| C[thumb defaults to min]
    C --> D{User selects min value}
    D -->|value unchanged| E[no change event fired]
    E --> F[answers map unchanged]
    F --> G[isAnswered returns false]
    G --> H[Required gate blocks submission]
    B -->|New: radiogroup| I[all values rendered as radios]
    I --> J{User clicks any radio}
    J --> K[onChange fires with literal value]
    K --> L[answers map updated including 0]
    L --> M[isAnswered number returns true]
    M --> N[Gate passes submit allowed]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fsrc%2Fcomponents%2Fassessments%2Fquestion-input.tsx%3A52-53%0AFloating-point%20accumulation%20in%20the%20%60values%60%20loop%20can%20silently%20drop%20or%20duplicate%20the%20%60max%60%20endpoint%20for%20non-integer%20steps.%20For%20example%2C%20with%20%60min%3D0%2C%20max%3D1%2C%20step%3D0.1%60%20the%20loop%20yields%20%600.30000000000000004%60%20as%20the%20third%20value%2C%20and%20%60v%20%3C%3D%20max%60%20may%20fail%20to%20include%20%601.0%60%20exactly.%20A%20%60step%60%20of%20%600%60%20would%20also%20spin%20forever.%20All%20current%20callers%20use%20integer%20steps%2C%20but%20the%20%60SliderScale%60%20type%20allows%20any%20%60number%60.%20Using%20index%20arithmetic%20avoids%20both%20problems.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20count%20%3D%20step%20%3E%200%20%3F%20Math.floor%28%28max%20-%20min%29%20%2F%20step%29%20%2B%201%20%3A%200%3B%0A%20%20%20%20const%20values%3A%20number%5B%5D%20%3D%20Array.from%28%7B%20length%3A%20count%20%7D%2C%20%28_%2C%20i%29%20%3D%3E%20min%20%2B%20i%20*%20step%29%3B%0A%60%60%60%0A%0A&repo=jcbdelo26%2Fscaling-up-platform-v2&pr=33&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["refactor(assessment): Likert scale wraps..."](https://github.com/jcbdelo26/scaling-up-platform-v2/commit/7492b9bf96152084c3fcc9e891ed8619ad9bd5f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35580600)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->