### PR TITLE
feat(assessment): section intro-slide copy for Rockefeller + LVA

### DIFF
--- a/src/prisma/seed-lva-assessment.ts
+++ b/src/prisma/seed-lva-assessment.ts
@@ -227,6 +227,7 @@ interface SectionPayload {
   stableKey: string;
   sortOrder: number;
   name: string;
+  description: string;
 }
 
 // ─── Content builder ──────────────────────────────────────────────────────
@@ -259,14 +260,62 @@ function buildSectionsAndQuestions(): {
   questions: QuestionPayload[];
 } {
   const sections: SectionPayload[] = [
-    { stableKey: "S0_welcome",    sortOrder: 1, name: "Welcome" },
-    { stableKey: "S1_financials", sortOrder: 2, name: "The Company in Three Years — Financials & Scale" },
-    { stableKey: "S2_vision",     sortOrder: 3, name: "Vision on the Future" },
-    { stableKey: "S3_strengths",  sortOrder: 4, name: "Organizational Strengths and Weaknesses" },
-    { stableKey: "S4_obstacles",  sortOrder: 5, name: "Biggest Obstacles to Growth" },
-    { stableKey: "S5_explained",  sortOrder: 6, name: "Obstacles and Challenges Explained" },
-    { stableKey: "S6_focus",      sortOrder: 7, name: "Important Focus Areas" },
-    { stableKey: "S7_completion", sortOrder: 8, name: "Completion" },
+    {
+      stableKey: "S0_welcome",
+      sortOrder: 1,
+      name: "Welcome",
+      description:
+        "Welcome. This Leadership Vision Alignment assessment captures how you see the company's future — its financials, vision, strengths, obstacles, and focus areas. There are no right answers; please respond candidly.",
+    },
+    {
+      stableKey: "S1_financials",
+      sortOrder: 2,
+      name: "The Company in Three Years — Financials & Scale",
+      description:
+        "Picture the company three years from now. These questions capture your view of its financial scale — revenue, margins, people, and reach.",
+    },
+    {
+      stableKey: "S2_vision",
+      sortOrder: 3,
+      name: "Vision on the Future",
+      description:
+        "Describe where the business is headed: its products, market, competitors, and what will drive its success over the next three years.",
+    },
+    {
+      stableKey: "S3_strengths",
+      sortOrder: 4,
+      name: "Organizational Strengths and Weaknesses",
+      description:
+        "Rate the organization across key factors, from weak to strong, to surface where it's solid and where it needs work.",
+    },
+    {
+      stableKey: "S4_obstacles",
+      sortOrder: 5,
+      name: "Biggest Obstacles to Growth",
+      description:
+        "Identify the factors most holding the company back from its growth ambitions.",
+    },
+    {
+      stableKey: "S5_explained",
+      sortOrder: 6,
+      name: "Obstacles and Challenges Explained",
+      description:
+        "Explain the obstacles you selected — the reasoning behind each — and the one thing you would change.",
+    },
+    {
+      stableKey: "S6_focus",
+      sortOrder: 7,
+      name: "Important Focus Areas",
+      description:
+        "Capture the priorities, goals, and strategic focus areas that matter most for the period ahead.",
+    },
+    {
+      stableKey: "S7_completion",
+      sortOrder: 8,
+      name: "Completion",
+      description:
+        "That's everything — thank you for sharing your perspective. Review your answers and submit when you're ready.",
+    },
   ];
 
   let sortOrder = 0;

--- a/src/prisma/seed-rockefeller-assessment.ts
+++ b/src/prisma/seed-rockefeller-assessment.ts
@@ -53,6 +53,7 @@ Your coach will review the results with you afterward.`;
 
 interface SectionDef {
   name: string;
+  description: string;
   questions: string[];
 }
 
@@ -63,6 +64,8 @@ interface SectionDef {
 const SECTIONS: SectionDef[] = [
   {
     name: "The executive team is healthy and aligned.",
+    description:
+      "A healthy, aligned leadership team is the foundation for scaling. Rate how well your executive team trusts one another, debates openly, and operates as a genuine team.",
     questions: [
       "Team members understand each other's differences, priorities, and styles",
       "The team meets frequently (weekly is best) for strategic thinking.",
@@ -72,6 +75,8 @@ const SECTIONS: SectionDef[] = [
   },
   {
     name: "Everyone is aligned with the #1 thing that needs to be accomplished this quarter to move the company forward.",
+    description:
+      "Rate how clearly the team is aligned on the single most important priority for this quarter — and whether everyone could actually name it.",
     questions: [
       "The Critical Number is identified to move the company ahead this quarter.",
       "3-5 Priorities (Rocks) that support the Critical Number are identified and ranked for the quarter.",
@@ -81,6 +86,8 @@ const SECTIONS: SectionDef[] = [
   },
   {
     name: "Communication rhythm is established and information moves through organization accurately and quickly.",
+    description:
+      "A predictable meeting rhythm keeps information moving quickly. Rate how well your daily, weekly, monthly, and quarterly cadence is working.",
     questions: [
       "All employees are in a daily huddle that lasts less than 15 minutes.",
       "All teams have a weekly meeting.",
@@ -90,6 +97,8 @@ const SECTIONS: SectionDef[] = [
   },
   {
     name: "Every facet of the organization has a person assigned with accountability for ensuring goals are met.",
+    description:
+      "Every function and process should have one clear owner. Rate how completely accountability is assigned across the organization.",
     questions: [
       "The Function Accountability Chart (FACe) is completed (right person, doing the right things, right).",
       "Financial statements have a person assigned to each line item.",
@@ -99,6 +108,8 @@ const SECTIONS: SectionDef[] = [
   },
   {
     name: "Ongoing employee input is collected to identify obstacles and opportunities.",
+    description:
+      "Frontline employees see obstacles and opportunities first. Rate how consistently you collect and act on their input.",
     questions: [
       "All executives (and middle managers) have a Start/Stop/Keep conversation with at least one employee weekly.",
       "The insights from employee conversations are shared at the weekly executive team meeting.",
@@ -108,6 +119,8 @@ const SECTIONS: SectionDef[] = [
   },
   {
     name: "Reporting and analysis of customer feedback data is as frequent and accurate as financial data.",
+    description:
+      "Customer insight should be as timely and rigorous as your financials. Rate how well you gather, analyze, and act on customer feedback.",
     questions: [
       "All executives (and middle managers) have a 4Q conversation with at least one end user weekly.",
       "The insights from customer conversations are shared at the weekly executive team meeting.",
@@ -117,6 +130,8 @@ const SECTIONS: SectionDef[] = [
   },
   {
     name: 'Core Values and Purpose are "alive" in the organization.',
+    description:
+      "Core Values and Purpose should guide real decisions, not just sit on a wall. Rate how 'alive' they are in day-to-day work.",
     questions: [
       "Core Values are discovered, Purpose is articulated, and both are known by all employees.",
       "All executives and middle managers refer back to the Core Values and Purpose when giving praise or reprimands.",
@@ -126,6 +141,8 @@ const SECTIONS: SectionDef[] = [
   },
   {
     name: "Employees can articulate the following key components of the company's strategy accurately.",
+    description:
+      "Everyone should describe the company's strategy the same way. Rate how clearly the strategy is understood across the team.",
     questions: [
       "Big Hairy Audacious Goal (BHAG) – Progress is tracked and visible.",
       "Core Customer(s) – Their profile in 25 words or less.",
@@ -135,6 +152,8 @@ const SECTIONS: SectionDef[] = [
   },
   {
     name: "All employees can answer quantitatively whether they had a good day or week (Column 7 of the One-Page Strategic Plan).",
+    description:
+      "People do their best when they know whether they're winning. Rate whether employees can quantitatively tell if they had a good day or week.",
     questions: [
       "1 or 2 Key Performance Indicators (KPIs) are reported on weekly for each role/person.",
       "Each employee has 1 Critical Number that aligns with the company's Critical Number for the quarter (clear line of sight).",
@@ -144,6 +163,8 @@ const SECTIONS: SectionDef[] = [
   },
   {
     name: "The company's plans and performance are visible to everyone.",
+    description:
+      "Visible plans and metrics keep everyone rowing in the same direction. Rate how transparent your plans and performance are to the whole company.",
     questions: [
       'A "situation room" is established for weekly meetings (physical or virtual).',
       "Core Values, Purpose and Priorities are posted throughout the company.",
@@ -185,6 +206,7 @@ interface SectionPayload {
   stableKey: string;
   sortOrder: number;
   name: string;
+  description: string;
 }
 
 interface QuestionPayload {
@@ -218,6 +240,7 @@ function buildSectionsAndQuestions(): {
       stableKey: sectionStableKey,
       sortOrder: sectionNumber,
       name: section.name,
+      description: section.description,
     });
 
     section.questions.forEach((label, qIdx) => {

--- a/src/src/__tests__/seed/lva-content.test.ts
+++ b/src/src/__tests__/seed/lva-content.test.ts
@@ -26,6 +26,27 @@ const EXPECTED_SLIDER_SCALE = {
   anchorMax: "Strong",
 };
 
+// Verbatim section intro-slide copy (body text rendered under the section
+// name on the one-section pager), keyed by section stableKey.
+const EXPECTED_SECTION_DESCRIPTIONS: Record<string, string> = {
+  S0_welcome:
+    "Welcome. This Leadership Vision Alignment assessment captures how you see the company's future — its financials, vision, strengths, obstacles, and focus areas. There are no right answers; please respond candidly.",
+  S1_financials:
+    "Picture the company three years from now. These questions capture your view of its financial scale — revenue, margins, people, and reach.",
+  S2_vision:
+    "Describe where the business is headed: its products, market, competitors, and what will drive its success over the next three years.",
+  S3_strengths:
+    "Rate the organization across key factors, from weak to strong, to surface where it's solid and where it needs work.",
+  S4_obstacles:
+    "Identify the factors most holding the company back from its growth ambitions.",
+  S5_explained:
+    "Explain the obstacles you selected — the reasoning behind each — and the one thing you would change.",
+  S6_focus:
+    "Capture the priorities, goals, and strategic focus areas that matter most for the period ahead.",
+  S7_completion:
+    "That's everything — thank you for sharing your perspective. Review your answers and submit when you're ready.",
+};
+
 describe("buildLvaContent()", () => {
   let content: LvaContent;
 
@@ -58,6 +79,19 @@ describe("buildLvaContent()", () => {
       .map((s) => s.sortOrder)
       .sort((a, b) => a - b);
     expect(orders).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+  });
+
+  it("every section has a non-empty description (intro-slide copy)", () => {
+    for (const s of content.sections) {
+      expect(typeof s.description).toBe("string");
+      expect(s.description!.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("each section description matches the verbatim copy by stableKey", () => {
+    for (const s of content.sections) {
+      expect(s.description).toBe(EXPECTED_SECTION_DESCRIPTIONS[s.stableKey]);
+    }
   });
 
   it("Welcome section (S0_welcome) has no questions assigned to it", () => {

--- a/src/src/__tests__/seed/rockefeller-content.test.ts
+++ b/src/src/__tests__/seed/rockefeller-content.test.ts
@@ -20,6 +20,21 @@ const EXPECTED_SCORING_MESSAGES = [
   "That is a great overall score.",
 ];
 
+// Verbatim section intro-slide copy (body text rendered under the section
+// name on the one-section pager). Indexed S1..S10 by section order.
+const EXPECTED_SECTION_DESCRIPTIONS = [
+  "A healthy, aligned leadership team is the foundation for scaling. Rate how well your executive team trusts one another, debates openly, and operates as a genuine team.",
+  "Rate how clearly the team is aligned on the single most important priority for this quarter — and whether everyone could actually name it.",
+  "A predictable meeting rhythm keeps information moving quickly. Rate how well your daily, weekly, monthly, and quarterly cadence is working.",
+  "Every function and process should have one clear owner. Rate how completely accountability is assigned across the organization.",
+  "Frontline employees see obstacles and opportunities first. Rate how consistently you collect and act on their input.",
+  "Customer insight should be as timely and rigorous as your financials. Rate how well you gather, analyze, and act on customer feedback.",
+  "Core Values and Purpose should guide real decisions, not just sit on a wall. Rate how 'alive' they are in day-to-day work.",
+  "Everyone should describe the company's strategy the same way. Rate how clearly the strategy is understood across the team.",
+  "People do their best when they know whether they're winning. Rate whether employees can quantitatively tell if they had a good day or week.",
+  "Visible plans and metrics keep everyone rowing in the same direction. Rate how transparent your plans and performance are to the whole company.",
+];
+
 describe("buildRockefellerContent()", () => {
   let content: RockefellerContent;
 
@@ -66,6 +81,21 @@ describe("buildRockefellerContent()", () => {
     expect(s7!.name).toContain('"alive"');
     // Must NOT use smart/curly quotes or single quotes around alive
     expect(s7!.name).not.toContain("'alive'");
+  });
+
+  it("every section has a non-empty description (intro-slide copy)", () => {
+    for (const s of content.sections) {
+      expect(typeof s.description).toBe("string");
+      expect(s.description!.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("section descriptions in order (S1..S10) match the verbatim copy", () => {
+    const actual = content.sections
+      .slice()
+      .sort((a, b) => a.sortOrder - b.sortOrder)
+      .map((s) => s.description);
+    expect(actual).toEqual(EXPECTED_SECTION_DESCRIPTIONS);
   });
 
   it("scoringConfig.tierMetric === 'countAchieved'", () => {


### PR DESCRIPTION
Adds a description to every Rockefeller + LVA section so the one-section pager renders real intro copy (QSP/SU Full already have them). Content-hash changes → re-locked the Rockefeller BC snapshot; integration tests green; build clean. New DRAFT versions only when safe-seed.mjs runs against prod + an admin publishes — no prod data touched here.

## Notes from implementation
- `SectionSchema` already declared `description: z.string().optional()`, so no schema/publish-path change was required — the publish schema accepts the new field.
- The Rockefeller BC scoring snapshot (`scoring-bc-snapshot.test.ts`) was **not** affected: it hashes `scoreSubmission` output, which depends on questions + scoringConfig + section grouping by stableKey, not on the section description text. So no re-lock was needed (the test passes unchanged). The earlier concern about a hash re-lock did not materialize for this change.
- Seed-only change. New DRAFT versions are created only when `safe-seed.mjs` runs against prod and an admin clicks Publish. No prod seed was run.

## Tests
- `rockefeller-content` + `lva-content`: section-description verbatim guards now pass (RED → GREEN).
- Full seed + scoring suites: 372/372 across 17 suites green.
- `CI=true npx next build --turbopack`: Compiled successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds intro-slide copy (`description`) to every section in the Rockefeller (10 sections) and LVA (8 sections) assessment seeds, making those assessments match the QSP/SU Full pagers that already had descriptions. The change is content-only: the `SectionSchema` already accepted `description` as an optional string, so no schema or publish-path changes were required.

- Both seed files update their local `SectionDef`/`SectionPayload` interfaces to require `description: string`, populate all sections with verbatim copy, and thread the field through the builder function.
- Both test files add a two-part verbatim guard: a non-empty assertion for every section and a byte-for-byte comparison against a locked constant, following the same pattern used by existing content tests in this suite.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely additive content on an already-supported optional schema field, gated behind the existing safe-seed + admin-publish flow.

All four changed files are either seed build functions or their corresponding verbatim-guard tests. The `description` field was already declared in `SectionSchema` as `z.string().optional()`, so the publish path is unchanged. No migrations, no API changes, and no prod data is written by merging. The only finding is a redundant non-null assertion in a test file.

No files require special attention; `lva-content.test.ts` has a trivial redundant `!` operator.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/prisma/seed-lva-assessment.ts | Adds `description: string` (required) to `SectionPayload` and populates all 8 LVA sections with verbatim intro-slide copy; no other logic changed. |
| src/prisma/seed-rockefeller-assessment.ts | Adds `description: string` to both `SectionDef` and `SectionPayload`, populates all 10 Rockefeller sections with copy, and threads the field through `buildSectionsAndQuestions()`. |
| src/src/__tests__/seed/lva-content.test.ts | Adds a stableKey-keyed `EXPECTED_SECTION_DESCRIPTIONS` constant plus two verbatim-guard tests; the non-null assertion on `s.description` is redundant given the updated required type. |
| src/src/__tests__/seed/rockefeller-content.test.ts | Adds a positionally-ordered `EXPECTED_SECTION_DESCRIPTIONS` array and two verbatim-guard tests that sort by `sortOrder` before comparing; consistent with the existing test pattern. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["safe-seed.mjs runs against prod"] --> B{"content hash\nchanged?"}
    B -- "yes (new descriptions)" --> C["ensureTemplateVersionContent\nappends new DRAFT vN+1"]
    B -- "no" --> D["no-op"]
    C --> E["Admin reviews + clicks Publish"]
    E --> F["New PUBLISHED version live\n(respondents see intro-slide copy)"]
    subgraph "Seed Build Functions (no DB)"
        G["buildRockefellerContent()\n10 sections"]
        H["buildLvaContent()\n8 sections"]
    end
    subgraph "Verbatim-Guard Tests"
        I["rockefeller-content.test.ts\nsort by sortOrder"]
        J["lva-content.test.ts\nlookup by stableKey"]
    end
    G --> I
    H --> J
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fsrc%2F__tests__%2Fseed%2Flva-content.test.ts%3A87%0AThe%20non-null%20assertion%20%60s.description!%60%20is%20redundant%20here.%20%60SectionPayload.description%60%20was%20changed%20to%20a%20required%20%60string%60%20in%20this%20same%20PR%2C%20so%20TypeScript%20already%20knows%20the%20value%20cannot%20be%20%60undefined%60.%20Dropping%20the%20%60!%60%20removes%20a%20misleading%20signal%20that%20the%20field%20might%20be%20nullable.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20expect%28s.description.length%29.toBeGreaterThan%280%29%3B%0A%60%60%60%0A%0A&repo=jcbdelo26%2Fscaling-up-platform-v2&pr=36&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(assessment): author section intro-s..."](https://github.com/jcbdelo26/scaling-up-platform-v2/commit/234ac0bc9e87e7687df1e80f875ce5ea122ea178) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35701946)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->