### PR TITLE
feat(assessment): numbered scale ticks + clear unanswered state on the Likert slider (no default, best-practice)

### DIFF
--- a/src/src/__tests__/components/assessments/question-input.test.tsx
+++ b/src/src/__tests__/components/assessments/question-input.test.tsx
@@ -222,4 +222,38 @@ describe("QuestionInput", () => {
     fireEvent.click(slider);
     expect(onChange).toHaveBeenCalledWith("S1_Q0", 0);
   });
+
+  test("11. SLIDER_LIKERT unanswered renders ticks for each value + prompt; answered shows 'Your rating: N'", () => {
+    const tickQuestion: QuestionForInput = {
+      stableKey: "tick_q",
+      type: "SLIDER_LIKERT",
+      label: "Tick test",
+      isRequired: true,
+      scale: { min: 0, max: 3, step: 1, anchorMin: "Low", anchorMax: "High" },
+    };
+
+    // --- Unanswered ---
+    const { unmount } = render(
+      <QuestionInput question={tickQuestion} value={undefined} onChange={jest.fn()} />
+    );
+    // All tick values should be visible (0,1,2,3)
+    expect(screen.getByText("0")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+    // Unanswered status prompt
+    expect(screen.getByText("Tap or drag the slider to rate.")).toBeInTheDocument();
+    // "—" must NOT be present
+    expect(screen.queryByText("—")).not.toBeInTheDocument();
+    unmount();
+
+    // --- Answered with value=2 ---
+    render(
+      <QuestionInput question={tickQuestion} value={2} onChange={jest.fn()} />
+    );
+    expect(screen.getByText("Your rating: 2")).toBeInTheDocument();
+    // Ticks still visible
+    expect(screen.getByText("0")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+  });
 });

