### PR TITLE
fix(assessment): restore Likert slider + make default/min value selectable (no drag-dance)

### DIFF
--- a/src/src/__tests__/assessments/org-survey-pager.test.tsx
+++ b/src/src/__tests__/assessments/org-survey-pager.test.tsx
@@ -121,8 +121,8 @@ describe("OrgSurveyClient — SectionPager wiring + hidden-orphan fix", () => {
     expect(screen.getByText("Q1")).toBeInTheDocument();
     expect(screen.queryByText("Orphan Q")).not.toBeInTheDocument();
 
-    // Answer the required scale by clicking the radio for value 2, then advance.
-    fireEvent.click(screen.getByRole("radio", { name: "2" }));
+    // Answer the required scale by dragging the slider to value 2, then advance.
+    fireEvent.change(screen.getByRole("slider"), { target: { value: "2" } });
     fireEvent.click(screen.getByRole("button", { name: /next/i }));
 
     // The "Other" page now renders the orphan question (previously invisible).
@@ -137,7 +137,7 @@ describe("OrgSurveyClient — SectionPager wiring + hidden-orphan fix", () => {
     await reachPager();
 
     await screen.findByText(/section 1 of 2/i);
-    fireEvent.click(screen.getByRole("radio", { name: "2" }));
+    fireEvent.change(screen.getByRole("slider"), { target: { value: "2" } });
     fireEvent.click(screen.getByRole("button", { name: /next/i }));
 
     await screen.findByText(/section 2 of 2/i);
@@ -181,10 +181,10 @@ describe("OrgSurveyClient — SectionPager wiring + hidden-orphan fix", () => {
     await screen.findByText(/section 1 of 2/i);
 
     // The scale reflects the restored value 3 (draft hydrated once /me loaded
-    // the respondentKey and the draftKey transitioned null → value): the radio
-    // for value 3 (max, anchored "hi") is checked.
-    const radio3 = screen.getByRole("radio", { name: /^3/ }) as HTMLInputElement;
-    expect(radio3.checked).toBe(true);
+    // the respondentKey and the draftKey transitioned null → value): the slider
+    // now holds value 3 (max, anchored "hi").
+    const slider = screen.getByRole("slider") as HTMLInputElement;
+    expect(slider.value).toBe("3");
 
     // Advance to the Other page and confirm the orphan textarea restored.
     fireEvent.click(screen.getByRole("button", { name: /next/i }));
@@ -205,10 +205,10 @@ describe("OrgSurveyClient — SectionPager wiring + hidden-orphan fix", () => {
     await reachPager();
     await screen.findByText(/section 1 of 2/i);
 
-    // The scale stays empty — the alias-keyed draft was NOT loaded, so the
-    // radio for value 3 is not checked (nothing is selected).
-    const radio3 = screen.getByRole("radio", { name: /^3/ }) as HTMLInputElement;
-    expect(radio3.checked).toBe(false);
+    // The scale stays unanswered — the alias-keyed draft was NOT loaded, so the
+    // slider sits at its default minimum (0), not the leaked value 3.
+    const slider = screen.getByRole("slider") as HTMLInputElement;
+    expect(slider.value).toBe("0");
   });
 
   it("keys the autosaved draft by the per-respondent invitedDraftKey(respondentKey)", async () => {
@@ -216,7 +216,7 @@ describe("OrgSurveyClient — SectionPager wiring + hidden-orphan fix", () => {
     await screen.findByText(/section 1 of 2/i);
 
     // Answer and let the 500ms debounced autosave flush.
-    fireEvent.click(screen.getByRole("radio", { name: "2" }));
+    fireEvent.change(screen.getByRole("slider"), { target: { value: "2" } });
 
     await waitFor(() => {
       expect(localStorage.getItem(invitedDraftKey(RESPONDENT_KEY))).not.toBeNull();

--- a/src/src/__tests__/assessments/public-quiz-pager.test.tsx
+++ b/src/src/__tests__/assessments/public-quiz-pager.test.tsx
@@ -116,13 +116,13 @@ describe("PublicQuizClient — SectionPager wiring", () => {
 
     reachFormStep();
 
-    // Section 1 — answer q1 by clicking the discrete radio for value 2, then Next.
-    fireEvent.click(screen.getByRole("radio", { name: "2" }));
+    // Section 1 — answer q1 by dragging the slider to value 2, then Next.
+    fireEvent.change(screen.getByRole("slider"), { target: { value: "2" } });
     fireEvent.click(screen.getByRole("button", { name: /next/i }));
 
     // Section 2 — answer q2 (max value 3, anchored "hi"), then Submit.
     expect(screen.getByText(/section 2 of 2/i)).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("radio", { name: /^3/ }));
+    fireEvent.change(screen.getByRole("slider"), { target: { value: "3" } });
     fireEvent.click(screen.getByRole("button", { name: /submit/i }));
 
     await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));

--- a/src/src/__tests__/assessments/section-pager.test.tsx
+++ b/src/src/__tests__/assessments/section-pager.test.tsx
@@ -64,17 +64,18 @@ describe("SectionPager", () => {
     expect(bar).toHaveAttribute("aria-valuemax", "1");
   });
 
-  it("renders the SLIDER_LIKERT as a radiogroup with an accessible name equal to the question label", () => {
+  it("renders the SLIDER_LIKERT as a slider with an accessible name equal to the question label", () => {
     setup();
     fireEvent.click(screen.getByRole("button", { name: /start/i }));
-    expect(screen.getByRole("radiogroup", { name: "Q1" })).toBeInTheDocument();
+    expect(screen.getByRole("slider", { name: "Q1" })).toBeInTheDocument();
   });
 
   it("selecting the MINIMUM value (0) reports it and satisfies the required gate", () => {
     const { onSubmit, onAnswerChange, rerender } = setup();
     fireEvent.click(screen.getByRole("button", { name: /start/i }));
-    // Click the radio for the minimum value 0 — the previously-unselectable case.
-    fireEvent.click(screen.getByRole("radio", { name: /^0/ }));
+    // Click the slider at its default minimum (0) — the previously-unrecordable
+    // case where the thumb sits at min and a plain click fired nothing.
+    fireEvent.click(screen.getByRole("slider", { name: "Q1" }));
     // The change is reported with the literal 0 (not undefined / no-op).
     expect(onAnswerChange).toHaveBeenCalledWith("q1", 0);
     // SectionPager is controlled: the parent now feeds the recorded answer back.

--- a/src/src/__tests__/components/assessments/question-input.test.tsx
+++ b/src/src/__tests__/components/assessments/question-input.test.tsx
@@ -2,8 +2,8 @@
  * Phase C — QuestionInput component (TDD red phase first).
  *
  * Tests:
- *  1. Renders SLIDER_LIKERT as a discrete radiogroup (named by label) with one
- *     radio per scale value + anchor labels
+ *  1. Renders SLIDER_LIKERT as a native range slider (named by label) with
+ *     aria-valuemin/max + anchor labels
  *  2. Renders TEXT with textarea
  *  3. Renders NUMBER with number input
  *  4. Renders MULTI_CHOICE with checkboxes
@@ -11,8 +11,10 @@
  *  6. MULTI_CHOICE onChange fires with correct string[] value
  *  7. TEXT onChange fires with string value
  *  8. NUMBER onChange fires with number value
- *  9. SLIDER_LIKERT min value (0) is selectable — clicking it fires onChange(key, 0)
- *     [regression lock for the unselectable-minimum bug]
+ *  9. SLIDER_LIKERT dragging fires onChange with the changed value
+ * 10. SLIDER_LIKERT clicking at the default minimum (0) commits 0 — fires
+ *     onChange(key, 0) even though no "change" event fired
+ *     [regression lock for the unselectable-minimum / drag-dance bug]
  */
 
 import React from "react";
@@ -64,7 +66,7 @@ const multiQuestion: QuestionForInput = {
 };
 
 describe("QuestionInput", () => {
-  test("1. renders SLIDER_LIKERT as a discrete radiogroup with one radio per value + anchors", () => {
+  test("1. renders SLIDER_LIKERT as a native range slider with aria-valuemin/max + anchors", () => {
     render(
       <QuestionInput
         question={sliderQuestion}
@@ -72,16 +74,15 @@ describe("QuestionInput", () => {
         onChange={jest.fn()}
       />
     );
-    // The control is a radiogroup named by the question label.
-    const group = screen.getByRole("radiogroup", { name: "How true is this?" });
-    expect(group).toBeInTheDocument();
-    // One radio per scale value (1..5 step 1 = 5 radios).
-    const radios = screen.getAllByRole("radio");
-    expect(radios).toHaveLength(5);
-    // The radio matching the current value (3) is checked.
-    const selected = radios.find((r) => (r as HTMLInputElement).checked);
-    expect(selected).toBeChecked();
-    expect(selected).toHaveAttribute("value", "3");
+    // The control is a native range slider (role="slider").
+    const slider = screen.getByRole("slider");
+    expect(slider).toBeInTheDocument();
+    expect(slider).toHaveAttribute("type", "range");
+    expect(slider).toHaveAttribute("aria-valuemin", "1");
+    expect(slider).toHaveAttribute("aria-valuemax", "5");
+    // The current value (3) is reflected.
+    expect((slider as HTMLInputElement).value).toBe("3");
+    expect(slider).toHaveAttribute("aria-valuenow", "3");
     // Anchor labels render.
     expect(screen.getByText("Never")).toBeInTheDocument();
     expect(screen.getByText("Always")).toBeInTheDocument();
@@ -188,7 +189,7 @@ describe("QuestionInput", () => {
     expect(onChange).toHaveBeenCalledWith("S1_Q3", 7);
   });
 
-  test("9. SLIDER_LIKERT minimum value (0) is selectable — clicking it fires onChange(key, 0)", () => {
+  test("9. SLIDER_LIKERT dragging fires onChange with the changed value", () => {
     const onChange = jest.fn();
     render(
       <QuestionInput
@@ -197,11 +198,28 @@ describe("QuestionInput", () => {
         onChange={onChange}
       />
     );
-    // Regression lock: the minimum (0) was unreachable on the old range slider
-    // because the thumb defaulted to min and "changing" to min fired nothing.
-    // Anchor regex to the start so it doesn't also match "10 — Always true".
-    const zeroRadio = screen.getByRole("radio", { name: /^0 —/ });
-    fireEvent.click(zeroRadio);
+    const slider = screen.getByRole("slider");
+    // Drag = a native `change` event carrying the new value.
+    fireEvent.change(slider, { target: { value: "2" } });
+    expect(onChange).toHaveBeenCalledWith("S1_Q0", 2);
+  });
+
+  test("10. SLIDER_LIKERT clicking at the default minimum (0) commits 0 — no drag-dance", () => {
+    const onChange = jest.fn();
+    render(
+      <QuestionInput
+        question={zeroBasedSliderQuestion}
+        value={undefined}
+        onChange={onChange}
+      />
+    );
+    // Regression lock for the unselectable-minimum bug: the thumb defaults to
+    // min (0) and a plain click does NOT fire `change`. The component must
+    // commit the slider's CURRENT DOM value on click, so a click at the default
+    // minimum records 0 (instead of the user being forced to drag away + back).
+    const slider = screen.getByRole("slider") as HTMLInputElement;
+    expect(slider.value).toBe("0"); // thumb sits at min when unanswered
+    fireEvent.click(slider);
     expect(onChange).toHaveBeenCalledWith("S1_Q0", 0);
   });
 });

--- a/src/src/components/assessments/question-input.tsx
+++ b/src/src/components/assessments/question-input.tsx
@@ -1,10 +1,12 @@
 "use client";
 
+import type { SyntheticEvent } from "react";
+
 /**
  * Phase C — QuestionInput shared component.
  *
  * Renders the appropriate input control for each question type:
- *   SLIDER_LIKERT  → discrete radiogroup (one radio per scale value) with anchor labels
+ *   SLIDER_LIKERT  → range slider with anchor labels
  *   TEXT           → <textarea>
  *   NUMBER         → <input type="number">
  *   MULTI_CHOICE   → checkbox group (respects maxChoices)
@@ -48,41 +50,39 @@ export function QuestionInput({
   disabled,
 }: QuestionInputProps) {
   if (q.type === "SLIDER_LIKERT" && q.scale) {
-    const { min, max, step, anchorMin, anchorMax } = q.scale;
-    const values: number[] = [];
-    for (let v = min; v <= max; v += step) values.push(v);
-    const selected = typeof value === "number" ? value : undefined;
+    const { min, max, step } = q.scale;
+    const answered = typeof value === "number";
+    const numVal = answered ? value : min;
+    const commit = (e: SyntheticEvent<HTMLInputElement>) =>
+      onChange(q.stableKey, Number(e.currentTarget.value));
+    const MOVE_KEYS = ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Home", "End", "PageUp", "PageDown"];
     return (
-      <div className="survey-scale" role="radiogroup" aria-label={q.label}>
-        <div className="survey-scale-options">
-          {values.map((v) => {
-            const isSel = selected === v;
-            const ariaLabel =
-              v === min ? `${v} — ${anchorMin}` : v === max ? `${v} — ${anchorMax}` : String(v);
-            return (
-              <label
-                key={v}
-                className={`survey-scale-option${isSel ? " is-selected" : ""}`}
-              >
-                <input
-                  type="radio"
-                  name={`q-${q.stableKey}`}
-                  className="survey-scale-radio"
-                  value={v}
-                  checked={isSel}
-                  aria-label={ariaLabel}
-                  onChange={() => onChange(q.stableKey, v)}
-                  disabled={disabled}
-                />
-                <span className="survey-scale-num" aria-hidden="true">{v}</span>
-              </label>
-            );
-          })}
+      <div className="survey-slider-wrap">
+        <input
+          id={`q-${q.stableKey}`}
+          type="range"
+          className="survey-slider"
+          min={min}
+          max={max}
+          step={step}
+          value={numVal}
+          aria-valuemin={min}
+          aria-valuemax={max}
+          aria-valuenow={answered ? value : undefined}
+          aria-valuetext={answered ? String(value) : "Not yet answered"}
+          onChange={commit}
+          onClick={commit}
+          onKeyUp={(e) => { if (MOVE_KEYS.includes(e.key)) commit(e); }}
+          disabled={disabled}
+        />
+        <div className="survey-slider-anchors">
+          <span>{q.scale.anchorMin}</span>
+          <span className="survey-slider-value">{answered ? value : "—"}</span>
+          <span>{q.scale.anchorMax}</span>
         </div>
-        <div className="survey-scale-anchors">
-          <span>{anchorMin}</span>
-          <span>{anchorMax}</span>
-        </div>
+        {!answered ? (
+          <p className="survey-slider-hint">Tap or drag the slider to rate.</p>
+        ) : null}
       </div>
     );
   }

--- a/src/src/styles/wireframes-scoped.css
+++ b/src/src/styles/wireframes-scoped.css
@@ -1164,37 +1164,11 @@
 .su-assessment-brand .wf-btn-primary:hover { background: hsl(269 56% 27%); }
 .wf-scope .survey-error { color: hsl(var(--destructive)); font-size: 0.875rem; margin-top: 0.75rem; }
 
-/* Discrete Likert scale control (replaces the range slider in the branded participant UI) */
-.su-assessment-brand .survey-scale { margin-top: 0.6rem; }
-.su-assessment-brand .survey-scale-options {
-  display: flex; flex-wrap: wrap; gap: 0.5rem;
-}
-.su-assessment-brand .survey-scale-option {
-  position: relative; display: flex; align-items: center; justify-content: center;
-  flex: 1 1 44px; min-width: 44px;
-  min-height: 48px; padding: 0 0.25rem;
-  border: 1.5px solid hsl(var(--border)); border-radius: 10px; background: #fff;
-  font-weight: 600; font-size: 1rem; color: hsl(var(--foreground)); cursor: pointer;
-  transition: background 120ms ease, border-color 120ms ease, color 120ms ease, box-shadow 120ms ease;
-  user-select: none;
-}
-.su-assessment-brand .survey-scale-option:hover {
-  border-color: hsl(var(--primary)); background: hsl(var(--primary) / 0.06);
-}
-.su-assessment-brand .survey-scale-option.is-selected {
-  background: hsl(var(--primary)); border-color: hsl(var(--primary)); color: #fff;
-  box-shadow: 0 1px 4px hsl(var(--primary) / 0.35);
-}
-.su-assessment-brand .survey-scale-option:has(.survey-scale-radio:focus-visible) {
-  outline: 2px solid hsl(var(--ring)); outline-offset: 2px;
-}
-.su-assessment-brand .survey-scale-radio {
-  position: absolute; opacity: 0; width: 1px; height: 1px; margin: 0; pointer-events: none;
-}
-.su-assessment-brand .survey-scale-anchors {
-  display: flex; justify-content: space-between; margin-top: 0.45rem;
-  font-size: 0.8rem; color: hsl(var(--muted-foreground));
-}
+/* Range slider Likert control (branded participant UI) */
+.su-assessment-brand .survey-slider { width: 100%; accent-color: hsl(var(--primary)); cursor: pointer; }
+.wf-scope .survey-slider-anchors { display: flex; justify-content: space-between; margin-top: 0.45rem; font-size: 0.8rem; color: hsl(var(--muted-foreground)); }
+.wf-scope .survey-slider-value { font-weight: 600; color: hsl(var(--foreground)); }
+.su-assessment-brand .survey-slider-hint { margin: 0.35rem 0 0; font-size: 0.8rem; font-style: italic; color: hsl(var(--muted-foreground)); }
 /* Question cards — group + space the per-section questions (currently a flat cramped stack) */
 .su-assessment-brand .survey-question-list { list-style: none; margin: 0; padding: 0; }
 .su-assessment-brand .survey-question {


### PR DESCRIPTION
## Why
Course-correct on the participant Likert control. PR #33 replaced the slider with discrete buttons — but the slider was wanted **kept**, with its real bug fixed.

**The bug (kept slider, now fixed):** the native range slider defaults its thumb to the minimum with the value showing "—" (unanswered), but only records on a *change* event — so if the answer is the minimum/leftmost, leaving the slider there records nothing, forcing a drag-away-and-back. 

## Fix
A single **click/tap (or keyboard move) commits the slider's current value**, read from the DOM (`Number(e.currentTarget.value)`) on `onChange` (drag), `onClick` (click/tap — commits even when unchanged, so clicking at min records min), and `onKeyUp` gated to slider-moving keys. An **untouched** slider still records nothing → the required gate correctly catches a skipped question (no auto-answer / no bad data). Tab/hover/scroll/wheel commit nothing. Slider is branded purple (`accent-color`); unanswered shows "—" + a "Tap or drag to rate" hint and `aria-valuetext="Not yet answered"`.

Shared `QuestionInput`, so this applies to every assessment. Section layout, question cards, and intro branding from prior PRs are unchanged. Removed the dead `.survey-scale*` CSS.

## Verification
27 control/pager tests + 40 regression tests green; `CI=true npx next build --turbopack` clean; spec + code-quality reviewed — **incl. real-Chrome (Playwright) verification** that click-at-min commits min (min=0 and min=1) and that Tab/hover/scroll never auto-answer. Follow-up noted: add a Playwright E2E so this gesture has permanent CI coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reverts the PR #33 discrete-button Likert control and restores the native `<input type="range">` slider, fixing the original unselectable-minimum bug by committing the slider's current DOM value on `onClick` (in addition to `onChange` and a gated `onKeyUp`). Test fixtures across all three pager test suites are updated to match.

- **Core fix** — `onClick` on the slider commits the current value even when the thumb hasn't moved, resolving the drag-dance required to record a minimum answer.
- **Event handler design** — `onClick` also fires after every drag (mouse-up), and `onKeyUp` fires alongside `onChange` for every non-boundary key press, producing redundant double-commits in both cases; these are idempotent for the current controlled-component pattern but add fragility for future consumers.
- **Accessibility** — The old `radiogroup` carried `aria-label={q.label}` self-contained; the new slider relies on an external `<label htmlFor>` from the parent for its accessible name.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core bug fix is correct and all test suites pass. The three concerns are non-breaking quality issues in the event-handler design.

The click-at-min fix works correctly and is well-tested. The main rough edges are that dragging fires commit twice (once from onChange during drag, once from onClick on mouse-up) and keyboard movement similarly fires commit twice (once from onChange, once from onKeyUp). Both are idempotent for the current state-only consumer, but could silently trigger side effects if onChange is ever wired to anything beyond state. The slider also loses the self-contained aria-label that the old radiogroup had, delegating accessible naming entirely to the parent — a gap that tests happen to cover today but won't catch in a future usage without a label.

src/src/components/assessments/question-input.tsx — the three-event-handler commit design is where all the concerns live.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/src/components/assessments/question-input.tsx | Replaces discrete radiogroup SLIDER_LIKERT with native range slider; fixes the unselectable-minimum bug via onClick+onChange+onKeyUp commit paths, but onClick and onKeyUp each create redundant double-commits alongside onChange during normal drag and keyboard interaction. |
| src/src/styles/wireframes-scoped.css | Removes dead .survey-scale* CSS and adds slim slider styles; survey-slider is scoped to .su-assessment-brand while survey-slider-anchors/survey-slider-value are scoped to the broader .wf-scope — minor inconsistency but harmless given the nesting relationship. |
| src/src/__tests__/components/assessments/question-input.test.tsx | Updates and extends tests to match the slider implementation; adds regression test 10 for click-at-min; coverage is thorough for the intended behavior. |
| src/src/__tests__/assessments/section-pager.test.tsx | Switches from radiogroup assertions to slider assertions; all existing behavioral tests correctly updated. |
| src/src/__tests__/assessments/org-survey-pager.test.tsx | Updates radio interactions to slider interactions; draft-restore assertion correctly checks slider.value instead of radio.checked. |
| src/src/__tests__/assessments/public-quiz-pager.test.tsx | Straightforward swap from radio clicks to slider change events; no issues. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User interacts with slider] --> B{Interaction type}
    B -->|Mouse drag| C[onChange fires per value change]
    C --> D[commit called]
    C --> E[Mouse released: onClick fires]
    E --> F[commit called again — double-commit]
    B -->|Click at current position| G[onChange does NOT fire]
    G --> H[onClick fires]
    H --> I[commit called — fixes click-at-min bug]
    B -->|Arrow key, value changes| J[onChange fires]
    J --> K[commit called]
    J --> L[onKeyUp fires for MOVE_KEYS]
    L --> M[commit called again — double-commit]
    B -->|Arrow key at boundary| N[onChange does NOT fire]
    N --> O[onKeyUp fires for MOVE_KEYS]
    O --> P[commit called — records boundary value]
    B -->|Tab / hover / scroll| Q[No commit]
    style F fill:#ffe0b2,stroke:#e65100
    style M fill:#ffe0b2,stroke:#e65100
    style I fill:#c8e6c9,stroke:#2e7d32
    style P fill:#c8e6c9,stroke:#2e7d32
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2Fsrc%2Fcomponents%2Fassessments%2Fquestion-input.tsx%3A73-75%0A**Double-commit%20on%20drag%3A%20%60onClick%60%20fires%20after%20%60onChange%60**%0A%0AWhen%20a%20user%20drags%20the%20slider%2C%20%60onChange%60%20fires%20continuously%20during%20the%20drag%2C%20and%20then%20%60onClick%60%20fires%20on%20mouse-up%20%E2%80%94%20so%20the%20final%20value%20is%20committed%20twice.%20This%20is%20idempotent%20for%20pure%20state-setting%2C%20but%20any%20parent%20%60onChange%60%20handler%20that%20has%20side%20effects%20beyond%20state%20%28analytics%20events%2C%20external%20callbacks%29%20will%20trigger%20twice%20per%20drag.%20The%20autosave%20debounce%20in%20%60useAnswerDraft%60%20survives%20this%20because%20it%20resets%20the%20timer%2C%20but%20the%20pattern%20is%20fragile%20for%20future%20consumers.%20Consider%20gating%20%60onClick%60%20to%20only%20fire%20when%20%60onChange%60%20hasn't%20already%20handled%20the%20event%20%28e.g.%2C%20track%20a%20%60wasDragged%60%20ref%20via%20%60onMouseMove%60%20%2F%20%60onPointerMove%60%20and%20skip%20%60onClick%60%20when%20set%29.%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Fsrc%2Fcomponents%2Fassessments%2Fquestion-input.tsx%3A75%0A**%60onKeyUp%60%20%2B%20%60onChange%60%20redundant%20double-commit%20for%20non-boundary%20key%20presses**%0A%0AFor%20every%20arrow%20key%20press%20that%20moves%20the%20slider%20%28i.e.%2C%20value%20changes%29%2C%20both%20%60onChange%60%20and%20%60onKeyUp%60%20fire%20%60commit%60%20%E2%80%94%20so%20%60onChange%60%20is%20called%20twice%20with%20the%20same%20value.%20The%20only%20case%20where%20%60onKeyUp%60%20is%20uniquely%20needed%20is%20when%20a%20key%20is%20pressed%20but%20the%20slider%20is%20already%20at%20a%20boundary%20%28so%20%60onChange%60%20doesn't%20fire%29.%20For%20all%20other%20key%20presses%20the%20double-call%20is%20idempotent%20but%20wasteful%2C%20and%20the%20PR%20description's%20framing%20%E2%80%94%20%22onKeyUp%20gated%20to%20slider-moving%20keys%22%20%E2%80%94%20implies%20it's%20the%20sole%20keyboard%20path%20rather%20than%20an%20additive%20one.%20Consider%20checking%20whether%20the%20value%20actually%20changed%20in%20%60onKeyUp%60%2C%20or%20restructuring%20so%20%60onKeyUp%60%20only%20fires%20when%20%60onChange%60%20hasn't%20already%20committed.%0A%0A%23%23%23%20Issue%203%20of%203%0Asrc%2Fsrc%2Fcomponents%2Fassessments%2Fquestion-input.tsx%3A61-77%0A**Accessible%20name%20depends%20entirely%20on%20an%20external%20%60%3Clabel%3E%60%20%E2%80%94%20no%20%60aria-label%60%20on%20the%20input**%0A%0AThe%20old%20%60radiogroup%60%20carried%20%60aria-label%3D%7Bq.label%7D%60%20directly%20on%20the%20container%2C%20making%20it%20self-contained.%20The%20new%20%60%3Cinput%20type%3D%22range%22%3E%60%20only%20has%20%60id%3D%7Bq-%24%7Bq.stableKey%7D%7D%60%20and%20relies%20on%20a%20parent%20%60%3Clabel%20htmlFor%3D%22...%22%3E%60%20for%20its%20accessible%20name.%20Current%20consumers%20%28section-pager%29%20provide%20that%20label%20so%20the%20tests%20pass%2C%20but%20any%20future%20consumer%20that%20renders%20%60%3CQuestionInput%3E%60%20without%20the%20corresponding%20%60%3Clabel%3E%60%20will%20produce%20a%20nameless%20slider.%20Adding%20%60aria-label%3D%7Bq.label%7D%60%20directly%20on%20the%20input%20would%20restore%20the%20self-contained%20accessibility%20guarantee%20the%20old%20design%20had.%0A%0A&repo=jcbdelo26%2Fscaling-up-platform-v2&pr=34&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(assessment): restore Likert slider +..."](https://github.com/jcbdelo26/scaling-up-platform-v2/commit/8a8cd534868ed2647dc1375f477eebe795028167) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35632471)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->