--- a/src/src/components/assessments/question-input.tsx
+++ b/src/src/components/assessments/question-input.tsx
@@ -50,14 +50,16 @@ export function QuestionInput({
   disabled,
 }: QuestionInputProps) {
   if (q.type === "SLIDER_LIKERT" && q.scale) {
-    const { min, max, step } = q.scale;
+    const { min, max, step, anchorMin, anchorMax } = q.scale;
     const answered = typeof value === "number";
     const numVal = answered ? value : min;
+    const values: number[] = [];
+    for (let v = min; v <= max; v += step) values.push(v);
     const commit = (e: SyntheticEvent<HTMLInputElement>) =>
       onChange(q.stableKey, Number(e.currentTarget.value));
     const MOVE_KEYS = ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Home", "End", "PageUp", "PageDown"];
     return (
-      <div className="survey-slider-wrap">
+      <div className={`survey-slider-wrap${answered ? "" : " is-unanswered"}`}>
         <input
           id={`q-${q.stableKey}`}
           type="range"
@@ -75,14 +77,23 @@ export function QuestionInput({
           onKeyUp={(e) => { if (MOVE_KEYS.includes(e.key)) commit(e); }}
           disabled={disabled}
         />
-        <div className="survey-slider-anchors">
-          <span>{q.scale.anchorMin}</span>
-          <span className="survey-slider-value">{answered ? value : "—"}</span>
-          <span>{q.scale.anchorMax}</span>
+        <div className="survey-slider-ticks" aria-hidden="true">
+          {values.map((v) => (
+            <span
+              key={v}
+              className={`survey-slider-tick${answered && value === v ? " is-current" : ""}`}
+            >
+              {v}
+            </span>
+          ))}
         </div>
-        {!answered ? (
-          <p className="survey-slider-hint">Tap or drag the slider to rate.</p>
-        ) : null}
+        <div className="survey-slider-anchors">
+          <span>{anchorMin}</span>
+          <span>{anchorMax}</span>
+        </div>
+        <p className="survey-slider-status">
+          {answered ? `Your rating: ${value}` : "Tap or drag the slider to rate."}
+        </p>
       </div>
     );
   }

--- a/src/src/styles/wireframes-scoped.css
+++ b/src/src/styles/wireframes-scoped.css
@@ -1166,9 +1166,12 @@
 
 /* Range slider Likert control (branded participant UI) */
 .su-assessment-brand .survey-slider { width: 100%; accent-color: hsl(var(--primary)); cursor: pointer; }
-.wf-scope .survey-slider-anchors { display: flex; justify-content: space-between; margin-top: 0.45rem; font-size: 0.8rem; color: hsl(var(--muted-foreground)); }
-.wf-scope .survey-slider-value { font-weight: 600; color: hsl(var(--foreground)); }
-.su-assessment-brand .survey-slider-hint { margin: 0.35rem 0 0; font-size: 0.8rem; font-style: italic; color: hsl(var(--muted-foreground)); }
+.su-assessment-brand .survey-slider-ticks { display: flex; justify-content: space-between; margin-top: 0.4rem; padding: 0 1px; }
+.su-assessment-brand .survey-slider-tick { min-width: 1.25rem; text-align: center; font-size: 0.85rem; font-weight: 600; color: hsl(var(--muted-foreground)); }
+.su-assessment-brand .survey-slider-tick.is-current { color: hsl(var(--primary)); }
+.wf-scope .survey-slider-anchors { display: flex; justify-content: space-between; margin-top: 0.3rem; font-size: 0.8rem; color: hsl(var(--muted-foreground)); }
+.su-assessment-brand .survey-slider-status { margin: 0.5rem 0 0; font-size: 0.85rem; text-align: center; color: hsl(var(--muted-foreground)); }
+.su-assessment-brand .survey-slider-wrap.is-unanswered .survey-slider-status { font-style: italic; }
 /* Question cards — group + space the per-section questions (currently a flat cramped stack) */
 .su-assessment-brand .survey-question-list { list-style: none; margin: 0; padding: 0; }
 .su-assessment-brand .survey-question {


### PR DESCRIPTION
Refines the participant Likert slider per survey-UX best practice (researched: a pre-filled default handle **biases responses** and can't be distinguished from a real answer — so we keep **no default**, but make the scale legible and the call-to-action obvious).

- **Numbered ticks `0..N`** under the track + endpoint anchor words → the discrete scale is visible.
- Selected tick **highlights purple**; a **status line** reads "Tap or drag the slider to rate." (unanswered, italic) or "Your rating: N" (answered) — replacing the cryptic "—".
- Unchanged behavior: single tap on any value (incl. the minimum) records it; an **untouched slider stays unanswered** (no auto-answer); `0` kept (it's a scored value on the Rockefeller 0–3 scale).

User-approved direction after researching slider best practices (MeasuringU, Qualtrics, "Where Should I Start?" study). 28 control/pager + 40 regression tests green; `CI=true npx next build --turbopack` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refines the participant Likert slider by adding numbered tick marks (`0..N`) beneath the track and replacing the center "—" / anchor-value display with a dedicated status line that reads as italic prompt when unanswered or "Your rating: N" when answered. The `is-unanswered` class drives italic styling via a CSS modifier, and the selected tick highlights purple via `is-current`.

- **`question-input.tsx`**: Destructures `anchorMin`/`anchorMax` from the scale, builds the `values` array with a new `for` loop, renders a `survey-slider-ticks` row (aria-hidden), and replaces the old three-span anchor bar with a two-span bar plus a standalone `<p class=\"survey-slider-status\">`.
- **`wireframes-scoped.css`**: Adds rules for `.survey-slider-ticks`, `.survey-slider-tick`, `.is-current`, and `.survey-slider-status`; removes the now-deleted `.survey-slider-value` rule.
- **Test 11**: Covers unanswered tick rendering, the \"Tap or drag\" prompt, absence of \"—\", and the \"Your rating: N\" answered state.

<h3>Confidence Score: 3/5</h3>

Safe to merge for the current Rockefeller 0–3 integer-step scales, but the new tick-generation loop will hang the browser tab on any question whose scale carries a zero or negative step value.

The tick-generation loop introduced in this PR has no guard against step <= 0. The SliderScale type accepts any number, so a misconfigured question would cause an infinite browser hang. Every current seeded scale uses step: 1, so this doesn't break anything today, but it is a real defect in the new code path rather than a theoretical future risk.

src/src/components/assessments/question-input.tsx — the tick-generation loop needs a positive-step guard before this can be considered fully robust.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/src/components/assessments/question-input.tsx | Adds numbered ticks and a status-line to the Likert slider; tick-generation loop lacks a guard against step <= 0 which would cause an infinite browser hang. |
| src/src/styles/wireframes-scoped.css | Adds CSS for tick marks and status line under `.su-assessment-brand`; removes old `.survey-slider-value` rule. Minor cross-browser tick-alignment concern with `padding: 0 1px`. |
| src/src/__tests__/components/assessments/question-input.test.tsx | Adds test 11 covering unanswered tick rendering and answered status string; existing tests unchanged and still valid with the new markup. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fsrc%2Fcomponents%2Fassessments%2Fquestion-input.tsx%3A57%0A**Infinite%20loop%20risk%20on%20zero%20or%20negative%20%60step%60**%0A%0AThe%20new%20tick-generation%20loop%20has%20no%20guard%20against%20%60step%20%3C%3D%200%60.%20The%20%60SliderScale.step%60%20field%20is%20typed%20as%20%60number%60%20with%20no%20minimum%20constraint%2C%20so%20a%20misconfigured%20question%20%28or%20a%20future%20question%20type%20seeded%20with%20%60step%3A%200%60%29%20would%20spin%20the%20browser's%20JS%20engine%20until%20the%20tab%20is%20killed.%20The%20previous%20code%20relied%20on%20the%20browser's%20native%20%60%3Cinput%20type%3D%22range%22%3E%60%2C%20which%20gracefully%20ignores%20an%20invalid%20step%3B%20the%20loop%20does%20not%20share%20that%20resilience.%20A%20simple%20cap%E2%80%94%60const%20safeStep%20%3D%20step%20%3E%200%20%3F%20step%20%3A%201%3B%60%E2%80%94prevents%20the%20hang.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fsrc%2Fstyles%2Fwireframes-scoped.css%3A1169%0A**Tick%20labels%20may%20not%20align%20with%20slider%20thumb%20endpoints%20on%20non-Chromium%20browsers**%0A%0AThe%20tick%20row%20uses%20%60justify-content%3A%20space-between%60%20with%20only%20%60padding%3A%200%201px%60%2C%20but%20native%20range%20inputs%20inset%20the%20usable%20track%20by%20roughly%20half%20the%20thumb%20width%20on%20each%20side.%20On%20macOS%20Safari%20and%20Firefox%20the%20thumb%20is%20wider%2C%20so%20the%20%220%22%20and%20max-value%20tick%20labels%20will%20sit%20visibly%20outside%20the%20actual%20slider%20thumb%20positions.%20Using%20a%20padding%20value%20that%20approximates%20the%20half-thumb%20offset%20%28typically%20%600.5rem%60%29%20produces%20better%20visual%20alignment%20across%20browsers.%0A%0A%60%60%60suggestion%0A.su-assessment-brand%20.survey-slider-ticks%20%7B%20display%3A%20flex%3B%20justify-content%3A%20space-between%3B%20margin-top%3A%200.4rem%3B%20padding%3A%200%200.5rem%3B%20%7D%0A%60%60%60%0A%0A&repo=jcbdelo26%2Fscaling-up-platform-v2&pr=35&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(assessment): visible numbered scale..."](https://github.com/jcbdelo26/scaling-up-platform-v2/commit/2e7f827dc2cc2f95b4aee7861bd2f547f84f034d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35676290)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->