### PR TITLE
feat(landing): Kajabi-faithful global SOLO_LANDING template + guarded rollout tooling

### DIFF
--- a/docs/runbooks/solo-landing-kajabi-rollout.md
+++ b/docs/runbooks/solo-landing-kajabi-rollout.md
@@ -1,0 +1,201 @@
+# Runbook — Global SOLO_LANDING Kajabi design rollout
+
+> Owner: CAIO (operator). Sign-off gate: do NOT run any `--apply` step against prod
+> without an explicit go-ahead recorded in the rollout ticket. Every write step is
+> CAS-guarded, on-disk-backed-up, audited (`AuditLog`), and reversible.
+
+This rollout replaces the global SOLO_LANDING design with the Kajabi-faithful
+Custom HTML block (`docs/specs/master-class-landing-kajabi.html`) in two guarded,
+ordered moves:
+
+1. **Script 1** — `scripts/update-solo-landing-template.ts` — CAS-updates the single
+   global `PageTemplate.customHtml` to the new artifact. Affects ALL workshops
+   approved AFTER this point (auto-build reads the template).
+2. **Script 2** — `scripts/backfill-solo-landing-kajabi.ts` — re-renders the new
+   artifact per-workshop and rewrites the EXISTING per-workshop
+   `LandingPage.customHtml` snapshots that are still on the old global design.
+
+Both scripts run from `src/`. Dry-run is the default; writes require
+`--apply --i-know-this-is-prod` (the safe-seed prod guard). `OPERATOR_EMAIL`
+(falls back to `ADMIN_EMAIL`, then `SYSTEM`) is stamped into each `AuditLog` row.
+
+---
+
+## Why a backfill at all (the targeting fact)
+
+`LandingPage.customHtml` is the **interpolated per-workshop snapshot** captured at
+auto-build time — it is NOT a live read of the template. Updating the template
+(Script 1) does **nothing** to pages that were already built. So the backfill
+(Script 2) must re-render the page per workshop and rewrite the snapshot.
+
+The backfill targets a row **only** when its current `customHtml` byte-for-byte
+equals the BACKED-UP OLD template re-rendered for THAT workshop (same two-pass
+auto-build pipeline + strict sanitize). A mismatch ⇒ bespoke / category-scoped /
+hand-edited ⇒ **skipped, never clobbered**. It never gates on a shared raw-template
+hash (which would match nothing).
+
+---
+
+## Preconditions
+
+- [ ] Guard tests green: `npm run test -- sanitize-custom-html interpolate-content-html workshop-slug-custom-html solo-landing-kajabi --passWithNoTests`
+- [ ] Build gate clean: `CI=true npx next build --turbopack`
+- [ ] Playwright render verification of the new artifact passed (desktop + mobile; fonts/icons; no global leak) — Task 5.
+- [ ] A complete prod snapshot taken: `npm run snapshot:prod` (belt-and-suspenders on top of Neon PITR).
+- [ ] `APP_URL` in the prod env points at the production host (the CTA preflight derives the expected host from it).
+- [ ] Decide the canary slug (the Martin Segnitz page) and have it handy.
+
+---
+
+## Step 1 — Template update (Script 1)
+
+### 1a. Dry-run (no write, no prod flag needed)
+```bash
+cd src
+npx tsx scripts/update-solo-landing-template.ts
+```
+Confirm: exactly one global SOLO_LANDING template is found, the artifact sanitizes
+with `didStripContent=false`, and the printed `oldSha`/`newSha`/`oldUpdatedAt`.
+
+### 1b. Apply (CAS + backup + audit)
+```bash
+npx tsx scripts/update-solo-landing-template.ts --apply --i-know-this-is-prod
+# Optionally pin the CAS expectation captured in 1a:
+#   --expected-sha <oldSha> --expected-updated-at <oldUpdatedAt ISO>
+```
+On success it prints **`NEW_GLOBAL_SHA`** and the **backup path**
+(`src/.snapshots/solo-landing-template-update-<ISO>.json`).
+**Record both** — the backfill consumes that backup, and the backup carries
+`NEW_GLOBAL_SHA` for the rollout-window inventory.
+
+> Rollout-window note (Task 10): between 1b and the backfill, any newly-approved
+> workshop auto-builds with the NEW design but is NOT in any backfill backup.
+> Prefer a brief approval freeze, or run the full backfill promptly after 1b.
+> The inventory step (below) finds these post-patch pages.
+
+---
+
+## Step 2 — Backfill (Script 2)
+
+Always pass `--old-template-backup` (the Script 1 backup) so targeting compares
+against the exact old template bytes; the new value comes from the explicit
+artifact (`--new-template`, default `docs/specs/master-class-landing-kajabi.html`).
+
+### 2a. Full dry-run inventory
+```bash
+npx tsx scripts/backfill-solo-landing-kajabi.ts \
+  --old-template-backup .snapshots/solo-landing-template-update-<ISO>.json
+```
+Review the per-row report + summary (`N candidates — T target, K no-op, S skip`) and
+the persisted JSON report under `src/.snapshots/solo-landing-kajabi-report-dry-run-*.json`.
+Inspect every SKIP reason (`bespoke-or-category-scoped`, `missing-coach-photo`,
+`cta-preflight-failed`, `price-preflight-failed`, `new-value-invalid`,
+`source-template-mismatch`). **Note the TARGET count `T`** — you assert it on apply.
+
+### 2b. Canary apply (one slug)
+```bash
+# dry-run the canary first
+npx tsx scripts/backfill-solo-landing-kajabi.ts \
+  --old-template-backup .snapshots/solo-landing-template-update-<ISO>.json \
+  --slug <martin-segnitz-slug>
+# then apply it (expect-count must equal the canary target count, normally 1)
+npx tsx scripts/backfill-solo-landing-kajabi.ts \
+  --old-template-backup .snapshots/solo-landing-template-update-<ISO>.json \
+  --slug <martin-segnitz-slug> --expect-count 1 --apply --i-know-this-is-prod
+```
+**Smoke check the canary** (see Monitoring) before going wider.
+
+### 2c. Cohort apply (batch)
+```bash
+npx tsx scripts/backfill-solo-landing-kajabi.ts \
+  --old-template-backup .snapshots/solo-landing-template-update-<ISO>.json \
+  --limit 10 --expect-count <cohort-target-count> --apply --i-know-this-is-prod
+```
+`--limit` caps the candidate scan; re-run dry-run with the same `--limit` first to
+read off the cohort target count for `--expect-count`. Smoke-check between batches.
+
+### 2d. Full apply
+```bash
+# re-confirm the full target count with a fresh dry-run, then:
+npx tsx scripts/backfill-solo-landing-kajabi.ts \
+  --old-template-backup .snapshots/solo-landing-template-update-<ISO>.json \
+  --expect-count <T> --apply --i-know-this-is-prod
+```
+`--apply` aborts unless `--expect-count` exactly equals the live TARGET count (a
+drift means the targeting changed under you — investigate, do not force).
+Per-workshop price exceptions: `--allow-price <workshopId>` (repeatable).
+
+Each apply writes a backup (`solo-landing-kajabi-backfill-<ISO>.json`, carries
+`oldGlobalTemplateId` + `newGlobalSha`), a JSON report, an `AuditLog`
+`SOLO_LANDING_BACKFILL_APPLY` row (updated/skipped IDs + targeting-skip reasons),
+and CAS-writes each row (`where id + updatedAt`; a concurrent edit is skipped, not
+clobbered).
+
+---
+
+## Monitoring / smoke checks (between every batch)
+
+For each touched slug, load `https://<APP_URL>/workshop/<slug>` and confirm:
+- [ ] Renders the NEW look (Kajabi hero, four-color stripe, coach photo present).
+- [ ] `h1` font is "Fira Sans" (fonts load via `@import` under prod CSP).
+- [ ] CSS hero icons draw; hero grid collapses to one column on mobile (≤760px).
+- [ ] **Register button** resolves to the correct PUBLISHED registration page
+      (absolute https, prod host, right workshop) — NOT a relative/staging/404 URL.
+- [ ] Price shows a real amount (no `TBD`/`Free` unless intended via `--allow-price`).
+- [ ] No coach-photo broken-image icon.
+- [ ] No global style leak into app/admin chrome.
+
+Synthetic check: `--inventory` lists every SOLO_LANDING slug + current SHA so you
+can confirm post-patch pages and spot any row still on an unexpected hash.
+```bash
+npx tsx scripts/backfill-solo-landing-kajabi.ts --inventory
+```
+
+---
+
+## Rollback (idempotent, CAS-guarded)
+
+Roll back in REVERSE order. Each restore is CAS-guarded so it never clobbers a
+legitimate later edit, and is audited.
+
+### R1 — Restore the backfilled rows
+```bash
+npx tsx scripts/backfill-solo-landing-kajabi.ts \
+  --restore .snapshots/solo-landing-kajabi-backfill-<ISO>.json --i-know-this-is-prod
+```
+Restores each row whose current value still hashes to the `newSha` we wrote; rows
+edited since are skipped (reported). Run once per apply backup if you applied in
+batches (newest first).
+
+### R2 — Restore the global template
+```bash
+npx tsx scripts/update-solo-landing-template.ts \
+  --restore .snapshots/solo-landing-template-update-<ISO>.json --i-know-this-is-prod
+```
+CAS-restores the pre-update template `customHtml` (only if live still equals
+`NEW_GLOBAL_SHA`).
+
+### R3 — Verify no target row remains on the rolled-back design
+```bash
+npx tsx scripts/backfill-solo-landing-kajabi.ts --inventory
+```
+Confirm no SOLO_LANDING page still carries a NEW-design render. For any post-patch
+page that auto-built with the new design and is NOT in a backfill backup (the
+rollout-window case), re-publish it via the normal auto-build/landing-page path or
+hand-restore using the inventory SHA as the diff reference.
+
+Last resort: Neon PITR or `npm run restore:from-snapshot <snapshotFile>` per
+`docs/runbooks/database-protection.md`.
+
+---
+
+## Owner / sign-off checkpoints
+
+| Step | Gate | Owner |
+|------|------|-------|
+| Preconditions | tests + build + Playwright + snapshot all green | CAIO |
+| 1b template apply | go-ahead recorded; `NEW_GLOBAL_SHA` + backup path captured | CAIO + ticket |
+| 2b canary apply | canary smoke check passed | CAIO |
+| 2c cohort apply | each batch smoke-checked | CAIO |
+| 2d full apply | `--expect-count` matches the fresh dry-run target count | CAIO + ticket |
+| Rollback | any smoke failure → R1→R2→R3 immediately | CAIO |

--- a/docs/specs/master-class-landing-kajabi-implementation-plan.md
+++ b/docs/specs/master-class-landing-kajabi-implementation-plan.md
@@ -1,0 +1,78 @@
+# Implementation Plan — Scaling Up Solo-Landing Template (Kajabi Custom HTML block)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: use `superpowers:subagent-driven-development`. Spec: [`master-class-landing-kajabi.md`](./master-class-landing-kajabi.md). Pasteable artifact = spec **Appendix A** (generic, tokenized). **Hardened through a 3-round claudex/Codex adversarial review (2026-06-09)** — see "Adversarial hardening" at the bottom; the propagation, not the HTML, is the risky part.
+
+**Goal:** Ship a Kajabi-faithful, token-driven Custom HTML block as the **global** SOLO_LANDING design, with guard tests, then propagate it to the existing solo pages via a **guarded, canary-first, audited, reversible migration**.
+
+**Architecture:** Reuses TEMPLATE-02 (save-time sanitize → two-pass auto-build interpolate + strict re-sanitize → render echo). No schema migration, no new API route, no runtime code change. The HTML artifact is low-risk; the **prod propagation across every public solo landing page is the risk surface** and is treated as a controlled migration.
+
+Source root: `src/src`. TDD (RED first). Build gate **`CI=true npx next build --turbopack`**.
+
+---
+
+## A. The artifact + guard tests (safe, do first)
+
+### Task 0 — Finalize the single artifact
+- Canonical block = spec **Appendix A**. Save it ONCE to `docs/specs/master-class-landing-kajabi.html` (paste-ready) + a sample-filled copy for screenshots. **All tests load this file** — never duplicate the markup in a test (prevents the version-skew the review flagged). Add a CI check that fails if the saved artifact's SHA diverges from Appendix A.
+- **Coach photo = `<img src="{{coach_photo}}" alt="{{coach_name}}">`** (NOT a CSS `background-image`). Rationale (R2-High2): `src` URLs go through the sanitizer's URL allowlist + strict build-time re-sanitize, so a `javascript:`/bad value is stripped; a token in inline `style="...url()..."` is passed through UNPARSED (CSS-injection vector) — so dynamic tokens must never go in `style`. Empty-photo is handled by preflight (Task 7) + a platform default-avatar, not by markup tricks.
+- Confirm: tokens exact double-brace; `@import` first line of `<style>`; no inline `<svg>`/`<link>`/`<iframe>`; every selector `.su-mc`-prefixed; no bare `body{}`; single `<h1>` first.
+
+### Task 1 — Guard test: survives sanitization (RED→GREEN)
+Extend `sanitize-custom-html.test.ts`. Load the artifact file; `sanitizeCustomHtml(block)` (default) ⇒ `didStripContent===false`; contains `@import`, `data-su-mc`, `href="{{registration_url}}"`, `src="{{coach_photo}}"`, `{{workshop_description}}`, `.ico-cal::before`; contains no `<svg`/`<path`/`<rect`/`<link`/`<iframe`.
+
+### Task 2 — Guard test: interpolation + strict re-sanitize (RED→GREEN)
+Extend `interpolate-content-html.test.ts`. Representative vars → `interpolateContentForHtml`: no `{{` left; `&`-title escaped once; `href="https://…/workshop/<slug>"`. Then `sanitizeCustomHtml(interpolated,{allowTokenUris:false})`: https `href`/`img src` survive; a `javascript:`-substituted **href AND img src** are stripped.
+
+### Task 3 — Guard test: empty data degrades (RED→GREEN)
+Empty `{{coach_photo}}`/`{{workshop_description}}`/`{{registration_url}}`: renders without throwing; empty About paragraph harmless. (Empty `coach_photo`/`registration_url` are PREVENTED from shipping by Task 7/8 preflights, not relied on as graceful at render.)
+
+### Task 4 — Render-path smoke (RED→GREEN)
+Extend `workshop-slug-custom-html.test.tsx`. Published SOLO_LANDING `LandingPage.customHtml` (interpolated block) on an approved (`PRE_EVENT`) workshop renders `data-custom-html-render` with title + Register link, not the React template.
+
+### Task 5 — Playwright render verification (before any prod write)
+Against a rendered customHtml page at desktop + mobile: `getComputedStyle(h1).fontFamily` includes "Fira Sans" (fonts load via `@import` under prod-like CSP); hero CSS icons draw; hero grid collapses to 1-col ≤760px; no global style leak into app chrome; screenshots captured.
+
+## B. Propagation = a guarded migration (the risk surface)
+
+### Task 6 — Dedicated CAS-guarded TEMPLATE update script (NOT the admin route)
+The admin PATCH route has no expected-`updatedAt`/hash check (R2-High3/R3-Med1), so don't use it for prod. Write a one-off guarded script that: backs up the current global SOLO_LANDING `PageTemplate` `{id, updatedAt, customHtml, SHA=OLD_GLOBAL_HASH}`; refuses to write unless the live row still matches the expected old `updatedAt`/SHA; writes Appendix A; captures `NEW_GLOBAL_HASH`; writes an `AuditLog` (operator, old/new SHA, backup path). Provide the inverse restore (CAS on `NEW_GLOBAL_HASH`). Prod guard (`--i-know-this-is-prod`).
+
+### Task 7 — Correct backfill TARGETING (fixes the round-1 hash bug)
+`LandingPage.customHtml` is the **interpolated per-workshop snapshot**, so it will NEVER equal the raw template hash (R2-High1/R3-High1). Target instead by: (a) `sourceTemplateId == <old global SOLO_LANDING template id>`; AND (b) a **per-workshop expected-old hash** — re-render the BACKED-UP old template (Task 6 backup) with THAT workshop's variables + REGISTRATION slug, sanitize, SHA, and compare to the row's current `customHtml`; OR a stable old-design signature embedded in the markup. Rows that don't match (bespoke / category-scoped) are **skipped + logged**. Require an **expected matched-row count** confirmed before apply. **Coach-photo preflight:** require non-empty `coach.profileImage` for each target (skip/flag missing; or rely on the template's default-avatar). Tests: distinct workshops don't share a hash; a bespoke row is skipped; a matching row is rewritten.
+
+### Task 8 — Strengthened CTA preflight
+Not just "non-empty href" (R2-Med1): require an **absolute HTTPS URL on the expected production host**, and verify the slug belongs to a **PUBLISHED REGISTRATION page for the same workshop**, before writing. Fail/skip + report otherwise. Never globally ship a broken/relative/staging buy button.
+
+### Task 9 — Price preflight = FAIL, not flag
+Unresolved `TBD`/`Free`/price-vs-checkout mismatch **fails apply for that row** (R2-Low1) unless an explicit per-workshop exception de-emphasizes/removes the displayed price.
+
+### Task 10 — Rollout-window safety
+Patching/activating the template before backfill creates an untracked window where newly-approved workshops get the new HTML but aren't in the backfill backup (R3-High2). Mitigate: the **backfill consumes the explicit Appendix A artifact + `NEW_GLOBAL_HASH`** (it does not just read "current active template"); record the patch timestamp + `NEW_GLOBAL_HASH`; the rollback inventory **includes pages created after the patch timestamp carrying `NEW_GLOBAL_HASH`**. Prefer a brief approval-freeze or canary over a blind fanout.
+
+### Task 11 — Canary + batch controls
+Backfill supports `--slug` (single canary) and `--limit`/batch size (R3-Med2). Sequence: **one known slug (the Martin Segnitz page) → smoke check → small representative cohort → smoke → full apply**, with automated CTA/URL smoke checks between batches.
+
+### Task 12 — Audit + observability (hard part of every mutation)
+Template PATCH / backfill apply / restore each write an `AuditLog` (operator identity, old/new SHA, backup path, counts, skipped IDs + reasons, slugs, `runId`) as a non-optional step (R2-Med2/R3-Med3). Persist dry-run/apply/restore reports to `.snapshots/`. Add synthetic URL/CTA health checks.
+
+### Task 13 — Idempotent rollback + operator runbook
+Single rollback path that CAS-restores the PageTemplate by old/new hash AND restores the backfilled rows AND verifies no target row remains on the rolled-back hash (R2-Med3). Short operator runbook: preflight → canary → full apply → monitoring → restore commands + owner/signoff checkpoints (R3-Low).
+
+## C. Apply + close
+### Task 14 — Execute (prod, guarded, ordered)
+Order: Task 6 (template PATCH, capture `NEW_GLOBAL_HASH`) → Task 7–9 dry-run inventory (review matched-row count, skips, CTA/price flags) → Task 11 canary (Martin Segnitz) → smoke → cohort → smoke → full `--apply --i-know-this-is-prod` (backup + CAS + audit). Verify live: target pages render the new look with each workshop's tokens; fonts/icons load; no broken images; CTA resolves to the right published registration page.
+
+### Task 15 — Build gate + SoT
+`CI=true npx next build --turbopack`; `npx eslint` touched files; `npm run test -- sanitize-custom-html interpolate-content-html workshop-slug-custom-html --passWithNoTests`. Update `plans/CHANGELOG.md` + `CLAUDE.md` anchor; `notion-task`.
+
+## Notes
+- No schema migration / new API route / runtime code change. New code = guard tests + two guarded one-off scripts (template update, backfill) + an artifact-hash CI check.
+- Three known pre-existing unrelated test failures (`no-inline-tolocaledatestring` / `org-survey-exchange` / `assessment-campaigns-detail-route`) untouched.
+- **Gate:** do not execute until the user gives the go-ahead. Tasks 6–14 touch prod; all are CAS-guarded, audited, canary-first, and reversible.
+
+## Adversarial hardening (claudex review `20260609-043741-0904d9`, 3 rounds)
+- **R1 (senior eng, 7):** backfill predicate too narrow → SHA-gate (later corrected in R2); clobber-bespoke → hash allowlist; dead-CTA preflight; CAS template PATCH; price preflight; coach `<img>` empty-state; Playwright check.
+- **R2 (security/data-integrity, 8):** **SHA-gate compares interpolated snapshot to raw template hash → would skip every row** (fixed: per-workshop expected-old render, Task 7); **`background-image:url({{coach_photo}})` = CSS injection → reverted to `<img>`** (Task 0); admin PATCH not CAS → dedicated script (Task 6); CTA must be absolute-HTTPS-prod-host + published REGISTRATION (Task 8); durable AuditLog (Task 12); idempotent split rollback (Task 13); spec/PLAN artifact skew → single artifact + tests load it (Task 0); price mismatch → fail not flag (Task 9).
+- **R3 (ops/SRE, 7):** targeting via `sourceTemplateId` + per-workshop render / design marker + expected matched-row count (Task 7); rollout-window backup gap → explicit-HTML backfill + window inventory (Task 10); canary/batch controls (Task 11); persisted reports + synthetic checks (Task 12); operator runbook (Task 13).
+- **Caught two self-introduced R1 flaws** (the no-match SHA gate; the CSS-injection photo fix) — the review's main value.
+```

--- a/docs/specs/master-class-landing-kajabi.html
+++ b/docs/specs/master-class-landing-kajabi.html
@@ -1,0 +1,176 @@
+<div class="su-mc" data-su-mc>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,600;0,700;1,400&family=Fira+Sans:ital,wght@0,400;0,500;0,600;0,700;1,700&display=swap');
+
+  .su-mc{--ink:#161E2A;--body:#595959;--muted:#6b6b6b;--cta:#0072EF;--cta-hover:#005fce;
+    --su-purple:#522583;--c-people:#f7a600;--c-strategy:#008bd2;--c-exec:#946b36;--c-cash:#95c11f;
+    font-family:"Open Sans",Helvetica,Arial,sans-serif;color:var(--body);line-height:1.65;font-size:17px;-webkit-font-smoothing:antialiased;background:#fff;}
+  .su-mc *{box-sizing:border-box;}
+  .su-mc h1,.su-mc h2,.su-mc h3,.su-mc h4{font-family:"Fira Sans","Open Sans",Helvetica,Arial,sans-serif;color:var(--ink);font-weight:700;line-height:1.2;}
+  .su-mc .wrap{max-width:920px;margin:0 auto;padding:0 24px;}
+  .su-mc a{color:var(--cta);}
+
+  /* ---------- HERO BANNER (CSS rebuild of the Kajabi graphic) ---------- */
+  .su-mc .hero{max-width:1040px;margin:32px auto 0;padding:0 24px;}
+  .su-mc .hero-card{border-radius:10px;overflow:hidden;box-shadow:0 18px 50px rgba(22,30,42,.18);
+    display:grid;grid-template-columns:1.55fr 1fr;}
+  .su-mc .hero-stripe{height:10px;grid-column:1 / -1;display:flex;}
+  .su-mc .hero-stripe span{flex:1;}
+  .su-mc .hero-left{position:relative;background:#0b0b0d;color:#fff;padding:42px 40px 38px;overflow:hidden;}
+  .su-mc .hero-left::before{content:"";position:absolute;right:-60px;top:-40px;width:280px;height:320px;
+    background:linear-gradient(135deg,#6a2fae 0%,#3d1668 70%);transform:skewX(-14deg);opacity:.55;}
+  .su-mc .hero-logo{position:relative;font-family:"Fira Sans",Helvetica,Arial,sans-serif;font-weight:700;letter-spacing:.06em;font-size:15px;color:#fff;margin-bottom:34px;}
+  .su-mc .hero-logo b{display:inline-block;width:13px;height:13px;background:var(--c-cash);margin-left:6px;vertical-align:middle;}
+  .su-mc h1.hero-title{position:relative;font-size:40px;line-height:1.04;margin:0 0 6px;color:#fff;text-transform:uppercase;letter-spacing:.01em;}
+  .su-mc .hero-tag{position:relative;color:var(--c-people);font-weight:700;font-size:16px;margin:14px 0 24px;}
+  .su-mc .hero-meta{position:relative;display:flex;flex-direction:column;gap:9px;font-size:14px;color:#e8e8ea;}
+  .su-mc .hero-meta div{display:flex;align-items:center;gap:10px;}
+  .su-mc .hero-meta .ico{flex:none;display:inline-block;width:16px;height:16px;position:relative;}
+  /* CSS-drawn icons (inline SVG is stripped by the sanitizer) */
+  .su-mc .ico-cal::before{content:"";position:absolute;inset:1px 0 0;border:2px solid var(--c-people);border-radius:3px;}
+  .su-mc .ico-cal::after{content:"";position:absolute;top:-1px;left:3px;right:3px;height:3px;border-left:2px solid var(--c-people);border-right:2px solid var(--c-people);}
+  .su-mc .ico-clock::before{content:"";position:absolute;inset:1px;border:2px solid var(--c-people);border-radius:50%;}
+  .su-mc .ico-clock::after{content:"";position:absolute;left:7px;top:4px;width:2px;height:5px;background:var(--c-people);box-shadow:1px 4px 0 -1px var(--c-people);}
+  .su-mc .ico-pin::before{content:"";position:absolute;left:2px;top:0;width:12px;height:12px;border:2px solid var(--c-people);border-radius:50% 50% 50% 0;transform:rotate(-45deg);}
+  .su-mc .hero-right{background:#fff;padding:26px 24px;text-align:center;display:flex;flex-direction:column;align-items:center;justify-content:flex-start;}
+  .su-mc .hero-right .coachlogo{font-family:"Fira Sans",Helvetica,Arial,sans-serif;font-weight:700;font-size:12px;letter-spacing:.04em;color:var(--ink);margin-bottom:14px;}
+  .su-mc .hero-right .coachlogo span{display:block;font-size:9px;letter-spacing:.22em;color:var(--muted);font-weight:600;}
+  .su-mc .hero-photo{width:138px;height:138px;border-radius:50%;object-fit:cover;border:4px solid var(--su-purple);background:var(--su-purple);display:block;}
+  .su-mc .hero-right .cname{font-family:"Fira Sans",Helvetica,Arial,sans-serif;font-weight:700;color:var(--ink);font-size:20px;margin:14px 0 2px;}
+  .su-mc .hero-right .ctitle{font-size:12px;letter-spacing:.06em;text-transform:uppercase;color:var(--muted);}
+  .su-mc .hero-right .partner{margin-top:18px;padding-top:14px;border-top:1px solid #ececec;font-size:11px;letter-spacing:.1em;color:var(--muted);text-transform:uppercase;}
+
+  /* ---------- INTRO ---------- */
+  .su-mc .intro{text-align:center;padding:54px 24px 10px;}
+  .su-mc .intro .pre{font-size:26px;font-weight:400;font-family:"Fira Sans",Helvetica,Arial,sans-serif;color:var(--ink);}
+  .su-mc .intro .intro-title{font-family:"Fira Sans",Helvetica,Arial,sans-serif;font-weight:700;color:var(--ink);font-size:34px;margin:6px 0 0;line-height:1.2;}
+
+  /* ---------- CONTENT ---------- */
+  .su-mc section{padding:30px 0;}
+  .su-mc section h2{font-size:28px;margin:0 0 14px;}
+  .su-mc p{margin:0 0 16px;}
+  .su-mc .lead b{color:var(--ink);}
+  .su-mc ul.ticks{list-style:none;padding:0;margin:0;}
+  .su-mc ul.ticks li{position:relative;padding:8px 0 8px 34px;border-bottom:1px solid #f0f0f0;}
+  .su-mc ul.ticks li::before{content:"";position:absolute;left:0;top:13px;width:18px;height:18px;border-radius:50%;
+    background:var(--c-cash);}
+  .su-mc ul.ticks li::after{content:"";position:absolute;left:6px;top:17px;width:5px;height:9px;border:solid #fff;border-width:0 2px 2px 0;transform:rotate(45deg);}
+
+  .su-mc .callout{background:#f6f7f9;border-left:4px solid var(--su-purple);border-radius:6px;padding:26px 30px;text-align:center;margin:18px 0;}
+  .su-mc .callout strong{color:var(--ink);font-family:"Fira Sans",Helvetica,Arial,sans-serif;font-size:18px;}
+
+  /* ---------- VIDEO (omitted in v1 — re-add a .video block with a Vimeo/YouTube iframe when a real asset exists) ---------- */
+  .su-mc .video{max-width:760px;margin:30px auto;border-radius:10px;overflow:hidden;box-shadow:0 14px 40px rgba(22,30,42,.16);position:relative;background:#000;aspect-ratio:16/9;}
+  .su-mc .video iframe{position:absolute;inset:0;width:100%;height:100%;border:0;}
+
+  /* ---------- PRICE / REGISTER CARD ---------- */
+  .su-mc .buybar{max-width:620px;margin:34px auto 60px;border:1px solid #e7e7ea;border-radius:12px;overflow:hidden;box-shadow:0 12px 36px rgba(22,30,42,.10);}
+  .su-mc .buybar .thumb{height:8px;display:flex;}
+  .su-mc .buybar .thumb span{flex:1;}
+  .su-mc .buybar .bbody{padding:24px 28px;text-align:center;}
+  .su-mc .buybar h3{font-size:20px;margin:0 0 6px;}
+  .su-mc .buybar .price{font-family:"Fira Sans",Helvetica,Arial,sans-serif;font-weight:700;color:var(--ink);font-size:30px;margin:8px 0 18px;}
+  .su-mc .btn{display:inline-block;background:var(--cta);color:#fff;font-family:"Open Sans",Helvetica,Arial,sans-serif;font-weight:700;font-size:18px;
+    padding:13px 44px;border-radius:4px;text-decoration:none;width:100%;max-width:420px;}
+  .su-mc .btn:hover{background:var(--cta-hover);}
+
+  /* ---------- FOOTER ---------- */
+  .su-mc .foot{background:#0b0b0d;color:#bcbcc2;text-align:center;padding:34px 24px;font-size:13px;}
+  .su-mc .foot .flogo{font-family:"Fira Sans",Helvetica,Arial,sans-serif;font-weight:700;color:#fff;letter-spacing:.06em;font-size:15px;margin-bottom:8px;}
+
+  @media(max-width:760px){
+    .su-mc .hero-card{grid-template-columns:1fr;}
+    .su-mc h1.hero-title{font-size:30px;}
+    .su-mc .intro .pre{font-size:22px;}
+    .su-mc .intro .intro-title{font-size:26px;}
+  }
+</style>
+
+<!-- HERO -->
+<div class="hero">
+  <div class="hero-card">
+    <div class="hero-stripe">
+      <span style="background:var(--c-people)"></span>
+      <span style="background:var(--c-strategy)"></span>
+      <span style="background:var(--c-exec)"></span>
+      <span style="background:var(--c-cash)"></span>
+    </div>
+    <div class="hero-left">
+      <div class="hero-logo">SCALING UP<b></b></div>
+      <h1 class="hero-title">{{workshop_title}}</h1>
+      <div class="hero-tag">Growing Leaders. Growing Companies.</div>
+      <div class="hero-meta">
+        <div><span class="ico ico-cal" aria-hidden="true"></span> {{event_date}}</div>
+        <div><span class="ico ico-clock" aria-hidden="true"></span> {{event_time}}</div>
+        <div><span class="ico ico-pin" aria-hidden="true"></span> Scaling Up Workshop</div>
+      </div>
+    </div>
+    <div class="hero-right">
+      <div class="coachlogo">SCALING UP<span>COACHES</span></div>
+      <img class="hero-photo" src="{{coach_photo}}" alt="{{coach_name}}" width="138" height="138">
+      <div class="cname">{{coach_name}}</div>
+      <div class="ctitle">{{coach_title}}</div>
+      <div class="partner">In Partnership With Scaling Up</div>
+    </div>
+  </div>
+</div>
+
+<!-- INTRO -->
+<div class="intro">
+  <div class="pre">Join us for</div>
+  <div class="intro-title">&ldquo;{{workshop_title}}&rdquo;</div>
+</div>
+
+<div class="wrap">
+  <p class="lead" style="text-align:center;max-width:720px;margin:0 auto 10px;">Scaling Up workshops give business leaders the proven tools and frameworks to align their team, sharpen strategy, drive execution, and accelerate growth &mdash; the same methodology used by tens of thousands of companies worldwide.</p>
+
+  <section>
+    <h2>About the Workshop</h2>
+    <p>This session is led by <b>{{coach_name}}</b>, a Scaling Up Certified Coach, and draws on the proven Scaling Up methodology developed by <b>Verne Harnish</b> and used by growth companies around the world.</p>
+    <p>{{workshop_description}}</p>
+  </section>
+
+  <section>
+    <h2>What&rsquo;s Included</h2>
+    <ul class="ticks">
+      <li>The Scaling Up workbook and session materials</li>
+      <li>Proven frameworks and tools you can apply immediately</li>
+      <li>Live Q&amp;A with your Scaling Up Certified Coach</li>
+      <li>Connection with fellow business leaders</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Why Attend?</h2>
+    <ul class="ticks">
+      <li>Align your leadership team and get the right people in the right seats</li>
+      <li>Sharpen a strategy that sets your business apart</li>
+      <li>Build the execution rhythm that turns plans into results</li>
+      <li>Strengthen the cash flow that fuels sustainable growth</li>
+      <li>Leave with a clear action plan you can put to work right away</li>
+    </ul>
+  </section>
+
+  <div class="callout">
+    <strong>Secure your seat today.</strong><br>
+    Take the next step toward building a stronger, faster-growing business &mdash; on your terms. <em>Spots are limited.</em>
+  </div>
+
+  <div class="buybar">
+    <div class="thumb">
+      <span style="background:var(--c-people)"></span><span style="background:var(--c-strategy)"></span><span style="background:var(--c-exec)"></span><span style="background:var(--c-cash)"></span>
+    </div>
+    <div class="bbody">
+      <h3>{{event_date_no_weekday}} &middot; {{workshop_title}} with {{coach_name}}</h3>
+      <div class="price">{{price}}</div>
+      <a class="btn" href="{{registration_url}}">Register Here</a>
+    </div>
+  </div>
+</div>
+
+<div class="foot">
+  <div class="flogo">SCALING UP</div>
+  Growing Leaders &middot; Growing Companies &mdash; {{workshop_title}}, {{event_date_no_weekday}}
+</div>
+
+</div>

--- a/docs/specs/master-class-landing-kajabi.md
+++ b/docs/specs/master-class-landing-kajabi.md
@@ -1,0 +1,257 @@
+# Spec — Scaling Up Solo-Landing Template (Kajabi-faithful Custom HTML block)
+
+Source root: `src/src`. Reuses TEMPLATE-02 (`feat/template-02-custom-html`, PR #24). Build gate `CI=true npx next build --turbopack`. Sits beside `docs/specs/batch-a-workshop-landing-polish.md` (landing-page domain) — NOT `docs/specs/v7.6/*` (assessment domain). Implementation plan: [`master-class-landing-kajabi-implementation-plan.md`](./master-class-landing-kajabi-implementation-plan.md).
+
+> **Scope was sharpened by a `/grill-with-docs` pass (2026-06-09).** Jeff's "master class landing page" is served by the **global** `SOLO_LANDING` template (one row, every single-coach workshop) — so this is **the new global Scaling Up solo-landing look**, with **generic, format-neutral copy** (not the one-off exit-specific clone the first draft contained). See §2.
+
+## 1. Context — Jeff's ask
+Jeff (June 8 Slack): *"get the master class landing page to look as close to this the kajabi page as you can … I want to generate new code that looks more like this page … please help me generate the code."* Reference target captured live from `scalingupus.mykajabi.com/...claire-mula`: white editorial single-column, Fira Sans 700 headings / Open Sans body, the Four-Decisions four-color hero banner, a coach card, About / What's-Included / Why-Attend sections, a callout, a price + "Register Here" block, and a footer. The platform already supports this via TEMPLATE-02: an admin pastes BODY-HTML-only into the **Custom HTML** field on a SOLO_LANDING / DUO_LANDING `PageTemplate`; tokens are substituted at workshop-approval/build time and the stored (sanitized) string is echoed by the render path. This spec defines the **production-ready HTML artifact** (Appendix A) plus guard tests — it is an HTML deliverable, not a code-architecture change. Direction-mockup approved by the user (Gabriel) on June 8; scope grilled June 9.
+
+(Jeff's queued #2, "the scaling up quick assessment is the next one i want to see" — a separate, assessment-domain ask — is **parked** pending confirmation of *which* assessment he means; our templates are Rockefeller Habits Checklist / Quarterly Session Prep v1·v2 / Leadership Vision Alignment / Scaling Up Full, none literally a "Quick Assessment," and all already render in the branded quiz + report from PR #41. Out of scope here.)
+
+## 2. Scope & propagation (grilled)
+- **`SOLO_LANDING` is ONE global `PageTemplate`** keyed by `templateType` (+ optional `categoryId`); it has **no `workshopId`**. `auto-build-service.ts:93-119` fetches the active SOLO_LANDING row for *every* single-coach workshop. **So this block is the global solo-landing design** — copy must be generic + format-neutral (§7).
+- **`LandingPage` is a per-workshop snapshot** (`@@unique([workshopId, template])`). `runAutoBuild` copies `PageTemplate.customHtml` → `LandingPage.customHtml` **once, at `workshop/approved`** (idempotency-guarded). Editing the template therefore only affects workshops approved **afterward**.
+- **Existing pages (incl. the Martin Segnitz page Jeff is looking at) are updated via backfill, NOT rebuild.** Decision: **update the global template + backfill ALL existing solo pages.** Reuse the guarded `scripts/backfill-solo-landing-customhtml.ts` (June-4 precedent): per-workshop re-interpolation of the current `PageTemplate.customHtml` (`buildWorkshopVariables` → enrichedVars/registration_url two-pass → `interpolateContentForHtml` → strict `sanitizeCustomHtml`), `--dry-run` default → `--apply`, JSON backup, compare-and-swap on `updatedAt`, prod guard (`--i-know-this-is-prod`), reversible via `--restore`. It deliberately avoids `runAutoBuild` (no re-sent "Workshop Ready" emails, no workflow reassignment, no status flip).
+- **Propagation is a guarded, canary-first migration** (hardened by claudex review `20260609-043741-0904d9`, see the implementation plan). Critically: target rows by `sourceTemplateId` + a **per-workshop re-render of the OLD template** (the interpolated `LandingPage.customHtml` never equals the raw template hash, so a raw-hash gate would skip every row — claudex R2/R3-High1); the prod template update + backfill run as **dedicated CAS-guarded, audited scripts** (the admin PATCH route is not CAS-guarded); CTA/registration + price preflights must pass; canary one slug → cohort → full; reversible via per-row + template restore.
+
+## 3. Verified token contract
+Interpolation is **pure string replace, no conditionals** (`interpolate-content-html.ts`: `out.split('{{key}}').join(escaped)` + the spaced `{{ key }}` form). Every value is **HTML-escaped** (`escapeHtml`) and null/undefined → `""`. Use the exact double-brace spelling (no inner spaces). Tokens used by this block (all verified in `buildWorkshopVariables`, `template-interpolation.ts`):
+
+| Slot | Token | Source / note |
+|------|-------|----------------|
+| Hero title (h1) + intro + buybar + footer | `{{workshop_title}}` | `workshop.title` |
+| **About body (per-workshop)** | `{{workshop_description}}` | `workshop.description \|\| ""` — **can be empty** (a generic lead sentence precedes it, so an empty value just yields no extra paragraph) |
+| Hero meta — full date | `{{event_date}}` | weekday + full date ("Thursday, June 18, 2026") |
+| Buybar + footer — terse date | `{{event_date_no_weekday}}` | "June 18, 2026" |
+| Hero meta — time | `{{event_time}}` | DST-zoned ("9:00 AM EDT") |
+| Coach name | `{{coach_name}}` | "First Last" |
+| Coach title | `{{coach_title}}` | `coach.title` → `coach.company` → "Scaling Up Certified Coach" |
+| Coach photo `<img src>` | `{{coach_photo}}` | `coach.profileImage \|\| ""` — **can be empty**. Use an `<img src>` (sanitizer validates src URLs + strict build-time re-sanitize). **Do NOT** put the token in a CSS `background-image:url('…')` — `style`/`url()` is passed through UNPARSED, so a dynamic token there is a CSS-injection vector (claudex R2-High2). Empty-photo is prevented from shipping by the backfill preflight (require a non-empty photo) + a template-level default-avatar, not by markup tricks. |
+| Price | `{{price}}` | "$NNN" / "Free" / "TBD" — never empty, bare-USD (no currency code/cents) |
+| Register CTA `href` | `{{registration_url}}` | seeded Pass 2 by `runAutoBuild`; `""` if no REGISTRATION template |
+
+**Tokens that do NOT exist (so handled as fixed template copy or omitted):** no `video`/`video_url` (video section **omitted** in v1, §8), no `partner`/partner-logo (a generic text line), no short-tagline, no coach-initials, no friendly-format-label (`{{workshop_format}}` is the raw enum, so the hero's third meta line is the neutral fixed label "Scaling Up Workshop").
+
+## 4. Sanitizer / CSP / font-loading facts (verified empirically against the real `sanitize-html` config)
+- **Allowed tags:** sanitize-html defaults + `img, style, iframe, section, article, header, footer, main, nav, aside, figure, figcaption`. **Stripped:** all inline SVG (`svg/path/rect/circle/…`) and `<link>` (proven: `HAS svg: false`).
+- **`<style>` content is preserved verbatim** (`allowVulnerableTags:true`): `@import`, `var()`, `aspect-ratio`, grid/flex, `@media`, `::before/::after` all survive (proven: `HAS @import: true`). Inline `style=""` passes through un-normalized (`parseStyleAttributes:false`).
+- **Fonts MUST load via `@import` as the FIRST line inside `<style>`** — not `<link>`. CSP (`vercel.json`) allows it: `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com`; `font-src 'self' https://fonts.gstatic.com`.
+- **Token URIs survive save-time** in `href`/`src` (`allowTokenUris=true`, `TOKEN_RE`); the build-time strict re-sanitize (`allowTokenUris=false`) keeps the interpolated absolute https URL and strips any `javascript:`/non-allowlisted result.
+- **Icons:** inline SVG is unsupported → CSS-drawn glyphs (`::before/::after`). This block uses them for the three hero-meta icons.
+- **Video (when re-added):** `<iframe>` allowed only for `FRAME_SRC_ALLOWLIST` hosts (Stripe, `player.vimeo.com`, `youtube(-nocookie).com`); `srcdoc` always deleted.
+- **Render:** `workshop/[slug]/page.tsx` echoes the stored sanitized+interpolated string into a plain `<div data-custom-html-render>` via React's HTML-injection prop — **no shadow DOM, no re-sanitize at render, no scoping** (so the block must self-scope: §5).
+
+## 5. Scoping (ADR-0005 principle — no global leak)
+The render `<div>` has no scoping, so a bare selector in the injected `<style>` leaks page-wide. **Rule:** every selector MUST be prefixed `.su-mc`; the root carries `class="su-mc"`. No bare `body{}/html{}/*{}/h1{}/a{}`. `background:#fff` lives on `.su-mc` itself; no preview-only `body{}` ships.
+
+## 6. Section structure (top → bottom)
+Hero card (four-color stripe → dark left panel: SCALING UP wordmark, **h1 = `{{workshop_title}}`**, generic tagline "Growing Leaders. Growing Companies.", three CSS-icon meta rows [`{{event_date}}` / `{{event_time}}` / "Scaling Up Workshop"]; white right panel: SU Coaches wordmark, coach photo, name, title, "In Partnership With Scaling Up") → intro ("Join us for" + the quoted `{{workshop_title}}`) → generic centered lead paragraph → **About the Workshop** (h2: generic lead + `{{workshop_description}}`) → **What's Included** (h2, 4 ticks) → **Why Attend?** (h2, 5 ticks, Four-Decisions framing) → centered "Secure your seat / Spots are limited" callout → price + "Register Here" buybar → dark footer. **No video section in v1.**
+
+## 7. Copy model (generic + format-neutral)
+Because the template is global (virtual AND in-person, exit AND non-exit single-coach workshops):
+- **Per-workshop (tokens):** workshop title, About body (`{{workshop_description}}`), event date (full + terse), event time, coach name, coach title, coach photo, price, registration URL.
+- **Fixed generic template copy:** hero tagline, "Join us for", the generic lead sentence, About lead sentence (names Verne Harnish generically as the Scaling Up methodology author — not exit-specific), What's-Included bullets (format-neutral: "workbook and session materials", "frameworks you can apply", "live Q&A", "connection with fellow leaders" — **no lunch/take-home**), Why-Attend bullets (People/Strategy/Execution/Cash), the callout, "In Partnership With Scaling Up", the SCALING UP wordmarks. Editable in place to spin a category-scoped variant later if wanted.
+
+## 8. Fidelity decisions (grilled)
+- **CTA stays Kajabi blue `#0072EF`** (Jeff's "match Kajabi" ask). Swapping to SU purple `#522583` is a one-variable change (`--cta`/`--cta-hover`).
+- **Type/color match Kajabi:** headings Fira Sans 700 `#161E2A`; body Open Sans `#595959`.
+- **Video omitted in v1** — no per-workshop video token and no real Scaling Up asset; shipping a demo clip globally is worse than none. Re-add as a one-block change when Jeff supplies a Vimeo/YouTube URL (the only allowlisted hosts). The `.video` CSS rule is retained (commented intent) for trivial re-add.
+- **Price = bare USD** ("$349"); cannot reproduce Kajabi's "$445.00 AUD" (no currency field). Accepted for v1; flagged to Jeff.
+- **Partner line = generic text** ("In Partnership With Scaling Up"); real partner logos (e.g. Cornerstone/STS) would need a per-template image slot — deferred.
+
+## 9. Accessibility
+Single `<h1>` first in source order (the title); no skipped levels (h1 → h2). Coach `<img>` has `alt="{{coach_name}}"` and a purple background fallback for empty src. CTA is a real `<a href>` with discernible text. Decorative CSS icons are `aria-hidden="true"`. Muted greys use `--muted:#6b6b6b` (≥4.5:1 on white) — fixes the prior `#8a8a8a`/`#b0b0b0` AA failures.
+
+## 10. Responsive
+Breakpoint `@media(max-width:760px)`: hero collapses 2-col → 1-col; hero title 40→30px; intro 34→26px. Containers `max-width` + `margin:0 auto` + `padding:0 24px` (hero 1040, wrap 920, buybar 620, btn max 420). 138px photo fits narrow viewports.
+
+## 11. Open / follow-on (genuinely for Jeff or later)
+- **Real video asset** → re-add the embed.
+- **Multi-currency pricing** → per-workshop currency field + `{{price}}` formatter.
+- **Real partner logos** → per-template image slot.
+- **DUO_LANDING (two-coach)** variant → second coach card + two-photo hero; same pipeline; deferred.
+- **Category-scoped variant** → if a specific workshop family ever needs bespoke (e.g. exit-specific) copy, attach a `categoryId`-scoped SOLO_LANDING template; the global one stays generic.
+- **Jeff's #2 (quick assessment)** → parked pending which-assessment confirmation.
+
+## Appendix A — the pasteable Custom HTML block (production, tokenized, generic)
+Paste exactly this `<div>` (and nothing above/below it) into the SOLO_LANDING template's **Custom HTML** field. The `@import` must remain the first line inside `<style>`. Fixed copy is edited in place per template.
+
+```html
+<div class="su-mc" data-su-mc>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,600;0,700;1,400&family=Fira+Sans:ital,wght@0,400;0,500;0,600;0,700;1,700&display=swap');
+
+  .su-mc{--ink:#161E2A;--body:#595959;--muted:#6b6b6b;--cta:#0072EF;--cta-hover:#005fce;
+    --su-purple:#522583;--c-people:#f7a600;--c-strategy:#008bd2;--c-exec:#946b36;--c-cash:#95c11f;
+    font-family:"Open Sans",Helvetica,Arial,sans-serif;color:var(--body);line-height:1.65;font-size:17px;-webkit-font-smoothing:antialiased;background:#fff;}
+  .su-mc *{box-sizing:border-box;}
+  .su-mc h1,.su-mc h2,.su-mc h3,.su-mc h4{font-family:"Fira Sans","Open Sans",Helvetica,Arial,sans-serif;color:var(--ink);font-weight:700;line-height:1.2;}
+  .su-mc .wrap{max-width:920px;margin:0 auto;padding:0 24px;}
+  .su-mc a{color:var(--cta);}
+
+  /* ---------- HERO BANNER (CSS rebuild of the Kajabi graphic) ---------- */
+  .su-mc .hero{max-width:1040px;margin:32px auto 0;padding:0 24px;}
+  .su-mc .hero-card{border-radius:10px;overflow:hidden;box-shadow:0 18px 50px rgba(22,30,42,.18);
+    display:grid;grid-template-columns:1.55fr 1fr;}
+  .su-mc .hero-stripe{height:10px;grid-column:1 / -1;display:flex;}
+  .su-mc .hero-stripe span{flex:1;}
+  .su-mc .hero-left{position:relative;background:#0b0b0d;color:#fff;padding:42px 40px 38px;overflow:hidden;}
+  .su-mc .hero-left::before{content:"";position:absolute;right:-60px;top:-40px;width:280px;height:320px;
+    background:linear-gradient(135deg,#6a2fae 0%,#3d1668 70%);transform:skewX(-14deg);opacity:.55;}
+  .su-mc .hero-logo{position:relative;font-family:"Fira Sans",Helvetica,Arial,sans-serif;font-weight:700;letter-spacing:.06em;font-size:15px;color:#fff;margin-bottom:34px;}
+  .su-mc .hero-logo b{display:inline-block;width:13px;height:13px;background:var(--c-cash);margin-left:6px;vertical-align:middle;}
+  .su-mc h1.hero-title{position:relative;font-size:40px;line-height:1.04;margin:0 0 6px;color:#fff;text-transform:uppercase;letter-spacing:.01em;}
+  .su-mc .hero-tag{position:relative;color:var(--c-people);font-weight:700;font-size:16px;margin:14px 0 24px;}
+  .su-mc .hero-meta{position:relative;display:flex;flex-direction:column;gap:9px;font-size:14px;color:#e8e8ea;}
+  .su-mc .hero-meta div{display:flex;align-items:center;gap:10px;}
+  .su-mc .hero-meta .ico{flex:none;display:inline-block;width:16px;height:16px;position:relative;}
+  /* CSS-drawn icons (inline SVG is stripped by the sanitizer) */
+  .su-mc .ico-cal::before{content:"";position:absolute;inset:1px 0 0;border:2px solid var(--c-people);border-radius:3px;}
+  .su-mc .ico-cal::after{content:"";position:absolute;top:-1px;left:3px;right:3px;height:3px;border-left:2px solid var(--c-people);border-right:2px solid var(--c-people);}
+  .su-mc .ico-clock::before{content:"";position:absolute;inset:1px;border:2px solid var(--c-people);border-radius:50%;}
+  .su-mc .ico-clock::after{content:"";position:absolute;left:7px;top:4px;width:2px;height:5px;background:var(--c-people);box-shadow:1px 4px 0 -1px var(--c-people);}
+  .su-mc .ico-pin::before{content:"";position:absolute;left:2px;top:0;width:12px;height:12px;border:2px solid var(--c-people);border-radius:50% 50% 50% 0;transform:rotate(-45deg);}
+  .su-mc .hero-right{background:#fff;padding:26px 24px;text-align:center;display:flex;flex-direction:column;align-items:center;justify-content:flex-start;}
+  .su-mc .hero-right .coachlogo{font-family:"Fira Sans",Helvetica,Arial,sans-serif;font-weight:700;font-size:12px;letter-spacing:.04em;color:var(--ink);margin-bottom:14px;}
+  .su-mc .hero-right .coachlogo span{display:block;font-size:9px;letter-spacing:.22em;color:var(--muted);font-weight:600;}
+  .su-mc .hero-photo{width:138px;height:138px;border-radius:50%;object-fit:cover;border:4px solid var(--su-purple);background:var(--su-purple);display:block;}
+  .su-mc .hero-right .cname{font-family:"Fira Sans",Helvetica,Arial,sans-serif;font-weight:700;color:var(--ink);font-size:20px;margin:14px 0 2px;}
+  .su-mc .hero-right .ctitle{font-size:12px;letter-spacing:.06em;text-transform:uppercase;color:var(--muted);}
+  .su-mc .hero-right .partner{margin-top:18px;padding-top:14px;border-top:1px solid #ececec;font-size:11px;letter-spacing:.1em;color:var(--muted);text-transform:uppercase;}
+
+  /* ---------- INTRO ---------- */
+  .su-mc .intro{text-align:center;padding:54px 24px 10px;}
+  .su-mc .intro .pre{font-size:26px;font-weight:400;font-family:"Fira Sans",Helvetica,Arial,sans-serif;color:var(--ink);}
+  .su-mc .intro .intro-title{font-family:"Fira Sans",Helvetica,Arial,sans-serif;font-weight:700;color:var(--ink);font-size:34px;margin:6px 0 0;line-height:1.2;}
+
+  /* ---------- CONTENT ---------- */
+  .su-mc section{padding:30px 0;}
+  .su-mc section h2{font-size:28px;margin:0 0 14px;}
+  .su-mc p{margin:0 0 16px;}
+  .su-mc .lead b{color:var(--ink);}
+  .su-mc ul.ticks{list-style:none;padding:0;margin:0;}
+  .su-mc ul.ticks li{position:relative;padding:8px 0 8px 34px;border-bottom:1px solid #f0f0f0;}
+  .su-mc ul.ticks li::before{content:"";position:absolute;left:0;top:13px;width:18px;height:18px;border-radius:50%;
+    background:var(--c-cash);}
+  .su-mc ul.ticks li::after{content:"";position:absolute;left:6px;top:17px;width:5px;height:9px;border:solid #fff;border-width:0 2px 2px 0;transform:rotate(45deg);}
+
+  .su-mc .callout{background:#f6f7f9;border-left:4px solid var(--su-purple);border-radius:6px;padding:26px 30px;text-align:center;margin:18px 0;}
+  .su-mc .callout strong{color:var(--ink);font-family:"Fira Sans",Helvetica,Arial,sans-serif;font-size:18px;}
+
+  /* ---------- VIDEO (omitted in v1 — re-add a .video block with a Vimeo/YouTube iframe when a real asset exists) ---------- */
+  .su-mc .video{max-width:760px;margin:30px auto;border-radius:10px;overflow:hidden;box-shadow:0 14px 40px rgba(22,30,42,.16);position:relative;background:#000;aspect-ratio:16/9;}
+  .su-mc .video iframe{position:absolute;inset:0;width:100%;height:100%;border:0;}
+
+  /* ---------- PRICE / REGISTER CARD ---------- */
+  .su-mc .buybar{max-width:620px;margin:34px auto 60px;border:1px solid #e7e7ea;border-radius:12px;overflow:hidden;box-shadow:0 12px 36px rgba(22,30,42,.10);}
+  .su-mc .buybar .thumb{height:8px;display:flex;}
+  .su-mc .buybar .thumb span{flex:1;}
+  .su-mc .buybar .bbody{padding:24px 28px;text-align:center;}
+  .su-mc .buybar h3{font-size:20px;margin:0 0 6px;}
+  .su-mc .buybar .price{font-family:"Fira Sans",Helvetica,Arial,sans-serif;font-weight:700;color:var(--ink);font-size:30px;margin:8px 0 18px;}
+  .su-mc .btn{display:inline-block;background:var(--cta);color:#fff;font-family:"Open Sans",Helvetica,Arial,sans-serif;font-weight:700;font-size:18px;
+    padding:13px 44px;border-radius:4px;text-decoration:none;width:100%;max-width:420px;}
+  .su-mc .btn:hover{background:var(--cta-hover);}
+
+  /* ---------- FOOTER ---------- */
+  .su-mc .foot{background:#0b0b0d;color:#bcbcc2;text-align:center;padding:34px 24px;font-size:13px;}
+  .su-mc .foot .flogo{font-family:"Fira Sans",Helvetica,Arial,sans-serif;font-weight:700;color:#fff;letter-spacing:.06em;font-size:15px;margin-bottom:8px;}
+
+  @media(max-width:760px){
+    .su-mc .hero-card{grid-template-columns:1fr;}
+    .su-mc h1.hero-title{font-size:30px;}
+    .su-mc .intro .pre{font-size:22px;}
+    .su-mc .intro .intro-title{font-size:26px;}
+  }
+</style>
+
+<!-- HERO -->
+<div class="hero">
+  <div class="hero-card">
+    <div class="hero-stripe">
+      <span style="background:var(--c-people)"></span>
+      <span style="background:var(--c-strategy)"></span>
+      <span style="background:var(--c-exec)"></span>
+      <span style="background:var(--c-cash)"></span>
+    </div>
+    <div class="hero-left">
+      <div class="hero-logo">SCALING UP<b></b></div>
+      <h1 class="hero-title">{{workshop_title}}</h1>
+      <div class="hero-tag">Growing Leaders. Growing Companies.</div>
+      <div class="hero-meta">
+        <div><span class="ico ico-cal" aria-hidden="true"></span> {{event_date}}</div>
+        <div><span class="ico ico-clock" aria-hidden="true"></span> {{event_time}}</div>
+        <div><span class="ico ico-pin" aria-hidden="true"></span> Scaling Up Workshop</div>
+      </div>
+    </div>
+    <div class="hero-right">
+      <div class="coachlogo">SCALING UP<span>COACHES</span></div>
+      <img class="hero-photo" src="{{coach_photo}}" alt="{{coach_name}}" width="138" height="138">
+      <div class="cname">{{coach_name}}</div>
+      <div class="ctitle">{{coach_title}}</div>
+      <div class="partner">In Partnership With Scaling Up</div>
+    </div>
+  </div>
+</div>
+
+<!-- INTRO -->
+<div class="intro">
+  <div class="pre">Join us for</div>
+  <div class="intro-title">&ldquo;{{workshop_title}}&rdquo;</div>
+</div>
+
+<div class="wrap">
+  <p class="lead" style="text-align:center;max-width:720px;margin:0 auto 10px;">Scaling Up workshops give business leaders the proven tools and frameworks to align their team, sharpen strategy, drive execution, and accelerate growth &mdash; the same methodology used by tens of thousands of companies worldwide.</p>
+
+  <section>
+    <h2>About the Workshop</h2>
+    <p>This session is led by <b>{{coach_name}}</b>, a Scaling Up Certified Coach, and draws on the proven Scaling Up methodology developed by <b>Verne Harnish</b> and used by growth companies around the world.</p>
+    <p>{{workshop_description}}</p>
+  </section>
+
+  <section>
+    <h2>What&rsquo;s Included</h2>
+    <ul class="ticks">
+      <li>The Scaling Up workbook and session materials</li>
+      <li>Proven frameworks and tools you can apply immediately</li>
+      <li>Live Q&amp;A with your Scaling Up Certified Coach</li>
+      <li>Connection with fellow business leaders</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Why Attend?</h2>
+    <ul class="ticks">
+      <li>Align your leadership team and get the right people in the right seats</li>
+      <li>Sharpen a strategy that sets your business apart</li>
+      <li>Build the execution rhythm that turns plans into results</li>
+      <li>Strengthen the cash flow that fuels sustainable growth</li>
+      <li>Leave with a clear action plan you can put to work right away</li>
+    </ul>
+  </section>
+
+  <div class="callout">
+    <strong>Secure your seat today.</strong><br>
+    Take the next step toward building a stronger, faster-growing business &mdash; on your terms. <em>Spots are limited.</em>
+  </div>
+
+  <div class="buybar">
+    <div class="thumb">
+      <span style="background:var(--c-people)"></span><span style="background:var(--c-strategy)"></span><span style="background:var(--c-exec)"></span><span style="background:var(--c-cash)"></span>
+    </div>
+    <div class="bbody">
+      <h3>{{event_date_no_weekday}} &middot; {{workshop_title}} with {{coach_name}}</h3>
+      <div class="price">{{price}}</div>
+      <a class="btn" href="{{registration_url}}">Register Here</a>
+    </div>
+  </div>
+</div>
+
+<div class="foot">
+  <div class="flogo">SCALING UP</div>
+  Growing Leaders &middot; Growing Companies &mdash; {{workshop_title}}, {{event_date_no_weekday}}
+</div>
+
+</div>
+```

--- a/src/scripts/backfill-solo-landing-kajabi.ts
+++ b/src/scripts/backfill-solo-landing-kajabi.ts
@@ -97,18 +97,19 @@ const DEFAULT_ARTIFACT = join(REPO_ROOT, "docs/specs/master-class-landing-kajabi
  * Re-interpolate a template's customHtml for a workshop, exactly as auto-build's
  * Pass 2 does: buildWorkshopVariables → enrichedVars (+ registration_url two-pass
  * from the EXISTING REGISTRATION slug) → interpolate → STRICT sanitize.
+ *
+ * Fix 3 (P2): accepts a pre-resolved registrationUrl so the caller (resolveWorkshopFacts)
+ * does the single REGISTRATION lookup and passes the result in — eliminates the
+ * duplicate db.landingPage.findUnique that was happening once here and once in
+ * resolveWorkshopFacts for every candidate workshop.
  */
 async function reinterpolate(
   workshopId: string,
   templateCustomHtml: string,
+  registrationUrl: string,
 ): Promise<SanitizeOutcome | null> {
   const variables = await buildWorkshopVariables(workshopId);
   if (!variables) return null;
-  const existingReg = await db.landingPage.findUnique({
-    where: { workshopId_template: { workshopId, template: "REGISTRATION" } },
-    select: { slug: true },
-  });
-  const registrationUrl = existingReg?.slug ? `${process.env.APP_URL}/workshop/${existingReg.slug}` : "";
   const enrichedVars: Record<string, string | null | undefined> = {
     ...variables,
     registration_url: registrationUrl,
@@ -132,6 +133,7 @@ async function resolveWorkshopFacts(workshopId: string): Promise<WorkshopFacts |
   });
   if (!workshop) return null;
 
+  // Single REGISTRATION lookup — result is shared with reinterpolate (Fix 3).
   const reg = await db.landingPage.findUnique({
     where: { workshopId_template: { workshopId, template: "REGISTRATION" } },
     select: { slug: true, status: true },

--- a/src/scripts/backfill-solo-landing-kajabi.ts
+++ b/src/scripts/backfill-solo-landing-kajabi.ts
@@ -73,6 +73,7 @@ import {
   parseKajabiArgs,
   checkExpectedCount,
   toKajabiBackupEntry,
+  NEW_DESIGN_MARKER,
   type KajabiRowPlan,
   type KajabiBackupFile,
   type TemplateBackupFile,
@@ -297,6 +298,28 @@ async function main(): Promise<void> {
   }
   const artifactPath = args.newTemplate ?? DEFAULT_ARTIFACT;
   const newArtifactRaw = await readFile(artifactPath, "utf8");
+  // Mirror Script 1 (update-solo-landing-template.ts → loadSanitizedArtifact):
+  // the template stored in DB is save-time-sanitized with allowTokenUris:true (default).
+  // Targeting hashes must be computed from the SAME sanitized string, not raw.
+  const {
+    sanitized: newArtifactSanitized,
+    didStripContent,
+    strippedTags,
+    strippedAttrs,
+  } = sanitizeCustomHtml(newArtifactRaw);
+  if (didStripContent) {
+    console.error(
+      `Artifact sanitize STRIPPED content — refusing to proceed.\n` +
+        `  strippedTags=[${strippedTags.join(", ")}] strippedAttrs=[${strippedAttrs.join(", ")}]`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+  if (!newArtifactSanitized.includes(NEW_DESIGN_MARKER)) {
+    console.error(`Sanitized artifact does not contain the design marker "${NEW_DESIGN_MARKER}".`);
+    process.exitCode = 1;
+    return;
+  }
   const newGlobalSha = oldBackup.newSha; // SHA of the template we patched live.
 
   const { plans, counts } = await buildBackfillPlans(
@@ -306,7 +329,7 @@ async function main(): Promise<void> {
     {
       oldGlobalTemplateId: oldBackup.templateId,
       oldTemplateCustomHtml: oldBackup.oldCustomHtml,
-      newTemplateCustomHtml: newArtifactRaw,
+      newTemplateCustomHtml: newArtifactSanitized,
       expectedHost: ctaExpectedHost,
       allowPriceWorkshopIds: args.allowPrice,
       slug: args.slug,

--- a/src/scripts/backfill-solo-landing-kajabi.ts
+++ b/src/scripts/backfill-solo-landing-kajabi.ts
@@ -1,0 +1,364 @@
+/**
+ * backfill-solo-landing-kajabi.ts  [Tasks 7–13]
+ *
+ * Script 2 of the GLOBAL SOLO_LANDING Kajabi rollout: a guarded, canary-first,
+ * audited, reversible backfill of the EXISTING per-workshop SOLO_LANDING
+ * LandingPage.customHtml snapshots from the OLD global design to the NEW Kajabi
+ * design.
+ *
+ * ── TARGETING (the #1 thing to get right; claudex R2-High1 / R3-High1) ────────
+ * `LandingPage.customHtml` is the INTERPOLATED per-workshop snapshot, so it will
+ * NEVER equal the RAW PageTemplate.customHtml hash. We therefore do NOT gate on
+ * a shared raw-template hash. Instead, for each candidate SOLO_LANDING page:
+ *   1. re-interpolate the BACKED-UP OLD global template
+ *      (--old-template-backup <Script-1 backup>) with THIS workshop's
+ *      buildWorkshopVariables + REGISTRATION slug (the SAME two-pass auto-build
+ *      uses), strict-sanitize → expectedOldRender;
+ *   2. re-interpolate the NEW artifact (--new-template <path>, default the
+ *      docs/specs artifact — explicit, NOT "current active template") the same
+ *      way → newRender;
+ *   3. SHA(currentCustomHtml) == SHA(newRender) → NO-OP (already migrated);
+ *      SHA(currentCustomHtml) == SHA(expectedOldRender) → TARGET;
+ *      anything else → SKIP + log (bespoke / category / hand-edited — never clobber).
+ *   Also: if sourceTemplateId is set and != the old global template id → SKIP.
+ *
+ * ── PREFLIGHTS on each TARGET (skip + flag if any fail) ─────────────────────────
+ *   - coach photo: coach.profileImage non-empty (Task 7);
+ *   - CTA (Task 8): registration_url is absolute https on the expected prod host
+ *     AND the slug belongs to a PUBLISHED REGISTRATION page for the same workshop;
+ *   - price (Task 9): rendered {{price}} not TBD/Free unless --allow-price <wsId>;
+ *   - new-value validity: contains data-su-mc, NO unresolved {{, non-empty CTA href.
+ *
+ * ── EXPECTED-COUNT GATE (Task 7) ────────────────────────────────────────────────
+ * --apply requires --expect-count N exactly == the dry-run TARGET count, else abort.
+ *
+ * ── CANARY + BATCH (Task 11) ────────────────────────────────────────────────────
+ * --slug <slug> (single page) and --limit <N> (batch the candidate scan).
+ *
+ * ── AUDIT + REPORTS + BACKUP + CAS + RESTORE (Tasks 10/12/13) ────────────────────
+ * Every apply/restore writes an AuditLog row + a JSON report under src/.snapshots/.
+ * Backup-before-write; CAS-on-updatedAt; --restore <backup> CAS-restores rows.
+ * The backup records oldGlobalTemplateId + newGlobalSha for the rollback window.
+ *
+ * ── Usage ──────────────────────────────────────────────────────────────────────
+ *   cd src
+ *   npx tsx scripts/backfill-solo-landing-kajabi.ts \
+ *     --old-template-backup .snapshots/solo-landing-template-update-<ISO>.json   # dry-run
+ *   ... --slug <canarySlug>                                                       # canary dry-run
+ *   ... --slug <canarySlug> --expect-count 1 --apply --i-know-this-is-prod        # canary apply
+ *   ... --expect-count <N> --apply --i-know-this-is-prod                          # full apply
+ *   ... --restore .snapshots/solo-landing-kajabi-backfill-<ISO>.json --i-know-this-is-prod
+ *   ... --inventory                                                               # rollout-window list
+ */
+
+import { config as loadEnv } from "dotenv";
+import { join } from "node:path";
+
+const SRC_DIR = join(__dirname, "..");
+const REPO_ROOT = join(SRC_DIR, "..");
+loadEnv({ path: join(SRC_DIR, ".env.production.local") });
+loadEnv({ path: join(SRC_DIR, ".env.local") });
+loadEnv({ path: join(SRC_DIR, ".env") });
+
+import { PrismaClient } from "@prisma/client";
+import { mkdir, writeFile, readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+
+import { checkGuard, parseHost } from "../src/lib/scripts/safe-seed-guard";
+import { buildWorkshopVariables } from "../src/lib/templates/template-interpolation";
+import { interpolateContentForHtml } from "../src/lib/templates/interpolate-content-html";
+import { sanitizeCustomHtml } from "../src/lib/templates/sanitize-custom-html";
+import {
+  parseKajabiArgs,
+  checkExpectedCount,
+  toKajabiBackupEntry,
+  type KajabiRowPlan,
+  type KajabiBackupFile,
+  type TemplateBackupFile,
+} from "../src/lib/scripts/solo-landing-kajabi-core";
+import {
+  buildBackfillPlans,
+  applyBackfillPlans,
+  restoreBackfill,
+  inventorySoloPages,
+  type DbClient,
+  type SanitizeOutcome,
+  type WorkshopFacts,
+} from "../src/lib/scripts/solo-landing-kajabi-runner";
+
+const db = new PrismaClient();
+const SNAPSHOT_DIR = join(SRC_DIR, ".snapshots");
+const DEFAULT_ARTIFACT = join(REPO_ROOT, "docs/specs/master-class-landing-kajabi.html");
+
+// ─── Per-workshop renders + facts (the real pipeline, injected into the runner) ──
+
+/**
+ * Re-interpolate a template's customHtml for a workshop, exactly as auto-build's
+ * Pass 2 does: buildWorkshopVariables → enrichedVars (+ registration_url two-pass
+ * from the EXISTING REGISTRATION slug) → interpolate → STRICT sanitize.
+ */
+async function reinterpolate(
+  workshopId: string,
+  templateCustomHtml: string,
+): Promise<SanitizeOutcome | null> {
+  const variables = await buildWorkshopVariables(workshopId);
+  if (!variables) return null;
+  const existingReg = await db.landingPage.findUnique({
+    where: { workshopId_template: { workshopId, template: "REGISTRATION" } },
+    select: { slug: true },
+  });
+  const registrationUrl = existingReg?.slug ? `${process.env.APP_URL}/workshop/${existingReg.slug}` : "";
+  const enrichedVars: Record<string, string | null | undefined> = {
+    ...variables,
+    registration_url: registrationUrl,
+    registrationUrl,
+  };
+  const interpolated = interpolateContentForHtml(templateCustomHtml, enrichedVars);
+  const { sanitized, strippedTags, strippedAttrs } = sanitizeCustomHtml(interpolated, {
+    allowTokenUris: false,
+  });
+  return { sanitized, strippedTags, strippedAttrs };
+}
+
+/** Resolve the per-workshop preflight facts (coach photo / registration / price). */
+async function resolveWorkshopFacts(workshopId: string): Promise<WorkshopFacts | null> {
+  const workshop = await db.workshop.findUnique({
+    where: { id: workshopId },
+    include: {
+      coach: { select: { profileImage: true } },
+      pricingTier: { select: { amountCents: true } },
+    },
+  });
+  if (!workshop) return null;
+
+  const reg = await db.landingPage.findUnique({
+    where: { workshopId_template: { workshopId, template: "REGISTRATION" } },
+    select: { slug: true, status: true },
+  });
+  const registrationUrl = reg?.slug ? `${process.env.APP_URL}/workshop/${reg.slug}` : "";
+
+  // Mirror buildWorkshopVariables' price derivation (same source as checkout).
+  const renderedPrice = workshop.pricingTier
+    ? `$${(workshop.pricingTier.amountCents / 100).toFixed(0)}`
+    : workshop.isFree
+      ? "Free"
+      : workshop.priceCents
+        ? `$${(workshop.priceCents / 100).toFixed(0)}`
+        : "TBD";
+
+  return {
+    coachProfileImage: workshop.coach?.profileImage ?? null,
+    registrationUrl,
+    registrationSlug: reg?.slug ?? null,
+    registrationPublished: reg?.status === "PUBLISHED",
+    renderedPrice,
+  };
+}
+
+// ─── Reporting ───────────────────────────────────────────────────────────────
+
+function printReport(plans: KajabiRowPlan[]): void {
+  console.log("\n── Per-row plan ──────────────────────────────────────────");
+  for (const p of plans) {
+    if (p.decision === "target") {
+      console.log(`\n[TARGET] ${p.slug} (lp=${p.landingPageId} ws=${p.workshopId})`);
+      console.log(`  oldSha=${p.oldSha.slice(0, 14)}… newSha=${p.newSha.slice(0, 14)}…`);
+      console.log(`  cta=${p.validation.resolvedCtaHref ?? "—"}`);
+      if (p.sanitizerStripped) {
+        console.warn(
+          `  ⚠ sanitizer stripped: tags=[${p.strippedTags.join(",")}] attrs=[${p.strippedAttrs.join(",")}] (BLOCKS apply)`,
+        );
+      }
+    } else if (p.decision === "no-op") {
+      console.log(`\n[NO-OP] ${p.slug} — already on the new design.`);
+    } else {
+      console.log(`\n[SKIP] ${p.slug} — ${p.skipReason}${p.skipDetail ? `: ${p.skipDetail}` : ""}`);
+    }
+  }
+  console.log("\n──────────────────────────────────────────────────────────");
+}
+
+async function writeReport(runId: string, host: string, mode: string, plans: KajabiRowPlan[]): Promise<string> {
+  if (!existsSync(SNAPSHOT_DIR)) await mkdir(SNAPSHOT_DIR, { recursive: true });
+  const iso = new Date().toISOString().replace(/[:.]/g, "-");
+  const file = join(SNAPSHOT_DIR, `solo-landing-kajabi-report-${mode}-${iso}.json`);
+  const report = {
+    kind: "solo-landing-kajabi-report",
+    runId,
+    mode,
+    createdAt: new Date().toISOString(),
+    databaseHost: host,
+    rows: plans.map((p) => ({
+      slug: p.slug,
+      landingPageId: p.landingPageId,
+      workshopId: p.workshopId,
+      decision: p.decision,
+      skipReason: p.skipReason,
+      skipDetail: p.skipDetail,
+      oldSha: p.oldSha,
+      newSha: p.newSha,
+      cta: p.validation.resolvedCtaHref,
+      sanitizerStripped: p.sanitizerStripped,
+    })),
+  };
+  await writeFile(file, JSON.stringify(report, null, 2), "utf8");
+  return file;
+}
+
+async function writeBackfillBackup(
+  runId: string,
+  host: string,
+  oldGlobalTemplateId: string,
+  newGlobalSha: string,
+  targets: KajabiRowPlan[],
+): Promise<string> {
+  if (!existsSync(SNAPSHOT_DIR)) await mkdir(SNAPSHOT_DIR, { recursive: true });
+  const iso = new Date().toISOString().replace(/[:.]/g, "-");
+  const file = join(SNAPSHOT_DIR, `solo-landing-kajabi-backfill-${iso}.json`);
+  const backup: KajabiBackupFile = {
+    kind: "solo-landing-kajabi-backfill",
+    runId,
+    createdAt: new Date().toISOString(),
+    databaseHost: host,
+    oldGlobalTemplateId,
+    newGlobalSha,
+    entries: targets.map(toKajabiBackupEntry),
+  };
+  await writeFile(file, JSON.stringify(backup, null, 2), "utf8");
+  return file;
+}
+
+// ─── main ────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  const args = parseKajabiArgs(argv);
+  const url = process.env.DATABASE_URL ?? "";
+  const host = parseHost(url);
+  const expectedHostGuard = process.env.ASSESSMENT_PROD_EXPECTED_HOST;
+  const operator = process.env.OPERATOR_EMAIL || process.env.ADMIN_EMAIL || "SYSTEM";
+  const runId = randomUUID();
+
+  // Expected production host for the CTA preflight — derive from APP_URL.
+  const ctaExpectedHost = (() => {
+    try {
+      return new URL(process.env.APP_URL ?? "").host;
+    } catch {
+      return "";
+    }
+  })();
+
+  console.log(`backfill-solo-landing-kajabi — mode=${args.mode} host=${host || "(none)"} runId=${runId}`);
+
+  if (argv.includes("--inventory")) {
+    const inv = await inventorySoloPages(db as unknown as DbClient);
+    console.log(`\nSOLO_LANDING inventory (${inv.length} pages):`);
+    for (const row of inv) {
+      console.log(`  ${row.slug}  sha=${row.sha.slice(0, 14)}…  src=${row.sourceTemplateId ?? "—"}`);
+    }
+    return;
+  }
+
+  if (args.mode === "apply" || args.mode === "restore") {
+    const decision = checkGuard({ url, expectedHost: expectedHostGuard, hasOverride: args.hasOverride });
+    if (!decision.allowed) {
+      console.error(`\n❌ BLOCKED — prod guard refused (${args.mode}).\n  ${decision.reason}\n`);
+      process.exitCode = 1;
+      return;
+    }
+  }
+
+  if (args.mode === "restore") {
+    if (!args.restoreFile) {
+      console.error("Usage: --restore <backfillBackup.json> --i-know-this-is-prod");
+      process.exitCode = 1;
+      return;
+    }
+    const backup = JSON.parse(await readFile(args.restoreFile, "utf8")) as KajabiBackupFile;
+    const result = await restoreBackfill(db as unknown as DbClient, backup, { operator, runId });
+    console.log(`\nRestore: ${result.restored} restored, ${result.skipped} skipped.`);
+    return;
+  }
+
+  // dry-run + apply both build the plans first.
+  if (!args.oldTemplateBackup) {
+    console.error("Required: --old-template-backup <Script-1 backup .json> (the expected-old-render source).");
+    process.exitCode = 1;
+    return;
+  }
+  const oldBackup = JSON.parse(await readFile(args.oldTemplateBackup, "utf8")) as TemplateBackupFile;
+  if (oldBackup.kind !== "solo-landing-template-update") {
+    console.error("--old-template-backup is not a recognised template-update backup.");
+    process.exitCode = 1;
+    return;
+  }
+  const artifactPath = args.newTemplate ?? DEFAULT_ARTIFACT;
+  const newArtifactRaw = await readFile(artifactPath, "utf8");
+  const newGlobalSha = oldBackup.newSha; // SHA of the template we patched live.
+
+  const { plans, counts } = await buildBackfillPlans(
+    db as unknown as DbClient,
+    reinterpolate,
+    resolveWorkshopFacts,
+    {
+      oldGlobalTemplateId: oldBackup.templateId,
+      oldTemplateCustomHtml: oldBackup.oldCustomHtml,
+      newTemplateCustomHtml: newArtifactRaw,
+      expectedHost: ctaExpectedHost,
+      allowPriceWorkshopIds: args.allowPrice,
+      slug: args.slug,
+      limit: args.limit,
+    },
+  );
+
+  printReport(plans);
+  console.log(
+    `\nSummary: ${counts.candidates} candidates — ${counts.targets} target, ${counts.noops} no-op, ${counts.skips} skip.`,
+  );
+  const reportFile = await writeReport(runId, host, args.mode, plans);
+  console.log(`Report: ${reportFile}`);
+
+  if (args.mode === "dry-run") {
+    console.log(`\nDRY RUN — no writes. To apply: --expect-count ${counts.targets} --apply --i-know-this-is-prod`);
+    return;
+  }
+
+  // apply: enforce the expected-count gate.
+  const gate = checkExpectedCount(counts.targets, args.expectCount);
+  if (!gate.ok) {
+    console.error(`\n❌ ${gate.reason}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const result = await applyBackfillPlans(db as unknown as DbClient, plans, {
+    writeBackup: (targets) =>
+      writeBackfillBackup(runId, host, oldBackup.templateId, newGlobalSha, targets),
+    operator,
+    runId,
+    newGlobalSha,
+  });
+
+  if (result.blocked > 0) {
+    console.error(`\n❌ Refusing to apply — ${result.blocked} target row(s) had sanitizer strips.`);
+    process.exitCode = 1;
+    return;
+  }
+  if (!result.backupFile) {
+    console.log("Nothing to apply (no target rows).");
+    return;
+  }
+  console.log(`\nBackup: ${result.backupFile}`);
+  console.log(`Applied: ${result.updated} updated, ${result.skipped} skipped (CAS abort).`);
+  console.log(`Restore with: --restore ${result.backupFile} --i-know-this-is-prod`);
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await db.$disconnect();
+  });

--- a/src/scripts/update-solo-landing-template.ts
+++ b/src/scripts/update-solo-landing-template.ts
@@ -1,0 +1,204 @@
+/**
+ * update-solo-landing-template.ts  [Task 6]
+ *
+ * Script 1 of the GLOBAL SOLO_LANDING Kajabi rollout: a guarded, CAS-protected,
+ * audited, reversible update of the SINGLE global SOLO_LANDING PageTemplate's
+ * customHtml to the new Kajabi artifact.
+ *
+ * WHY a dedicated script (NOT the admin PATCH route):
+ *   The admin PATCH route has no expected-`updatedAt`/hash check (claudex
+ *   R2-High3/R3-Med1). For a prod write of the canonical global template we want
+ *   read-then-CAS, an on-disk backup, save-time sanitize assertion, and a
+ *   durable AuditLog row.
+ *
+ * ── What it does ─────────────────────────────────────────────────────────────
+ *   1. Locate the global SOLO_LANDING PageTemplate
+ *      (templateType=SOLO_LANDING, categoryId=null, isActive=true).
+ *      >1 match → FAIL loudly. 0 match → FAIL.
+ *   2. Read the new artifact (default docs/specs/master-class-landing-kajabi.html,
+ *      override with --new-template <path>), run it through sanitizeCustomHtml
+ *      (save-time, allowTokenUris defaulted true) and ASSERT didStripContent===false
+ *      (a strip means the artifact is unsafe — abort).
+ *   3. Back up { id, updatedAt, oldSha, oldCustomHtml } to src/.snapshots/.
+ *   4. CAS: refuse to write unless the live row still matches the expected
+ *      updatedAt/SHA. Operator may pass --expected-sha <hex> / --expected-updated-at
+ *      <ISO>; otherwise the read-then-CAS-on-updatedAt (updateMany where id+updatedAt)
+ *      is the guard.
+ *   5. Write the sanitized artifact; capture newSha; write an AuditLog
+ *      (action SOLO_LANDING_TEMPLATE_UPDATE; operator, old/new SHA, backup path).
+ *
+ * ── Modes ─────────────────────────────────────────────────────────────────────
+ *   (default)   dry-run — locate template, show old/new SHA + sanitizer audit, no write.
+ *   --apply     write (requires --i-know-this-is-prod on a prod host).
+ *   --restore <templateBackup.json>  CAS-restore the pre-update value.
+ *
+ * ── Usage ──────────────────────────────────────────────────────────────────────
+ *   cd src
+ *   npx tsx scripts/update-solo-landing-template.ts                        # dry-run
+ *   npx tsx scripts/update-solo-landing-template.ts --apply --i-know-this-is-prod
+ *   npx tsx scripts/update-solo-landing-template.ts --restore .snapshots/<file>.json --i-know-this-is-prod
+ *
+ * Backups: src/.snapshots/solo-landing-template-update-<ISO>.json
+ */
+
+import { config as loadEnv } from "dotenv";
+import { join } from "node:path";
+
+const SRC_DIR = join(__dirname, "..");
+const REPO_ROOT = join(SRC_DIR, "..");
+loadEnv({ path: join(SRC_DIR, ".env.production.local") });
+loadEnv({ path: join(SRC_DIR, ".env.local") });
+loadEnv({ path: join(SRC_DIR, ".env") });
+
+import { PrismaClient } from "@prisma/client";
+import { mkdir, writeFile, readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+
+import { checkGuard, parseHost } from "../src/lib/scripts/safe-seed-guard";
+import { sanitizeCustomHtml } from "../src/lib/templates/sanitize-custom-html";
+import {
+  NEW_DESIGN_MARKER,
+  type TemplateBackupFile,
+} from "../src/lib/scripts/solo-landing-kajabi-core";
+import {
+  buildTemplateUpdatePlan,
+  applyTemplateUpdate,
+  restoreTemplateFromBackup,
+  type DbClient,
+} from "../src/lib/scripts/solo-landing-kajabi-runner";
+
+const db = new PrismaClient();
+const SNAPSHOT_DIR = join(SRC_DIR, ".snapshots");
+const DEFAULT_ARTIFACT = join(REPO_ROOT, "docs/specs/master-class-landing-kajabi.html");
+
+function flagValue(flag: string): string | undefined {
+  const idx = process.argv.indexOf(flag);
+  return idx >= 0 ? process.argv[idx + 1] : undefined;
+}
+
+async function loadSanitizedArtifact(path: string): Promise<string> {
+  const raw = await readFile(path, "utf8");
+  const { sanitized, didStripContent, strippedTags, strippedAttrs } = sanitizeCustomHtml(raw);
+  if (didStripContent) {
+    throw new Error(
+      `Artifact sanitize STRIPPED content — refusing to ship.\n` +
+        `  strippedTags=[${strippedTags.join(", ")}] strippedAttrs=[${strippedAttrs.join(", ")}]`,
+    );
+  }
+  if (!sanitized.includes(NEW_DESIGN_MARKER)) {
+    throw new Error(`Sanitized artifact does not contain the design marker "${NEW_DESIGN_MARKER}".`);
+  }
+  return sanitized;
+}
+
+async function writeTemplateBackup(
+  host: string,
+  runId: string,
+  plan: { templateId: string; oldUpdatedAt: Date; oldSha: string; newSha: string; oldCustomHtml: string },
+): Promise<string> {
+  if (!existsSync(SNAPSHOT_DIR)) await mkdir(SNAPSHOT_DIR, { recursive: true });
+  const iso = new Date().toISOString().replace(/[:.]/g, "-");
+  const file = join(SNAPSHOT_DIR, `solo-landing-template-update-${iso}.json`);
+  const backup: TemplateBackupFile = {
+    kind: "solo-landing-template-update",
+    runId,
+    createdAt: new Date().toISOString(),
+    databaseHost: host,
+    templateId: plan.templateId,
+    oldUpdatedAt: plan.oldUpdatedAt.toISOString(),
+    oldSha: plan.oldSha,
+    newSha: plan.newSha,
+    oldCustomHtml: plan.oldCustomHtml,
+  };
+  await writeFile(file, JSON.stringify(backup, null, 2), "utf8");
+  return file;
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  const hasOverride = argv.includes("--i-know-this-is-prod");
+  const mode = argv.includes("--restore")
+    ? "restore"
+    : argv.includes("--apply")
+      ? "apply"
+      : "dry-run";
+
+  const url = process.env.DATABASE_URL ?? "";
+  const host = parseHost(url);
+  const expectedHost = process.env.ASSESSMENT_PROD_EXPECTED_HOST;
+  const operator = process.env.OPERATOR_EMAIL || process.env.ADMIN_EMAIL || "SYSTEM";
+  const runId = randomUUID();
+
+  console.log(`update-solo-landing-template — mode=${mode} host=${host || "(none)"} runId=${runId}`);
+
+  if (mode === "apply" || mode === "restore") {
+    const decision = checkGuard({ url, expectedHost, hasOverride });
+    if (!decision.allowed) {
+      console.error(`\n❌ BLOCKED — prod guard refused (${mode}).\n  ${decision.reason}\n`);
+      process.exitCode = 1;
+      return;
+    }
+  }
+
+  if (mode === "restore") {
+    const file = flagValue("--restore");
+    if (!file) {
+      console.error("Usage: --restore <templateBackup.json> --i-know-this-is-prod");
+      process.exitCode = 1;
+      return;
+    }
+    const backup = JSON.parse(await readFile(file, "utf8")) as TemplateBackupFile;
+    const result = await restoreTemplateFromBackup(db as unknown as DbClient, backup, {
+      operator,
+      runId,
+    });
+    console.log(`\nRestore: ${result.status}${result.reason ? ` — ${result.reason}` : ""}`);
+    return;
+  }
+
+  const artifactPath = flagValue("--new-template") ?? DEFAULT_ARTIFACT;
+  const newSanitized = await loadSanitizedArtifact(artifactPath);
+  console.log(`Artifact: ${artifactPath} (sanitized, didStripContent=false)`);
+
+  const plan = await buildTemplateUpdatePlan(db as unknown as DbClient, { newSanitized });
+  console.log(`\nGlobal SOLO_LANDING template: ${plan.templateId}`);
+  console.log(`  oldSha=${plan.oldSha.slice(0, 16)}…  newSha=${plan.newSha.slice(0, 16)}…`);
+  console.log(`  oldUpdatedAt=${plan.oldUpdatedAt.toISOString()}`);
+  console.log(`  ${plan.isNoOp ? "NO-OP (already on the new artifact)" : "CHANGE"}`);
+
+  if (mode === "dry-run") {
+    console.log(`\nDRY RUN — no writes. Re-run with --apply --i-know-this-is-prod.`);
+    console.log(`When you apply, record NEW_GLOBAL_SHA = ${plan.newSha} for the backfill.`);
+    return;
+  }
+
+  const expectedSha = flagValue("--expected-sha");
+  const expectedUpdatedAtRaw = flagValue("--expected-updated-at");
+  const result = await applyTemplateUpdate(db as unknown as DbClient, plan, {
+    writeBackup: (p) => writeTemplateBackup(host, runId, p),
+    operator,
+    runId,
+    expectedOldSha: expectedSha,
+    expectedUpdatedAt: expectedUpdatedAtRaw ? new Date(expectedUpdatedAtRaw) : undefined,
+  });
+
+  console.log(`\nApply: ${result.status}${result.reason ? ` — ${result.reason}` : ""}`);
+  if (result.backupFile) console.log(`Backup: ${result.backupFile}`);
+  if (result.status === "applied") {
+    console.log(`\n✅ NEW_GLOBAL_SHA = ${plan.newSha}`);
+    console.log(`Pass this to the backfill: --new-template ${artifactPath}`);
+    console.log(`Restore with: --restore ${result.backupFile} --i-know-this-is-prod`);
+  } else if (result.status === "cas-abort") {
+    process.exitCode = 1;
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await db.$disconnect();
+  });

--- a/src/src/__tests__/app/workshop-slug-custom-html.test.tsx
+++ b/src/src/__tests__/app/workshop-slug-custom-html.test.tsx
@@ -3,7 +3,19 @@
  * the stored DOMPurify-sanitized HTML renders via React's HTML-injection
  * prop and the React template switch is bypassed. Empty / null /
  * whitespace customHtml falls through to the existing switch.
+ *
+ * Task 5 adds a smoke test that uses the real interpolated Kajabi master-class
+ * artifact as the customHtml payload so a regression in the render path for
+ * a realistic payload is caught early.
  */
+import * as fs from "fs";
+import * as path from "path";
+import { interpolateContentForHtml } from "@/lib/templates/interpolate-content-html";
+import { sanitizeCustomHtml } from "@/lib/templates/sanitize-custom-html";
+
+// Repo root is five levels up from src/src/__tests__/app/
+const REPO_ROOT = path.join(__dirname, "..", "..", "..", "..");
+const ARTIFACT_PATH = path.join(REPO_ROOT, "docs", "specs", "master-class-landing-kajabi.html");
 
 jest.mock("@/lib/db", () => ({
   db: {
@@ -232,5 +244,88 @@ describe("workshop slug pre-approval guard", () => {
     expect(markup).toContain("Registration isn&#x27;t open yet");
     // The default template + registration form must NOT render.
     expect(markup).not.toContain("Pending Workshop");
+  });
+});
+
+// ── Task 5 — Render-path smoke: real interpolated artifact ────────────────────
+describe("workshop slug customHtml render path — master-class artifact smoke", () => {
+  it("renders data-custom-html-render wrapper with workshop title and Register anchor when artifact is the customHtml payload", async () => {
+    // Build a realistic, fully-interpolated, sanitized artifact — mirroring
+    // what runAutoBuild stores in LandingPage.customHtml at build time.
+    const raw = fs.readFileSync(ARTIFACT_PATH, "utf8");
+    const interpolated = interpolateContentForHtml(raw, {
+      workshop_title: "Scaling Up Masterclass",
+      workshop_description: "A full-day intensive for growth-focused leaders.",
+      event_date: "Thursday, June 19, 2026",
+      event_date_no_weekday: "June 19, 2026",
+      event_time: "9:00 AM EDT",
+      coach_name: "Alex Johnson",
+      coach_title: "Scaling Up Certified Coach",
+      coach_photo: "https://cdn.example.com/photos/alex.jpg",
+      price: "$349",
+      registration_url: "https://app.example.com/workshop/scaling-up-masterclass",
+    });
+    const { sanitized: storedHtml } = sanitizeCustomHtml(interpolated, { allowTokenUris: false });
+
+    (db.landingPage.findUnique as jest.Mock).mockResolvedValueOnce(
+      landingFixture({
+        template: "SOLO_LANDING",
+        customHtml: storedHtml,
+        workshop: {
+          ...landingFixture().workshop,
+          status: "PRE_EVENT",
+        },
+      })
+    );
+
+    const node = await LandingPageView(await Promise.resolve(makeProps("scaling-up-masterclass")));
+    const markup = renderToStaticMarkup(node as React.ReactElement);
+
+    // Must render the customHtml wrapper — NOT the React SOLO_LANDING template.
+    expect(markup).toContain("data-custom-html-render");
+    expect(markup).not.toContain("solo:React title");
+
+    // Workshop title text must be present (interpolated into multiple locations).
+    expect(markup).toContain("Scaling Up Masterclass");
+
+    // The Register Here anchor must be present with the registration URL.
+    expect(markup).toContain(">Register Here</a>");
+    expect(markup).toContain("https://app.example.com/workshop/scaling-up-masterclass");
+  });
+
+  it("does NOT render the React SOLO_LANDING template when artifact customHtml is present", async () => {
+    const raw = fs.readFileSync(ARTIFACT_PATH, "utf8");
+    const interpolated = interpolateContentForHtml(raw, {
+      workshop_title: "Exit Planning Workshop",
+      workshop_description: "",
+      event_date: "Friday, July 4, 2026",
+      event_date_no_weekday: "July 4, 2026",
+      event_time: "10:00 AM CDT",
+      coach_name: "Sam Rivera",
+      coach_title: "Scaling Up Certified Coach",
+      coach_photo: "https://cdn.example.com/photos/sam.jpg",
+      price: "$299",
+      registration_url: "https://app.example.com/workshop/exit-planning",
+    });
+    const { sanitized: storedHtml } = sanitizeCustomHtml(interpolated, { allowTokenUris: false });
+
+    (db.landingPage.findUnique as jest.Mock).mockResolvedValueOnce(
+      landingFixture({
+        template: "SOLO_LANDING",
+        customHtml: storedHtml,
+        content: JSON.stringify({ heroTitle: "React fallback title" }),
+        workshop: {
+          ...landingFixture().workshop,
+          status: "PRE_EVENT",
+        },
+      })
+    );
+
+    const node = await LandingPageView(await Promise.resolve(makeProps("exit-planning")));
+    const markup = renderToStaticMarkup(node as React.ReactElement);
+
+    expect(markup).toContain("data-custom-html-render");
+    // The React SoloLandingPageTemplate mock renders "solo:<heroTitle>".
+    expect(markup).not.toContain("solo:React fallback title");
   });
 });

--- a/src/src/__tests__/lib/templates/interpolate-content-html.test.ts
+++ b/src/src/__tests__/lib/templates/interpolate-content-html.test.ts
@@ -1,7 +1,15 @@
+import * as fs from "fs";
+import * as path from "path";
 import {
   escapeHtml,
   interpolateContentForHtml,
 } from "@/lib/templates/interpolate-content-html";
+import { sanitizeCustomHtml } from "@/lib/templates/sanitize-custom-html";
+
+// ── path to the artifact (repo-root relative to this test file) ───────────────
+// src/src/__tests__/lib/templates/ → up 5 → repo-root (where docs/ lives)
+const REPO_ROOT = path.join(__dirname, "..", "..", "..", "..", "..");
+const ARTIFACT_PATH = path.join(REPO_ROOT, "docs", "specs", "master-class-landing-kajabi.html");
 
 describe("escapeHtml", () => {
   it("1. encodes ampersand", () => {
@@ -83,5 +91,229 @@ describe("interpolateContentForHtml", () => {
     expect(interpolateContentForHtml("{{q}}", { q: "A & B" })).toBe(
       "A &amp; B"
     );
+  });
+});
+
+// ── Task 3 — Interpolation + strict re-sanitize (positive path) ───────────────
+describe("master-class artifact: interpolation + strict re-sanitize", () => {
+  const VARS = {
+    workshop_title: "Exit & Valuation Master Class",
+    workshop_description: "A one-day session for founders ready to build enterprise value.",
+    event_date: "Thursday, June 18, 2026",
+    event_date_no_weekday: "June 18, 2026",
+    event_time: "9:00 AM EDT",
+    coach_name: "Jane Smith",
+    coach_title: "Scaling Up Certified Coach",
+    coach_photo: "https://cdn.example.com/photos/jane-smith.jpg",
+    price: "$349",
+    registration_url: "https://app.example.com/workshop/foo-bar",
+  };
+
+  let artifact: string;
+  let out: string;
+  let strictOut: string;
+
+  beforeAll(() => {
+    artifact = fs.readFileSync(ARTIFACT_PATH, "utf8");
+    out = interpolateContentForHtml(artifact, VARS);
+    strictOut = sanitizeCustomHtml(out, { allowTokenUris: false }).sanitized;
+  });
+
+  it("no {{workshop_title}} tokens remain after interpolation", () => {
+    expect(out).not.toContain("{{workshop_title}}");
+  });
+
+  it("no {{workshop_description}} tokens remain after interpolation", () => {
+    expect(out).not.toContain("{{workshop_description}}");
+  });
+
+  it("no {{event_date}} tokens remain after interpolation", () => {
+    expect(out).not.toContain("{{event_date}}");
+  });
+
+  it("no {{coach_name}} tokens remain after interpolation", () => {
+    expect(out).not.toContain("{{coach_name}}");
+  });
+
+  it("no {{coach_photo}} tokens remain after interpolation", () => {
+    expect(out).not.toContain("{{coach_photo}}");
+  });
+
+  it("no {{registration_url}} tokens remain after interpolation", () => {
+    expect(out).not.toContain("{{registration_url}}");
+  });
+
+  it("ampersand in workshop_title is HTML-escaped exactly once (not double-escaped)", () => {
+    // "Exit & Valuation" → "Exit &amp; Valuation"; must NOT be "&amp;amp;"
+    expect(out).toContain("Exit &amp; Valuation");
+    expect(out).not.toContain("&amp;amp;");
+  });
+
+  it("registration_url href survives interpolation literally", () => {
+    expect(out).toContain('href="https://app.example.com/workshop/foo-bar"');
+  });
+
+  it("coach_photo src survives interpolation literally", () => {
+    expect(out).toContain('src="https://cdn.example.com/photos/jane-smith.jpg"');
+  });
+
+  it("strict re-sanitize: https href survives", () => {
+    expect(strictOut).toContain('href="https://app.example.com/workshop/foo-bar"');
+  });
+
+  it("strict re-sanitize: https img src survives", () => {
+    expect(strictOut).toContain('src="https://cdn.example.com/photos/jane-smith.jpg"');
+  });
+});
+
+// ── Task 3 — Interpolation + strict re-sanitize (negative/XSS path) ──────────
+describe("master-class artifact: javascript: injection stripped by strict re-sanitize", () => {
+  let artifact: string;
+
+  beforeAll(() => {
+    artifact = fs.readFileSync(ARTIFACT_PATH, "utf8");
+  });
+
+  it("javascript: registration_url does not survive strict re-sanitize", () => {
+    const out = interpolateContentForHtml(artifact, {
+      registration_url: "javascript:alert(1)",
+      // provide safe fallbacks for all other tokens so the only javascript:
+      // risk is the one being tested
+      workshop_title: "Test",
+      workshop_description: "",
+      event_date: "June 18, 2026",
+      event_date_no_weekday: "June 18, 2026",
+      event_time: "9:00 AM EDT",
+      coach_name: "Test Coach",
+      coach_title: "Coach",
+      coach_photo: "https://cdn.example.com/safe.jpg",
+      price: "$349",
+    });
+    const { sanitized } = sanitizeCustomHtml(out, { allowTokenUris: false });
+    expect(sanitized).not.toContain("javascript:");
+  });
+
+  it("javascript: coach_photo does not survive strict re-sanitize", () => {
+    const out = interpolateContentForHtml(artifact, {
+      coach_photo: "javascript:alert(2)",
+      workshop_title: "Test",
+      workshop_description: "",
+      event_date: "June 18, 2026",
+      event_date_no_weekday: "June 18, 2026",
+      event_time: "9:00 AM EDT",
+      coach_name: "Test Coach",
+      coach_title: "Coach",
+      registration_url: "https://app.example.com/workshop/safe",
+      price: "$349",
+    });
+    const { sanitized } = sanitizeCustomHtml(out, { allowTokenUris: false });
+    expect(sanitized).not.toContain("javascript:");
+  });
+});
+
+// ── Task 4 — Empty-data degrade ────────────────────────────────────────────────
+describe("master-class artifact: empty-data graceful degrade", () => {
+  let artifact: string;
+
+  beforeAll(() => {
+    artifact = fs.readFileSync(ARTIFACT_PATH, "utf8");
+  });
+
+  it("does not throw when coach_photo, workshop_description, and registration_url are empty", () => {
+    expect(() =>
+      interpolateContentForHtml(artifact, {
+        coach_photo: "",
+        workshop_description: "",
+        registration_url: "",
+        workshop_title: "Empty Data Test",
+        event_date: "June 18, 2026",
+        event_date_no_weekday: "June 18, 2026",
+        event_time: "9:00 AM EDT",
+        coach_name: "Test Coach",
+        coach_title: "Coach",
+        price: "$349",
+      })
+    ).not.toThrow();
+  });
+
+  it("output still contains hero-card markup after empty interpolation", () => {
+    const out = interpolateContentForHtml(artifact, {
+      coach_photo: "",
+      workshop_description: "",
+      registration_url: "",
+      workshop_title: "Empty Data Test",
+      event_date: "June 18, 2026",
+      event_date_no_weekday: "June 18, 2026",
+      event_time: "9:00 AM EDT",
+      coach_name: "Test Coach",
+      coach_title: "Coach",
+      price: "$349",
+    });
+    expect(out).toContain('class="hero-card"');
+  });
+
+  it("output still contains the generic About lead sentence after empty interpolation", () => {
+    const out = interpolateContentForHtml(artifact, {
+      coach_photo: "",
+      workshop_description: "",
+      registration_url: "",
+      workshop_title: "Empty Data Test",
+      event_date: "June 18, 2026",
+      event_date_no_weekday: "June 18, 2026",
+      event_time: "9:00 AM EDT",
+      coach_name: "Test Coach",
+      coach_title: "Coach",
+      price: "$349",
+    });
+    // The About section opens with a generic sentence (does not depend on any token)
+    expect(out).toContain("a Scaling Up Certified Coach");
+  });
+
+  it("{{coach_photo}} token is gone even when value is empty string", () => {
+    const out = interpolateContentForHtml(artifact, {
+      coach_photo: "",
+      workshop_description: "",
+      registration_url: "",
+      workshop_title: "Empty Data Test",
+      event_date: "June 18, 2026",
+      event_date_no_weekday: "June 18, 2026",
+      event_time: "9:00 AM EDT",
+      coach_name: "Test Coach",
+      coach_title: "Coach",
+      price: "$349",
+    });
+    expect(out).not.toContain("{{coach_photo}}");
+  });
+
+  it("{{workshop_description}} token is gone even when value is empty string", () => {
+    const out = interpolateContentForHtml(artifact, {
+      coach_photo: "",
+      workshop_description: "",
+      registration_url: "",
+      workshop_title: "Empty Data Test",
+      event_date: "June 18, 2026",
+      event_date_no_weekday: "June 18, 2026",
+      event_time: "9:00 AM EDT",
+      coach_name: "Test Coach",
+      coach_title: "Coach",
+      price: "$349",
+    });
+    expect(out).not.toContain("{{workshop_description}}");
+  });
+
+  it("{{registration_url}} token is gone even when value is empty string", () => {
+    const out = interpolateContentForHtml(artifact, {
+      coach_photo: "",
+      workshop_description: "",
+      registration_url: "",
+      workshop_title: "Empty Data Test",
+      event_date: "June 18, 2026",
+      event_date_no_weekday: "June 18, 2026",
+      event_time: "9:00 AM EDT",
+      coach_name: "Test Coach",
+      coach_title: "Coach",
+      price: "$349",
+    });
+    expect(out).not.toContain("{{registration_url}}");
   });
 });

--- a/src/src/__tests__/lib/templates/master-class-artifact.test.ts
+++ b/src/src/__tests__/lib/templates/master-class-artifact.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Guard / characterization tests for the Kajabi master-class landing HTML artifact.
+ *
+ * All tests load the artifact from disk — never inline the markup — so a change
+ * to the file is immediately visible in CI.
+ *
+ * Repo-root is three levels up from this test file:
+ *   src/src/__tests__/lib/templates/ → src/src/__tests__/lib/ → src/src/__tests__/
+ *   → src/src/ → src/ → repo-root (docs/)
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+// ── path helpers ───────────────────────────────────────────────────────────────
+const REPO_ROOT = path.join(__dirname, "..", "..", "..", "..", "..");
+const ARTIFACT_PATH = path.join(REPO_ROOT, "docs", "specs", "master-class-landing-kajabi.html");
+const SPEC_PATH = path.join(REPO_ROOT, "docs", "specs", "master-class-landing-kajabi.md");
+
+function loadArtifact(): string {
+  return fs.readFileSync(ARTIFACT_PATH, "utf8");
+}
+
+function loadSpec(): string {
+  return fs.readFileSync(SPEC_PATH, "utf8");
+}
+
+// ── Task 1 — Artifact ↔ spec sync ─────────────────────────────────────────────
+describe("master-class artifact ↔ spec sync (CI guard)", () => {
+  it("artifact file content equals the ```html fenced block in the spec", () => {
+    const spec = loadSpec();
+    const artifact = loadArtifact();
+
+    // Extract the first ```html…``` block from the spec markdown.
+    const match = spec.match(/```html\n([\s\S]*?)\n```/);
+    expect(match).not.toBeNull();
+    const extractedFromSpec = match![1];
+
+    // The artifact file ends with a single trailing newline; trim it once.
+    const artifactTrimmed = artifact.replace(/\n$/, "");
+
+    expect(artifactTrimmed).toBe(extractedFromSpec);
+  });
+});
+
+// ── Task 6 — Render-rules presence (cheap CI proxy) ───────────────────────────
+describe("master-class artifact render-rules presence", () => {
+  let artifact: string;
+
+  beforeAll(() => {
+    artifact = loadArtifact();
+  });
+
+  it("contains @import url with Fira+Sans from Google Fonts", () => {
+    expect(artifact).toMatch(
+      /@import url\('https:\/\/fonts\.googleapis\.com\/.*Fira\+Sans/
+    );
+  });
+
+  it("contains @media(max-width:760px) responsive breakpoint", () => {
+    expect(artifact).toContain("@media(max-width:760px)");
+  });
+
+  it("contains responsive .hero-card grid-template-columns:1fr inside the media block", () => {
+    // The media block must reset the two-col hero to single-col.
+    expect(artifact).toMatch(
+      /@media\(max-width:760px\)\s*\{[\s\S]*?\.su-mc \.hero-card\s*\{[^}]*grid-template-columns\s*:\s*1fr\b/
+    );
+  });
+
+  it("contains .ico-cal CSS rule", () => {
+    expect(artifact).toContain(".su-mc .ico-cal");
+  });
+
+  it("contains .ico-clock CSS rule", () => {
+    expect(artifact).toContain(".su-mc .ico-clock");
+  });
+
+  it("contains .ico-pin CSS rule", () => {
+    expect(artifact).toContain(".su-mc .ico-pin");
+  });
+
+  // Defence: the artifact must never contain inline SVG (stripped by sanitizer),
+  // <link> (stripped by sanitizer), or <iframe> (would need allowlisted host).
+  it("artifact itself contains no <svg tags", () => {
+    expect(artifact).not.toMatch(/<svg\b/i);
+  });
+
+  it("artifact itself contains no <link tags", () => {
+    expect(artifact).not.toMatch(/<link\b/i);
+  });
+
+  it("artifact itself contains no <iframe tags", () => {
+    expect(artifact).not.toMatch(/<iframe\b/i);
+  });
+
+  it("artifact itself contains no <path tags", () => {
+    expect(artifact).not.toMatch(/<path\b/i);
+  });
+
+  it("artifact itself contains no <rect tags", () => {
+    expect(artifact).not.toMatch(/<rect\b/i);
+  });
+});

--- a/src/src/__tests__/lib/templates/sanitize-custom-html.test.ts
+++ b/src/src/__tests__/lib/templates/sanitize-custom-html.test.ts
@@ -1,10 +1,17 @@
 /**
  * @jest-environment jsdom
  */
+import * as fs from "fs";
+import * as path from "path";
 import {
   sanitizeCustomHtml,
   FRAME_SRC_ALLOWLIST,
 } from "@/lib/templates/sanitize-custom-html";
+
+// ── path to the artifact (repo-root relative to this test file) ───────────────
+// src/src/__tests__/lib/templates/ → up 5 → repo-root (where docs/ lives)
+const REPO_ROOT = path.join(__dirname, "..", "..", "..", "..", "..");
+const ARTIFACT_PATH = path.join(REPO_ROOT, "docs", "specs", "master-class-landing-kajabi.html");
 
 describe("sanitizeCustomHtml", () => {
   it("1. passes through plain <p>Hello</p> unchanged", () => {
@@ -230,5 +237,77 @@ describe("sanitizeCustomHtml", () => {
     expect(
       FRAME_SRC_ALLOWLIST.some((r) => r.test("https://www.youtube.com/embed/x"))
     ).toBe(true);
+  });
+});
+
+// ── Task 2 — Artifact survives sanitization ────────────────────────────────────
+describe("master-class artifact survives sanitizeCustomHtml (default mode)", () => {
+  let artifact: string;
+  let result: ReturnType<typeof sanitizeCustomHtml>;
+
+  beforeAll(() => {
+    artifact = fs.readFileSync(ARTIFACT_PATH, "utf8");
+    result = sanitizeCustomHtml(artifact);
+  });
+
+  it("didStripContent is false", () => {
+    expect(result.didStripContent).toBe(false);
+  });
+
+  it("sanitized output contains @import", () => {
+    expect(result.sanitized).toContain("@import");
+  });
+
+  it("sanitized output contains data-su-mc", () => {
+    expect(result.sanitized).toContain("data-su-mc");
+  });
+
+  it("sanitized output contains href=\"{{registration_url}}\"", () => {
+    expect(result.sanitized).toContain('href="{{registration_url}}"');
+  });
+
+  it("sanitized output contains src=\"{{coach_photo}}\"", () => {
+    expect(result.sanitized).toContain('src="{{coach_photo}}"');
+  });
+
+  it("sanitized output contains {{workshop_description}}", () => {
+    expect(result.sanitized).toContain("{{workshop_description}}");
+  });
+
+  it("sanitized output contains .ico-cal", () => {
+    expect(result.sanitized).toContain(".ico-cal");
+  });
+
+  it("sanitized output does NOT contain <svg", () => {
+    expect(result.sanitized).not.toMatch(/<svg\b/i);
+  });
+
+  it("sanitized output does NOT contain <path", () => {
+    expect(result.sanitized).not.toMatch(/<path\b/i);
+  });
+
+  it("sanitized output does NOT contain <rect", () => {
+    expect(result.sanitized).not.toMatch(/<rect\b/i);
+  });
+
+  it("sanitized output does NOT contain <link", () => {
+    expect(result.sanitized).not.toMatch(/<link\b/i);
+  });
+
+  it("sanitized output does NOT contain <iframe", () => {
+    expect(result.sanitized).not.toMatch(/<iframe\b/i);
+  });
+
+  // Defence: verify the raw artifact itself is also free of stripped elements.
+  it("raw artifact contains no <svg tags", () => {
+    expect(artifact).not.toMatch(/<svg\b/i);
+  });
+
+  it("raw artifact contains no <link tags", () => {
+    expect(artifact).not.toMatch(/<link\b/i);
+  });
+
+  it("raw artifact contains no <iframe tags", () => {
+    expect(artifact).not.toMatch(/<iframe\b/i);
   });
 });

--- a/src/src/__tests__/scripts/solo-landing-kajabi-core.test.ts
+++ b/src/src/__tests__/scripts/solo-landing-kajabi-core.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Tests for the GLOBAL SOLO_LANDING Kajabi rollout — PURE core logic.
+ *
+ * These lock the claudex-hardened invariants the rollout depends on:
+ *   - TARGETING: a row whose current customHtml == the per-workshop OLD render is
+ *     a TARGET; one that matches the NEW render is a NO-OP; anything else is a
+ *     SKIP (bespoke — never clobber). And two DIFFERENT workshops produce
+ *     DIFFERENT old renders, so a shared raw-template hash can't be used.
+ *   - CTA preflight: absolute-https-prod-host + published-registration required.
+ *   - Price preflight: TBD/Free/empty FAILS unless an explicit exception.
+ *   - New-value validation: rejects unresolved {{ and empty CTA.
+ *   - Expected-count gate + template CAS.
+ *
+ * No DB. The actual interpolate/sanitize is represented by simple string
+ * substitution fixtures (the runner injects the real pipeline; the core only
+ * cares about SHA equality of whatever strings it is handed).
+ */
+
+import {
+  sha256,
+  decideRow,
+  validateNewValue,
+  extractCtaHref,
+  checkCtaPreflight,
+  checkPricePreflight,
+  hasCoachPhoto,
+  checkExpectedCount,
+  checkTemplateCas,
+  parseKajabiArgs,
+  NEW_DESIGN_MARKER,
+} from "../../lib/scripts/solo-landing-kajabi-core";
+
+const EXPECTED_HOST = "scaling-up-platform-v2.vercel.app";
+
+// A tiny stand-in "render" function: substitute {{coach_name}} / {{registration_url}}
+// so two workshops with different data produce different rendered strings — which
+// is exactly the property the targeting relies on.
+function fakeRender(template: string, vars: Record<string, string>): string {
+  let out = template;
+  for (const [k, v] of Object.entries(vars)) out = out.split(`{{${k}}}`).join(v);
+  return out;
+}
+
+const OLD_TEMPLATE = `<div class="old-design">Old · {{coach_name}} · {{registration_url}}</div>`;
+const NEW_TEMPLATE = `<div class="su-mc" ${NEW_DESIGN_MARKER}>New · {{coach_name}} · <a class="btn" href="{{registration_url}}">Register Here</a></div>`;
+
+describe("targeting: decideRow", () => {
+  const oldGlobalTemplateId = "tpl-old-global";
+
+  it("TARGET when current customHtml == per-workshop OLD render", () => {
+    const vars = { coach_name: "Ada Lovelace", registration_url: `https://${EXPECTED_HOST}/workshop/ada-reg` };
+    const oldRender = fakeRender(OLD_TEMPLATE, vars);
+    const newRender = fakeRender(NEW_TEMPLATE, vars);
+    const d = decideRow({
+      currentCustomHtml: oldRender,
+      expectedOldRender: oldRender,
+      newRender,
+      sourceTemplateId: oldGlobalTemplateId,
+      oldGlobalTemplateId,
+    });
+    expect(d.kind).toBe("target");
+  });
+
+  it("NO-OP when current customHtml == per-workshop NEW render (already migrated)", () => {
+    const vars = { coach_name: "Ada", registration_url: `https://${EXPECTED_HOST}/workshop/ada-reg` };
+    const oldRender = fakeRender(OLD_TEMPLATE, vars);
+    const newRender = fakeRender(NEW_TEMPLATE, vars);
+    const d = decideRow({
+      currentCustomHtml: newRender,
+      expectedOldRender: oldRender,
+      newRender,
+      sourceTemplateId: null,
+      oldGlobalTemplateId,
+    });
+    expect(d.kind).toBe("no-op");
+  });
+
+  it("SKIP (bespoke) when current matches neither old nor new render", () => {
+    const vars = { coach_name: "Ada", registration_url: `https://${EXPECTED_HOST}/workshop/ada-reg` };
+    const d = decideRow({
+      currentCustomHtml: `<div class="HAND-EDITED bespoke">totally different</div>`,
+      expectedOldRender: fakeRender(OLD_TEMPLATE, vars),
+      newRender: fakeRender(NEW_TEMPLATE, vars),
+      sourceTemplateId: null,
+      oldGlobalTemplateId,
+    });
+    expect(d.kind).toBe("skip");
+    if (d.kind === "skip") expect(d.reason).toBe("bespoke-or-category-scoped");
+  });
+
+  it("SKIP when sourceTemplateId points at a DIFFERENT template (category-scoped)", () => {
+    const vars = { coach_name: "Ada", registration_url: `https://${EXPECTED_HOST}/workshop/ada-reg` };
+    const oldRender = fakeRender(OLD_TEMPLATE, vars);
+    const d = decideRow({
+      // even if the CONTENT happens to match the old render, a foreign source wins.
+      currentCustomHtml: oldRender,
+      expectedOldRender: oldRender,
+      newRender: fakeRender(NEW_TEMPLATE, vars),
+      sourceTemplateId: "tpl-category-scoped",
+      oldGlobalTemplateId,
+    });
+    expect(d.kind).toBe("skip");
+    if (d.kind === "skip") expect(d.reason).toBe("source-template-mismatch");
+  });
+
+  it("SKIP empty current customHtml", () => {
+    const d = decideRow({
+      currentCustomHtml: "",
+      expectedOldRender: "x",
+      newRender: "y",
+      sourceTemplateId: null,
+      oldGlobalTemplateId,
+    });
+    expect(d.kind).toBe("skip");
+    if (d.kind === "skip") expect(d.reason).toBe("empty-current-customhtml");
+  });
+
+  it("two DIFFERENT workshops produce DIFFERENT old renders — a shared raw hash cannot be used", () => {
+    const adaOld = fakeRender(OLD_TEMPLATE, {
+      coach_name: "Ada Lovelace",
+      registration_url: `https://${EXPECTED_HOST}/workshop/ada-reg`,
+    });
+    const turingOld = fakeRender(OLD_TEMPLATE, {
+      coach_name: "Alan Turing",
+      registration_url: `https://${EXPECTED_HOST}/workshop/turing-reg`,
+    });
+    expect(sha256(adaOld)).not.toBe(sha256(turingOld));
+
+    // And each workshop's row is correctly targeted against ITS OWN old render,
+    // while a cross-applied old render would NOT match (proving per-workshop hashing).
+    const oldGlobalTemplateId = "tpl-old-global";
+    const adaNew = fakeRender(NEW_TEMPLATE, {
+      coach_name: "Ada Lovelace",
+      registration_url: `https://${EXPECTED_HOST}/workshop/ada-reg`,
+    });
+    const adaCorrect = decideRow({
+      currentCustomHtml: adaOld,
+      expectedOldRender: adaOld,
+      newRender: adaNew,
+      sourceTemplateId: null,
+      oldGlobalTemplateId,
+    });
+    expect(adaCorrect.kind).toBe("target");
+
+    const adaWrong = decideRow({
+      currentCustomHtml: adaOld,
+      expectedOldRender: turingOld, // wrong workshop's render
+      newRender: adaNew,
+      sourceTemplateId: null,
+      oldGlobalTemplateId,
+    });
+    expect(adaWrong.kind).toBe("skip");
+  });
+});
+
+describe("validateNewValue", () => {
+  it("accepts a valid render (marker + no unresolved + CTA href)", () => {
+    const html = fakeRender(NEW_TEMPLATE, {
+      coach_name: "Ada",
+      registration_url: `https://${EXPECTED_HOST}/workshop/ada-reg`,
+    });
+    const v = validateNewValue(html);
+    expect(v.ok).toBe(true);
+    expect(v.hasDesignMarker).toBe(true);
+    expect(v.noUnresolvedTokens).toBe(true);
+    expect(v.hasCtaHref).toBe(true);
+    expect(v.resolvedCtaHref).toBe(`https://${EXPECTED_HOST}/workshop/ada-reg`);
+  });
+
+  it("rejects a render with an unresolved {{token}}", () => {
+    const html = `<div ${NEW_DESIGN_MARKER}><a class="btn" href="https://x/workshop/a">go</a> {{price}}</div>`;
+    const v = validateNewValue(html);
+    expect(v.ok).toBe(false);
+    expect(v.noUnresolvedTokens).toBe(false);
+    expect(v.firstUnresolvedToken).toBe("{{price}}");
+  });
+
+  it("rejects a render with an empty CTA href", () => {
+    const html = `<div ${NEW_DESIGN_MARKER}><a class="btn" href="">go</a></div>`;
+    const v = validateNewValue(html);
+    expect(v.ok).toBe(false);
+    expect(v.hasCtaHref).toBe(false);
+  });
+
+  it("rejects a render missing the design marker", () => {
+    const html = `<div><a class="btn" href="https://x/workshop/a">go</a></div>`;
+    const v = validateNewValue(html);
+    expect(v.ok).toBe(false);
+    expect(v.hasDesignMarker).toBe(false);
+  });
+
+  it("extractCtaHref prefers the btn anchor (class before OR after href)", () => {
+    expect(extractCtaHref(`<a href="x" class="btn">a</a>`)).toBe("x");
+    expect(extractCtaHref(`<a class="btn primary" href="y">a</a>`)).toBe("y");
+    expect(extractCtaHref(`<a href="fallback">a</a>`)).toBe("fallback");
+  });
+});
+
+describe("CTA preflight (Task 8)", () => {
+  const base = {
+    expectedHost: EXPECTED_HOST,
+    hasPublishedRegistration: true,
+    expectedRegistrationSlug: "ada-reg",
+  };
+
+  it("passes absolute https on the prod host with a published matching registration", () => {
+    const r = checkCtaPreflight({ ...base, registrationUrl: `https://${EXPECTED_HOST}/workshop/ada-reg` });
+    expect(r.ok).toBe(true);
+  });
+
+  it("fails an empty registration URL", () => {
+    expect(checkCtaPreflight({ ...base, registrationUrl: "" }).ok).toBe(false);
+  });
+
+  it("fails a relative URL", () => {
+    expect(checkCtaPreflight({ ...base, registrationUrl: "/workshop/ada-reg" }).ok).toBe(false);
+  });
+
+  it("fails http (non-https)", () => {
+    expect(checkCtaPreflight({ ...base, registrationUrl: `http://${EXPECTED_HOST}/workshop/ada-reg` }).ok).toBe(false);
+  });
+
+  it("fails the wrong host (staging)", () => {
+    expect(
+      checkCtaPreflight({ ...base, registrationUrl: "https://staging.example.com/workshop/ada-reg" }).ok,
+    ).toBe(false);
+  });
+
+  it("fails when there is NO published REGISTRATION page", () => {
+    expect(
+      checkCtaPreflight({
+        ...base,
+        hasPublishedRegistration: false,
+        registrationUrl: `https://${EXPECTED_HOST}/workshop/ada-reg`,
+      }).ok,
+    ).toBe(false);
+  });
+
+  it("fails when the URL slug does not match the published registration slug", () => {
+    expect(
+      checkCtaPreflight({
+        ...base,
+        registrationUrl: `https://${EXPECTED_HOST}/workshop/SOME-OTHER-slug`,
+      }).ok,
+    ).toBe(false);
+  });
+});
+
+describe("price preflight (Task 9)", () => {
+  it("passes a confirmed dollar amount", () => {
+    expect(checkPricePreflight({ renderedPrice: "$497", hasExplicitException: false }).ok).toBe(true);
+  });
+
+  it("FAILS TBD (no exception)", () => {
+    expect(checkPricePreflight({ renderedPrice: "TBD", hasExplicitException: false }).ok).toBe(false);
+  });
+
+  it("FAILS Free (no exception)", () => {
+    expect(checkPricePreflight({ renderedPrice: "Free", hasExplicitException: false }).ok).toBe(false);
+  });
+
+  it("FAILS empty (no exception)", () => {
+    expect(checkPricePreflight({ renderedPrice: "", hasExplicitException: false }).ok).toBe(false);
+  });
+
+  it("passes TBD WHEN an explicit --allow-price exception is set", () => {
+    expect(checkPricePreflight({ renderedPrice: "TBD", hasExplicitException: true }).ok).toBe(true);
+  });
+});
+
+describe("coach-photo preflight", () => {
+  it("requires a non-empty profileImage", () => {
+    expect(hasCoachPhoto("https://cdn/x.jpg")).toBe(true);
+    expect(hasCoachPhoto("")).toBe(false);
+    expect(hasCoachPhoto("   ")).toBe(false);
+    expect(hasCoachPhoto(null)).toBe(false);
+    expect(hasCoachPhoto(undefined)).toBe(false);
+  });
+});
+
+describe("expected-count gate (Task 7)", () => {
+  it("FAILS apply when --expect-count is omitted", () => {
+    expect(checkExpectedCount(3, undefined).ok).toBe(false);
+  });
+  it("FAILS apply on a count mismatch", () => {
+    expect(checkExpectedCount(3, 2).ok).toBe(false);
+  });
+  it("passes on an exact match", () => {
+    expect(checkExpectedCount(3, 3).ok).toBe(true);
+  });
+});
+
+describe("template CAS", () => {
+  const updatedAt = new Date("2026-06-01T00:00:00Z");
+  it("passes when live matches the expected sha + updatedAt", () => {
+    expect(
+      checkTemplateCas({
+        liveUpdatedAt: updatedAt,
+        liveSha: "abc",
+        expectedUpdatedAt: updatedAt,
+        expectedOldSha: "abc",
+      }).ok,
+    ).toBe(true);
+  });
+  it("fails on a sha mismatch", () => {
+    expect(
+      checkTemplateCas({ liveUpdatedAt: updatedAt, liveSha: "abc", expectedOldSha: "def" }).ok,
+    ).toBe(false);
+  });
+  it("fails on an updatedAt mismatch", () => {
+    expect(
+      checkTemplateCas({
+        liveUpdatedAt: updatedAt,
+        liveSha: "abc",
+        expectedUpdatedAt: new Date("2026-06-02T00:00:00Z"),
+      }).ok,
+    ).toBe(false);
+  });
+  it("passes when no expectations are supplied (read-then-CAS-on-updatedAt only)", () => {
+    expect(checkTemplateCas({ liveUpdatedAt: updatedAt, liveSha: "abc" }).ok).toBe(true);
+  });
+});
+
+describe("parseKajabiArgs", () => {
+  it("defaults to dry-run and reads the kajabi flags", () => {
+    const a = parseKajabiArgs([
+      "--old-template-backup",
+      "/tmp/old.json",
+      "--new-template",
+      "/tmp/new.html",
+      "--slug",
+      "canary",
+      "--limit",
+      "5",
+      "--expect-count",
+      "3",
+      "--allow-price",
+      "ws1",
+      "--allow-price",
+      "ws2",
+    ]);
+    expect(a.mode).toBe("dry-run");
+    expect(a.oldTemplateBackup).toBe("/tmp/old.json");
+    expect(a.newTemplate).toBe("/tmp/new.html");
+    expect(a.slug).toBe("canary");
+    expect(a.limit).toBe(5);
+    expect(a.expectCount).toBe(3);
+    expect(a.allowPrice).toEqual(["ws1", "ws2"]);
+  });
+
+  it("recognises --apply + override", () => {
+    const a = parseKajabiArgs(["--apply", "--i-know-this-is-prod", "--expect-count", "0"]);
+    expect(a.mode).toBe("apply");
+    expect(a.hasOverride).toBe(true);
+    expect(a.expectCount).toBe(0);
+  });
+
+  it("recognises --restore with the next arg as the file", () => {
+    const a = parseKajabiArgs(["--restore", "/tmp/b.json"]);
+    expect(a.mode).toBe("restore");
+    expect(a.restoreFile).toBe("/tmp/b.json");
+  });
+});

--- a/src/src/__tests__/scripts/solo-landing-kajabi-runner.test.ts
+++ b/src/src/__tests__/scripts/solo-landing-kajabi-runner.test.ts
@@ -85,7 +85,6 @@ function makeAuditDb(extra: Partial<DbClient> = {}): { db: DbClient; auditCreate
       findMany: jest.fn().mockResolvedValue([]),
       findUnique: jest.fn().mockResolvedValue(null),
       updateMany: jest.fn().mockResolvedValue({ count: 1 }),
-      update: jest.fn().mockResolvedValue({}),
     },
     auditLog: { create: auditCreate },
     ...extra,
@@ -146,7 +145,7 @@ describe("Script 1 — applyTemplateUpdate", () => {
         findUnique: jest.fn(),
         updateMany,
       },
-      landingPage: { findMany: jest.fn(), findUnique: jest.fn(), updateMany: jest.fn(), update: jest.fn() },
+      landingPage: { findMany: jest.fn(), findUnique: jest.fn(), updateMany: jest.fn() },
       auditLog: { create: auditCreate },
     } as DbClient;
     return { db, updateMany, auditCreate };
@@ -238,7 +237,7 @@ describe("Script 1 — restoreTemplateFromBackup", () => {
         }),
         updateMany,
       },
-      landingPage: { findMany: jest.fn(), findUnique: jest.fn(), updateMany: jest.fn(), update: jest.fn() },
+      landingPage: { findMany: jest.fn(), findUnique: jest.fn(), updateMany: jest.fn() },
       auditLog: { create: auditCreate },
     } as DbClient;
     const r = await restoreTemplateFromBackup(db, backup, { operator: "o", runId: "r2" });
@@ -264,7 +263,7 @@ describe("Script 1 — restoreTemplateFromBackup", () => {
         }),
         updateMany,
       },
-      landingPage: { findMany: jest.fn(), findUnique: jest.fn(), updateMany: jest.fn(), update: jest.fn() },
+      landingPage: { findMany: jest.fn(), findUnique: jest.fn(), updateMany: jest.fn() },
       auditLog: { create: jest.fn() },
     } as DbClient;
     const r = await restoreTemplateFromBackup(db, backup, { operator: "o", runId: "r2" });
@@ -286,7 +285,6 @@ function backfillDb(pages: unknown[]): { db: DbClient; updateMany: jest.Mock; au
       findMany: jest.fn().mockResolvedValue(pages),
       findUnique: jest.fn().mockResolvedValue(null),
       updateMany,
-      update: jest.fn().mockResolvedValue({}),
     },
     auditLog: { create: auditCreate },
   } as DbClient;
@@ -557,8 +555,6 @@ describe("Script 2 — restoreBackfill", () => {
     });
     const r = await restoreBackfill(db, backup, { operator: "o", runId: "r3" });
     expect(r).toEqual({ restored: 1, skipped: 0 });
-    // Fix 2: must use CAS updateMany (not unconditional update)
-    expect(db.landingPage.update).not.toHaveBeenCalled();
     expect(db.landingPage.updateMany).toHaveBeenCalledWith({
       where: { id: "lp1", updatedAt: restoreUpdatedAt },
       data: { customHtml: render(OLD_TPL, WS.ws1) },
@@ -574,7 +570,6 @@ describe("Script 2 — restoreBackfill", () => {
     });
     const r = await restoreBackfill(db, backup, { operator: "o", runId: "r3" });
     expect(r).toEqual({ restored: 0, skipped: 1 });
-    expect(db.landingPage.update).not.toHaveBeenCalled();
     expect(db.landingPage.updateMany).not.toHaveBeenCalled();
   });
 
@@ -591,7 +586,6 @@ describe("Script 2 — restoreBackfill", () => {
     });
     const r = await restoreBackfill(db, corruptBackup, { operator: "o", runId: "r3" });
     expect(r).toEqual({ restored: 0, skipped: 1 });
-    expect(db.landingPage.update).not.toHaveBeenCalled();
     expect(db.landingPage.updateMany).not.toHaveBeenCalled();
   });
 
@@ -606,7 +600,6 @@ describe("Script 2 — restoreBackfill", () => {
     (db.landingPage.updateMany as jest.Mock).mockResolvedValue({ count: 0 });
     const r = await restoreBackfill(db, backup, { operator: "o", runId: "r3" });
     expect(r).toEqual({ restored: 0, skipped: 1 });
-    expect(db.landingPage.update).not.toHaveBeenCalled();
     // Audit log is still written (with skipped=1, restored=0)
     expect(auditCreate.mock.calls[0][0].data.action).toBe("SOLO_LANDING_BACKFILL_RESTORE");
   });

--- a/src/src/__tests__/scripts/solo-landing-kajabi-runner.test.ts
+++ b/src/src/__tests__/scripts/solo-landing-kajabi-runner.test.ts
@@ -1,0 +1,574 @@
+/**
+ * Tests for the GLOBAL SOLO_LANDING Kajabi rollout — RUNNER (DB-touching
+ * orchestration), driven with a MOCK Prisma client + injected reinterpolate /
+ * resolveFacts. No real DB.
+ *
+ * Covers:
+ *   Script 1: resolveGlobalSoloTemplate (>1 fails loud), buildTemplateUpdatePlan,
+ *             applyTemplateUpdate (CAS + backup-before-write + audit), restore.
+ *   Script 2: buildBackfillPlans (targets/no-ops/skips + every preflight),
+ *             applyBackfillPlans (CAS, sanitizer-strip block, audit), restore.
+ */
+
+import {
+  sha256,
+  NEW_DESIGN_MARKER,
+  type KajabiBackupFile,
+  type TemplateBackupFile,
+} from "../../lib/scripts/solo-landing-kajabi-core";
+import {
+  resolveGlobalSoloTemplate,
+  buildTemplateUpdatePlan,
+  applyTemplateUpdate,
+  restoreTemplateFromBackup,
+  buildBackfillPlans,
+  applyBackfillPlans,
+  restoreBackfill,
+  type DbClient,
+  type SanitizeOutcome,
+  type WorkshopFacts,
+} from "../../lib/scripts/solo-landing-kajabi-runner";
+
+const HOST = "scaling-up-platform-v2.vercel.app";
+const OLD_GLOBAL_ID = "tpl-old-global";
+
+const OLD_TPL = `<div class="old">{{coach_name}}|{{registration_url}}</div>`;
+const NEW_TPL = `<div class="su-mc" ${NEW_DESIGN_MARKER}>{{coach_name}}|<a class="btn" href="{{registration_url}}">Register Here</a></div>`;
+
+function render(template: string, vars: Record<string, string>): string {
+  let out = template;
+  for (const [k, v] of Object.entries(vars)) out = out.split(`{{${k}}}`).join(v);
+  return out;
+}
+const clean = (sanitized: string): SanitizeOutcome => ({ sanitized, strippedTags: [], strippedAttrs: [] });
+
+// Per-workshop variable fixtures.
+const WS = {
+  ws1: { coach_name: "Ada", registration_url: `https://${HOST}/workshop/ws1-reg` },
+  ws2: { coach_name: "Alan", registration_url: `https://${HOST}/workshop/ws2-reg` },
+};
+
+function injectedReinterpolate(): jest.Mock {
+  // Returns the rendered string for whatever template it is given, per workshop.
+  return jest.fn(async (workshopId: string, tpl: string) => {
+    const vars = (WS as Record<string, Record<string, string>>)[workshopId];
+    if (!vars) return null;
+    return clean(render(tpl, vars));
+  });
+}
+
+function injectedFacts(overrides: Partial<Record<string, Partial<WorkshopFacts>>> = {}): jest.Mock {
+  return jest.fn(async (workshopId: string): Promise<WorkshopFacts | null> => {
+    const slug = `${workshopId}-reg`;
+    const base: WorkshopFacts = {
+      coachProfileImage: "https://cdn/photo.jpg",
+      registrationUrl: `https://${HOST}/workshop/${slug}`,
+      registrationSlug: slug,
+      registrationPublished: true,
+      renderedPrice: "$497",
+    };
+    return { ...base, ...(overrides[workshopId] ?? {}) };
+  });
+}
+
+function makeAuditDb(extra: Partial<DbClient> = {}): { db: DbClient; auditCreate: jest.Mock } {
+  const auditCreate = jest.fn().mockResolvedValue({});
+  const db = {
+    pageTemplate: {
+      findMany: jest.fn().mockResolvedValue([]),
+      findUnique: jest.fn().mockResolvedValue(null),
+      updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+    },
+    landingPage: {
+      findMany: jest.fn().mockResolvedValue([]),
+      findUnique: jest.fn().mockResolvedValue(null),
+      updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      update: jest.fn().mockResolvedValue({}),
+    },
+    auditLog: { create: auditCreate },
+    ...extra,
+  } as DbClient;
+  return { db, auditCreate };
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+//  Script 1
+// ════════════════════════════════════════════════════════════════════════════
+
+describe("Script 1 — resolveGlobalSoloTemplate", () => {
+  it("returns the single active global template", async () => {
+    const { db } = makeAuditDb({
+      pageTemplate: {
+        findMany: jest.fn().mockResolvedValue([
+          { id: OLD_GLOBAL_ID, categoryId: null, isActive: true, customHtml: OLD_TPL, updatedAt: new Date() },
+        ]),
+        findUnique: jest.fn(),
+        updateMany: jest.fn(),
+      },
+    });
+    const tpl = await resolveGlobalSoloTemplate(db);
+    expect(tpl.id).toBe(OLD_GLOBAL_ID);
+  });
+
+  it("FAILS LOUDLY when more than one global active template exists", async () => {
+    const { db } = makeAuditDb({
+      pageTemplate: {
+        findMany: jest.fn().mockResolvedValue([
+          { id: "a", categoryId: null, isActive: true, customHtml: "x", updatedAt: new Date() },
+          { id: "b", categoryId: null, isActive: true, customHtml: "y", updatedAt: new Date() },
+        ]),
+        findUnique: jest.fn(),
+        updateMany: jest.fn(),
+      },
+    });
+    await expect(resolveGlobalSoloTemplate(db)).rejects.toThrow(/exactly ONE/);
+  });
+
+  it("FAILS when no active global template exists", async () => {
+    const { db } = makeAuditDb();
+    await expect(resolveGlobalSoloTemplate(db)).rejects.toThrow(/No active global/);
+  });
+});
+
+describe("Script 1 — applyTemplateUpdate", () => {
+  const updatedAt = new Date("2026-06-01T00:00:00Z");
+
+  function templateDb(customHtml: string, count = 1) {
+    const updateMany = jest.fn().mockResolvedValue({ count });
+    const auditCreate = jest.fn().mockResolvedValue({});
+    const db = {
+      pageTemplate: {
+        findMany: jest.fn().mockResolvedValue([
+          { id: OLD_GLOBAL_ID, categoryId: null, isActive: true, customHtml, updatedAt },
+        ]),
+        findUnique: jest.fn(),
+        updateMany,
+      },
+      landingPage: { findMany: jest.fn(), findUnique: jest.fn(), updateMany: jest.fn(), update: jest.fn() },
+      auditLog: { create: auditCreate },
+    } as DbClient;
+    return { db, updateMany, auditCreate };
+  }
+
+  it("CAS-writes (where id+updatedAt), backs up first, then audits", async () => {
+    const { db, updateMany, auditCreate } = templateDb(OLD_TPL);
+    const plan = await buildTemplateUpdatePlan(db, { newSanitized: NEW_TPL });
+    const writeBackup = jest.fn().mockResolvedValue("/tmp/tpl-backup.json");
+    const result = await applyTemplateUpdate(db, plan, {
+      writeBackup,
+      operator: "ops@x.com",
+      runId: "run-1",
+    });
+    expect(result.status).toBe("applied");
+    expect(writeBackup).toHaveBeenCalledTimes(1);
+    expect(writeBackup.mock.invocationCallOrder[0]).toBeLessThan(updateMany.mock.invocationCallOrder[0]);
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { id: OLD_GLOBAL_ID, updatedAt },
+      data: { customHtml: NEW_TPL },
+    });
+    expect(auditCreate).toHaveBeenCalledTimes(1);
+    expect(auditCreate.mock.calls[0][0].data.action).toBe("SOLO_LANDING_TEMPLATE_UPDATE");
+  });
+
+  it("no-op when the template already equals the new artifact", async () => {
+    const { db, updateMany } = templateDb(NEW_TPL);
+    const plan = await buildTemplateUpdatePlan(db, { newSanitized: NEW_TPL });
+    const result = await applyTemplateUpdate(db, plan, {
+      writeBackup: jest.fn(),
+      operator: "o",
+      runId: "r",
+    });
+    expect(result.status).toBe("no-op");
+    expect(updateMany).not.toHaveBeenCalled();
+  });
+
+  it("CAS abort when the operator-supplied expected SHA does not match live", async () => {
+    const { db, updateMany } = templateDb(OLD_TPL);
+    const plan = await buildTemplateUpdatePlan(db, { newSanitized: NEW_TPL });
+    const result = await applyTemplateUpdate(db, plan, {
+      writeBackup: jest.fn().mockResolvedValue("/tmp/x.json"),
+      operator: "o",
+      runId: "r",
+      expectedOldSha: "deadbeef",
+    });
+    expect(result.status).toBe("cas-abort");
+    expect(updateMany).not.toHaveBeenCalled();
+  });
+
+  it("CAS abort when updateMany matches 0 rows (concurrent edit)", async () => {
+    const { db } = templateDb(OLD_TPL, 0);
+    const plan = await buildTemplateUpdatePlan(db, { newSanitized: NEW_TPL });
+    const result = await applyTemplateUpdate(db, plan, {
+      writeBackup: jest.fn().mockResolvedValue("/tmp/x.json"),
+      operator: "o",
+      runId: "r",
+    });
+    expect(result.status).toBe("cas-abort");
+  });
+});
+
+describe("Script 1 — restoreTemplateFromBackup", () => {
+  const updatedAt = new Date("2026-06-02T00:00:00Z");
+  const backup: TemplateBackupFile = {
+    kind: "solo-landing-template-update",
+    runId: "run-1",
+    createdAt: new Date().toISOString(),
+    databaseHost: HOST,
+    templateId: OLD_GLOBAL_ID,
+    oldUpdatedAt: new Date("2026-06-01T00:00:00Z").toISOString(),
+    oldSha: sha256(OLD_TPL),
+    newSha: sha256(NEW_TPL),
+    oldCustomHtml: OLD_TPL,
+  };
+
+  it("CAS-restores when live still equals the value we wrote (newSha)", async () => {
+    const updateMany = jest.fn().mockResolvedValue({ count: 1 });
+    const auditCreate = jest.fn().mockResolvedValue({});
+    const db = {
+      pageTemplate: {
+        findMany: jest.fn(),
+        findUnique: jest.fn().mockResolvedValue({
+          id: OLD_GLOBAL_ID,
+          categoryId: null,
+          isActive: true,
+          customHtml: NEW_TPL,
+          updatedAt,
+        }),
+        updateMany,
+      },
+      landingPage: { findMany: jest.fn(), findUnique: jest.fn(), updateMany: jest.fn(), update: jest.fn() },
+      auditLog: { create: auditCreate },
+    } as DbClient;
+    const r = await restoreTemplateFromBackup(db, backup, { operator: "o", runId: "r2" });
+    expect(r.status).toBe("restored");
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { id: OLD_GLOBAL_ID, updatedAt },
+      data: { customHtml: OLD_TPL },
+    });
+    expect(auditCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses to clobber a LATER edit (live sha is neither old nor new)", async () => {
+    const updateMany = jest.fn();
+    const db = {
+      pageTemplate: {
+        findMany: jest.fn(),
+        findUnique: jest.fn().mockResolvedValue({
+          id: OLD_GLOBAL_ID,
+          categoryId: null,
+          isActive: true,
+          customHtml: "<div>SOMEONE EDITED THIS LATER</div>",
+          updatedAt,
+        }),
+        updateMany,
+      },
+      landingPage: { findMany: jest.fn(), findUnique: jest.fn(), updateMany: jest.fn(), update: jest.fn() },
+      auditLog: { create: jest.fn() },
+    } as DbClient;
+    const r = await restoreTemplateFromBackup(db, backup, { operator: "o", runId: "r2" });
+    expect(r.status).toBe("cas-abort");
+    expect(updateMany).not.toHaveBeenCalled();
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+//  Script 2
+// ════════════════════════════════════════════════════════════════════════════
+
+function backfillDb(pages: unknown[]): { db: DbClient; updateMany: jest.Mock; auditCreate: jest.Mock } {
+  const updateMany = jest.fn().mockResolvedValue({ count: 1 });
+  const auditCreate = jest.fn().mockResolvedValue({});
+  const db = {
+    pageTemplate: { findMany: jest.fn(), findUnique: jest.fn(), updateMany: jest.fn() },
+    landingPage: {
+      findMany: jest.fn().mockResolvedValue(pages),
+      findUnique: jest.fn().mockResolvedValue(null),
+      updateMany,
+      update: jest.fn().mockResolvedValue({}),
+    },
+    auditLog: { create: auditCreate },
+  } as DbClient;
+  return { db, updateMany, auditCreate };
+}
+
+const baseInput = {
+  oldGlobalTemplateId: OLD_GLOBAL_ID,
+  oldTemplateCustomHtml: OLD_TPL,
+  newTemplateCustomHtml: NEW_TPL,
+  expectedHost: HOST,
+  allowPriceWorkshopIds: [] as string[],
+};
+
+describe("Script 2 — buildBackfillPlans targeting + preflights", () => {
+  it("targets a row whose current customHtml == its per-workshop OLD render", async () => {
+    const oldRenderWs1 = render(OLD_TPL, WS.ws1);
+    const { db } = backfillDb([
+      {
+        id: "lp1",
+        workshopId: "ws1",
+        slug: "ws1-solo",
+        customHtml: oldRenderWs1,
+        updatedAt: new Date(),
+        categoryId: null,
+        sourceTemplateId: OLD_GLOBAL_ID,
+      },
+    ]);
+    const { plans, counts } = await buildBackfillPlans(db, injectedReinterpolate(), injectedFacts(), baseInput);
+    expect(counts.targets).toBe(1);
+    expect(plans[0].decision).toBe("target");
+    expect(plans[0].newSha).toBe(sha256(render(NEW_TPL, WS.ws1)));
+  });
+
+  it("marks an already-migrated row (current == new render) a no-op", async () => {
+    const newRenderWs1 = render(NEW_TPL, WS.ws1);
+    const { db } = backfillDb([
+      {
+        id: "lp1",
+        workshopId: "ws1",
+        slug: "ws1-solo",
+        customHtml: newRenderWs1,
+        updatedAt: new Date(),
+        categoryId: null,
+        sourceTemplateId: null,
+      },
+    ]);
+    const { counts } = await buildBackfillPlans(db, injectedReinterpolate(), injectedFacts(), baseInput);
+    expect(counts.noops).toBe(1);
+    expect(counts.targets).toBe(0);
+  });
+
+  it("skips a bespoke row (current matches neither old nor new) — never clobbered", async () => {
+    const { db } = backfillDb([
+      {
+        id: "lp1",
+        workshopId: "ws1",
+        slug: "ws1-solo",
+        customHtml: "<div>HAND EDITED BESPOKE</div>",
+        updatedAt: new Date(),
+        categoryId: null,
+        sourceTemplateId: null,
+      },
+    ]);
+    const { plans, counts } = await buildBackfillPlans(db, injectedReinterpolate(), injectedFacts(), baseInput);
+    expect(counts.skips).toBe(1);
+    expect(plans[0].skipReason).toBe("bespoke-or-category-scoped");
+  });
+
+  it("skips a row whose coach has no photo", async () => {
+    const { db } = backfillDb([
+      {
+        id: "lp1",
+        workshopId: "ws1",
+        slug: "ws1-solo",
+        customHtml: render(OLD_TPL, WS.ws1),
+        updatedAt: new Date(),
+        categoryId: null,
+        sourceTemplateId: OLD_GLOBAL_ID,
+      },
+    ]);
+    const facts = injectedFacts({ ws1: { coachProfileImage: "" } });
+    const { plans } = await buildBackfillPlans(db, injectedReinterpolate(), facts, baseInput);
+    expect(plans[0].decision).toBe("skip");
+    expect(plans[0].skipReason).toBe("missing-coach-photo");
+  });
+
+  it("skips a row whose CTA points at an unpublished registration", async () => {
+    const { db } = backfillDb([
+      {
+        id: "lp1",
+        workshopId: "ws1",
+        slug: "ws1-solo",
+        customHtml: render(OLD_TPL, WS.ws1),
+        updatedAt: new Date(),
+        categoryId: null,
+        sourceTemplateId: OLD_GLOBAL_ID,
+      },
+    ]);
+    const facts = injectedFacts({ ws1: { registrationPublished: false } });
+    const { plans } = await buildBackfillPlans(db, injectedReinterpolate(), facts, baseInput);
+    expect(plans[0].skipReason).toBe("cta-preflight-failed");
+  });
+
+  it("skips a TBD-price row unless an --allow-price exception is set", async () => {
+    const pages = [
+      {
+        id: "lp1",
+        workshopId: "ws1",
+        slug: "ws1-solo",
+        customHtml: render(OLD_TPL, WS.ws1),
+        updatedAt: new Date(),
+        categoryId: null,
+        sourceTemplateId: OLD_GLOBAL_ID,
+      },
+    ];
+    const facts = injectedFacts({ ws1: { renderedPrice: "TBD" } });
+
+    const { db: db1 } = backfillDb(pages);
+    const noException = await buildBackfillPlans(db1, injectedReinterpolate(), facts, baseInput);
+    expect(noException.plans[0].skipReason).toBe("price-preflight-failed");
+
+    const { db: db2 } = backfillDb(pages);
+    const withException = await buildBackfillPlans(db2, injectedReinterpolate(), injectedFacts({ ws1: { renderedPrice: "TBD" } }), {
+      ...baseInput,
+      allowPriceWorkshopIds: ["ws1"],
+    });
+    expect(withException.plans[0].decision).toBe("target");
+  });
+
+  it("skips a row whose sourceTemplateId points at a different template", async () => {
+    const { db } = backfillDb([
+      {
+        id: "lp1",
+        workshopId: "ws1",
+        slug: "ws1-solo",
+        customHtml: render(OLD_TPL, WS.ws1),
+        updatedAt: new Date(),
+        categoryId: "cat-x",
+        sourceTemplateId: "tpl-category-scoped",
+      },
+    ]);
+    const { plans } = await buildBackfillPlans(db, injectedReinterpolate(), injectedFacts(), baseInput);
+    expect(plans[0].skipReason).toBe("source-template-mismatch");
+  });
+});
+
+describe("Script 2 — applyBackfillPlans", () => {
+  async function targetPlanForWs1() {
+    const { db } = backfillDb([
+      {
+        id: "lp1",
+        workshopId: "ws1",
+        slug: "ws1-solo",
+        customHtml: render(OLD_TPL, WS.ws1),
+        updatedAt: new Date("2026-01-01T00:00:00Z"),
+        categoryId: null,
+        sourceTemplateId: OLD_GLOBAL_ID,
+      },
+    ]);
+    const { plans } = await buildBackfillPlans(db, injectedReinterpolate(), injectedFacts(), baseInput);
+    return plans;
+  }
+
+  it("CAS-writes target rows (where id+updatedAt), backs up first, audits", async () => {
+    const plans = await targetPlanForWs1();
+    const { db, updateMany, auditCreate } = backfillDb([]);
+    const writeBackup = jest.fn().mockResolvedValue("/tmp/backfill.json");
+    const result = await applyBackfillPlans(db, plans, {
+      writeBackup,
+      operator: "ops@x.com",
+      runId: "run-2",
+      newGlobalSha: "newglobalsha",
+    });
+    expect(result).toMatchObject({ updated: 1, skipped: 0, blocked: 0 });
+    expect(writeBackup).toHaveBeenCalledTimes(1);
+    expect(writeBackup.mock.invocationCallOrder[0]).toBeLessThan(updateMany.mock.invocationCallOrder[0]);
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { id: "lp1", updatedAt: new Date("2026-01-01T00:00:00Z") },
+      data: { customHtml: render(NEW_TPL, WS.ws1) },
+    });
+    expect(auditCreate.mock.calls[0][0].data.action).toBe("SOLO_LANDING_BACKFILL_APPLY");
+  });
+
+  it("CAS abort (count 0) → skipped, no clobber", async () => {
+    const plans = await targetPlanForWs1();
+    const { db, updateMany } = backfillDb([]);
+    updateMany.mockResolvedValue({ count: 0 });
+    const result = await applyBackfillPlans(db, plans, {
+      writeBackup: jest.fn().mockResolvedValue("/tmp/b.json"),
+      operator: "o",
+      runId: "r",
+      newGlobalSha: "s",
+    });
+    expect(result).toMatchObject({ updated: 0, skipped: 1, blocked: 0 });
+  });
+
+  it("blocks the whole apply (no writes) when a target had sanitizer strips", async () => {
+    const plans = await targetPlanForWs1();
+    plans[0].sanitizerStripped = true;
+    plans[0].strippedAttrs = ["onclick"];
+    const { db, updateMany } = backfillDb([]);
+    const writeBackup = jest.fn();
+    const result = await applyBackfillPlans(db, plans, {
+      writeBackup,
+      operator: "o",
+      runId: "r",
+      newGlobalSha: "s",
+    });
+    expect(result.blocked).toBe(1);
+    expect(writeBackup).not.toHaveBeenCalled();
+    expect(updateMany).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when there are no targets (skip-only plan)", async () => {
+    const { db } = backfillDb([
+      {
+        id: "lp1",
+        workshopId: "ws1",
+        slug: "ws1-solo",
+        customHtml: "<div>bespoke</div>",
+        updatedAt: new Date(),
+        categoryId: null,
+        sourceTemplateId: null,
+      },
+    ]);
+    const { plans } = await buildBackfillPlans(db, injectedReinterpolate(), injectedFacts(), baseInput);
+    const writeBackup = jest.fn();
+    const result = await applyBackfillPlans(db, plans, {
+      writeBackup,
+      operator: "o",
+      runId: "r",
+      newGlobalSha: "s",
+    });
+    expect(result).toEqual({ updated: 0, skipped: 0, blocked: 0 });
+    expect(writeBackup).not.toHaveBeenCalled();
+  });
+});
+
+describe("Script 2 — restoreBackfill", () => {
+  const backup: KajabiBackupFile = {
+    kind: "solo-landing-kajabi-backfill",
+    runId: "run-2",
+    createdAt: new Date().toISOString(),
+    databaseHost: HOST,
+    oldGlobalTemplateId: OLD_GLOBAL_ID,
+    newGlobalSha: "newglobalsha",
+    entries: [
+      {
+        landingPageId: "lp1",
+        workshopId: "ws1",
+        slug: "ws1-solo",
+        oldCustomHtml: render(OLD_TPL, WS.ws1),
+        oldUpdatedAt: new Date("2026-01-01T00:00:00Z").toISOString(),
+        oldSha: sha256(render(OLD_TPL, WS.ws1)),
+        newSha: sha256(render(NEW_TPL, WS.ws1)),
+      },
+    ],
+  };
+
+  it("restores rows still on the value we wrote (newSha)", async () => {
+    const { db, auditCreate } = backfillDb([]);
+    (db.landingPage.findUnique as jest.Mock).mockResolvedValue({ customHtml: render(NEW_TPL, WS.ws1) });
+    const r = await restoreBackfill(db, backup, { operator: "o", runId: "r3" });
+    expect(r).toEqual({ restored: 1, skipped: 0 });
+    expect(db.landingPage.update).toHaveBeenCalledWith({
+      where: { id: "lp1" },
+      data: { customHtml: render(OLD_TPL, WS.ws1) },
+    });
+    expect(auditCreate.mock.calls[0][0].data.action).toBe("SOLO_LANDING_BACKFILL_RESTORE");
+  });
+
+  it("skips a row edited after our apply (no clobber)", async () => {
+    const { db } = backfillDb([]);
+    (db.landingPage.findUnique as jest.Mock).mockResolvedValue({ customHtml: "<div>edited later</div>" });
+    const r = await restoreBackfill(db, backup, { operator: "o", runId: "r3" });
+    expect(r).toEqual({ restored: 0, skipped: 1 });
+    expect(db.landingPage.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects a malformed backup", async () => {
+    const { db } = backfillDb([]);
+    await expect(
+      restoreBackfill(db, { kind: "nope" } as unknown as KajabiBackupFile, { operator: "o", runId: "r" }),
+    ).rejects.toThrow(/recognised/);
+  });
+});

--- a/src/src/__tests__/scripts/solo-landing-kajabi-runner.test.ts
+++ b/src/src/__tests__/scripts/solo-landing-kajabi-runner.test.ts
@@ -50,7 +50,9 @@ const WS = {
 
 function injectedReinterpolate(): jest.Mock {
   // Returns the rendered string for whatever template it is given, per workshop.
-  return jest.fn(async (workshopId: string, tpl: string) => {
+  // Third param (registrationUrl) is accepted but unused — runner passes it in (Fix 3).
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  return jest.fn(async (workshopId: string, tpl: string, _registrationUrl: string) => {
     const vars = (WS as Record<string, Record<string, string>>)[workshopId];
     if (!vars) return null;
     return clean(render(tpl, vars));
@@ -545,24 +547,68 @@ describe("Script 2 — restoreBackfill", () => {
     ],
   };
 
-  it("restores rows still on the value we wrote (newSha)", async () => {
+  const restoreUpdatedAt = new Date("2026-05-01T00:00:00Z");
+
+  it("restores rows still on the value we wrote (newSha) using CAS updateMany", async () => {
     const { db, auditCreate } = backfillDb([]);
-    (db.landingPage.findUnique as jest.Mock).mockResolvedValue({ customHtml: render(NEW_TPL, WS.ws1) });
+    (db.landingPage.findUnique as jest.Mock).mockResolvedValue({
+      customHtml: render(NEW_TPL, WS.ws1),
+      updatedAt: restoreUpdatedAt,
+    });
     const r = await restoreBackfill(db, backup, { operator: "o", runId: "r3" });
     expect(r).toEqual({ restored: 1, skipped: 0 });
-    expect(db.landingPage.update).toHaveBeenCalledWith({
-      where: { id: "lp1" },
+    // Fix 2: must use CAS updateMany (not unconditional update)
+    expect(db.landingPage.update).not.toHaveBeenCalled();
+    expect(db.landingPage.updateMany).toHaveBeenCalledWith({
+      where: { id: "lp1", updatedAt: restoreUpdatedAt },
       data: { customHtml: render(OLD_TPL, WS.ws1) },
     });
     expect(auditCreate.mock.calls[0][0].data.action).toBe("SOLO_LANDING_BACKFILL_RESTORE");
   });
 
-  it("skips a row edited after our apply (no clobber)", async () => {
+  it("skips a row edited after our apply (SHA mismatch — no clobber)", async () => {
     const { db } = backfillDb([]);
-    (db.landingPage.findUnique as jest.Mock).mockResolvedValue({ customHtml: "<div>edited later</div>" });
+    (db.landingPage.findUnique as jest.Mock).mockResolvedValue({
+      customHtml: "<div>edited later</div>",
+      updatedAt: restoreUpdatedAt,
+    });
     const r = await restoreBackfill(db, backup, { operator: "o", runId: "r3" });
     expect(r).toEqual({ restored: 0, skipped: 1 });
     expect(db.landingPage.update).not.toHaveBeenCalled();
+    expect(db.landingPage.updateMany).not.toHaveBeenCalled();
+  });
+
+  // Fix 1 (P1): fail-safe CAS — falsy newSha in backup → skip, never write.
+  it("skips a row when entry.newSha is empty/falsy (corrupt backup — fail-safe)", async () => {
+    const corruptBackup: KajabiBackupFile = {
+      ...backup,
+      entries: [{ ...backup.entries[0], newSha: "" }],
+    };
+    const { db } = backfillDb([]);
+    (db.landingPage.findUnique as jest.Mock).mockResolvedValue({
+      customHtml: render(NEW_TPL, WS.ws1),
+      updatedAt: restoreUpdatedAt,
+    });
+    const r = await restoreBackfill(db, corruptBackup, { operator: "o", runId: "r3" });
+    expect(r).toEqual({ restored: 0, skipped: 1 });
+    expect(db.landingPage.update).not.toHaveBeenCalled();
+    expect(db.landingPage.updateMany).not.toHaveBeenCalled();
+  });
+
+  // Fix 2 (P1): TOCTOU guard — concurrent edit between findUnique and updateMany → skipped.
+  it("skips a row when updateMany matches 0 rows (concurrent edit between read and write)", async () => {
+    const { db, auditCreate } = backfillDb([]);
+    (db.landingPage.findUnique as jest.Mock).mockResolvedValue({
+      customHtml: render(NEW_TPL, WS.ws1),
+      updatedAt: restoreUpdatedAt,
+    });
+    // Simulate concurrent edit: CAS updateMany finds nothing (updatedAt already changed)
+    (db.landingPage.updateMany as jest.Mock).mockResolvedValue({ count: 0 });
+    const r = await restoreBackfill(db, backup, { operator: "o", runId: "r3" });
+    expect(r).toEqual({ restored: 0, skipped: 1 });
+    expect(db.landingPage.update).not.toHaveBeenCalled();
+    // Audit log is still written (with skipped=1, restored=0)
+    expect(auditCreate.mock.calls[0][0].data.action).toBe("SOLO_LANDING_BACKFILL_RESTORE");
   });
 
   it("rejects a malformed backup", async () => {

--- a/src/src/lib/scripts/solo-landing-kajabi-core.ts
+++ b/src/src/lib/scripts/solo-landing-kajabi-core.ts
@@ -1,0 +1,569 @@
+/**
+ * solo-landing-kajabi-core.ts
+ *
+ * Pure, side-effect-free helpers for the GLOBAL SOLO_LANDING Kajabi rollout:
+ *   - Script 1 (scripts/update-solo-landing-template.ts) — CAS-guarded update of
+ *     the single global SOLO_LANDING PageTemplate.customHtml to the new artifact.
+ *   - Script 2 (scripts/backfill-solo-landing-kajabi.ts) — guarded, canary-first,
+ *     audited backfill of the existing per-workshop SOLO_LANDING LandingPage
+ *     snapshots to the new design.
+ *
+ * WHY a separate module from the June-4 backfill core:
+ *   The June-4 backfill targeted by *migration-specific signatures* (old
+ *   `su-mark-q` logo markup OR a literal `{{event_time}}` token). That predicate
+ *   is wrong for the Kajabi rollout — the old global design is itself a
+ *   token-driven customHtml, so most rows DO have a resolved event_time and the
+ *   NEW logo style, and the signature predicate would miss them (claudex R2-High1).
+ *
+ *   This rollout targets by the ONLY correct signal: re-render the BACKED-UP OLD
+ *   global template with THIS workshop's variables (the exact two-pass auto-build
+ *   pipeline), strict-sanitize, SHA, and compare to the row's CURRENT customHtml.
+ *   A match ⇒ the row is still on the old global design ⇒ target. A mismatch ⇒
+ *   bespoke / category-scoped / hand-edited ⇒ SKIP + log. We never gate on a
+ *   shared raw-template hash (the snapshot is interpolated, so it NEVER equals
+ *   the raw template hash — R2-High1/R3-High1).
+ *
+ * No imports of `@/lib/db` or anything with side effects — everything here is
+ * pure and deterministic. The DB-touching orchestration lives in
+ * solo-landing-kajabi-runner.ts; the actual interpolate/sanitize pipeline is
+ * injected by the CLI wrapper.
+ */
+
+import { createHash } from "node:crypto";
+
+// ─── Hashing ───────────────────────────────────────────────────────────────
+
+/** SHA-256 hex digest of a string (template update CAS, per-row diff, backups). */
+export function sha256(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+// ─── New-artifact design marker ──────────────────────────────────────────────
+
+/**
+ * The new Kajabi design is uniquely identifiable by the `data-su-mc` attribute
+ * on its root <div>. We assert the artifact carries it, and validate every
+ * rendered NEW value still carries it (a defense against an interpolation /
+ * sanitize step accidentally dropping the wrapper).
+ */
+export const NEW_DESIGN_MARKER = "data-su-mc";
+
+// ─── New-value validation (Task 7/10) ─────────────────────────────────────────
+
+export interface NewValueValidation {
+  ok: boolean;
+  /** Contains the data-su-mc design marker. */
+  hasDesignMarker: boolean;
+  /** No unresolved `{{…}}` interpolation token remains. */
+  noUnresolvedTokens: boolean;
+  /** A non-empty CTA href resolved (the Register button points somewhere). */
+  hasCtaHref: boolean;
+  /** The first unresolved token found (for the report), if any. */
+  firstUnresolvedToken?: string;
+  /** The resolved CTA href that was extracted (for the report), if any. */
+  resolvedCtaHref?: string;
+}
+
+/**
+ * Match ANY `{{token}}` (whitespace-tolerant). Used to assert the rendered NEW
+ * value has no leftover interpolation placeholders. NOTE: applied to the
+ * interpolated+sanitized output, where the only legitimate `{{` would be a
+ * genuinely-unresolved variable, so any hit is a defect.
+ */
+const ANY_TOKEN_RE = /\{\{\s*[a-zA-Z_][a-zA-Z0-9_.]*\s*\}\}/;
+
+/**
+ * Extract the FIRST CTA href from the rendered customHtml. The artifact's
+ * register button is `<a class="btn" href="…">Register Here</a>`. We look for an
+ * <a> whose class contains `btn` and read its href; fall back to the first
+ * <a href> if no btn anchor is present (defensive — the artifact always has one).
+ */
+export function extractCtaHref(html: string): string | undefined {
+  // Prefer an anchor whose class mentions "btn" (the register button).
+  const btnMatch = html.match(
+    /<a\b[^>]*\bclass\s*=\s*["'][^"']*\bbtn\b[^"']*["'][^>]*\bhref\s*=\s*["']([^"']*)["']/i,
+  );
+  if (btnMatch) return btnMatch[1];
+  // class may come AFTER href on the same tag — try href-then-class order too.
+  const btnMatch2 = html.match(
+    /<a\b[^>]*\bhref\s*=\s*["']([^"']*)["'][^>]*\bclass\s*=\s*["'][^"']*\bbtn\b[^"']*["']/i,
+  );
+  if (btnMatch2) return btnMatch2[1];
+  const anyAnchor = html.match(/<a\b[^>]*\bhref\s*=\s*["']([^"']*)["']/i);
+  return anyAnchor ? anyAnchor[1] : undefined;
+}
+
+/**
+ * Validate a freshly-rendered NEW value for the three invariants Task 7/10
+ * require before we are willing to WRITE it to a public page:
+ *   1. carries the new design marker (data-su-mc),
+ *   2. has no unresolved {{…}} token,
+ *   3. has a non-empty CTA href.
+ */
+export function validateNewValue(renderedHtml: string): NewValueValidation {
+  const unresolved = renderedHtml.match(ANY_TOKEN_RE);
+  const hasDesignMarker = renderedHtml.includes(NEW_DESIGN_MARKER);
+  const noUnresolvedTokens = unresolved === null;
+  const ctaHref = extractCtaHref(renderedHtml);
+  const hasCtaHref = !!ctaHref && ctaHref.trim().length > 0;
+  return {
+    ok: hasDesignMarker && noUnresolvedTokens && hasCtaHref,
+    hasDesignMarker,
+    noUnresolvedTokens,
+    hasCtaHref,
+    firstUnresolvedToken: unresolved?.[0],
+    resolvedCtaHref: ctaHref,
+  };
+}
+
+// ─── CTA preflight (Task 8) ────────────────────────────────────────────────────
+
+export interface CtaPreflightInput {
+  /** The resolved registration URL embedded into this workshop's render. */
+  registrationUrl: string;
+  /** The expected production host (e.g. "scaling-up-platform-v2.vercel.app"). */
+  expectedHost: string;
+  /**
+   * Whether this workshop has a PUBLISHED REGISTRATION LandingPage whose slug
+   * matches the slug inside registrationUrl. The DB lookup is done by the
+   * runner; the pure check verifies the URL shape + the matched flag.
+   */
+  hasPublishedRegistration: boolean;
+  /** The REGISTRATION slug we expect to find inside registrationUrl (from DB). */
+  expectedRegistrationSlug?: string;
+}
+
+export interface CtaPreflightResult {
+  ok: boolean;
+  reason?: string;
+}
+
+/**
+ * Strengthened CTA preflight (claudex R2-Med1): the resolved registration URL
+ * must be an ABSOLUTE https URL on the expected production host AND correspond
+ * to a PUBLISHED REGISTRATION LandingPage for the same workshop. A relative,
+ * http, staging-host, or unpublished-registration URL FAILS (skip + flag) —
+ * we never globally ship a broken or wrong-host buy button.
+ */
+export function checkCtaPreflight(input: CtaPreflightInput): CtaPreflightResult {
+  const { registrationUrl, expectedHost, hasPublishedRegistration, expectedRegistrationSlug } =
+    input;
+
+  if (!registrationUrl || registrationUrl.trim().length === 0) {
+    return { ok: false, reason: "registration URL is empty" };
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(registrationUrl);
+  } catch {
+    return { ok: false, reason: `registration URL is not absolute/parseable: "${registrationUrl}"` };
+  }
+
+  if (parsed.protocol !== "https:") {
+    return { ok: false, reason: `registration URL is not https (got "${parsed.protocol}")` };
+  }
+
+  if (!expectedHost || expectedHost.trim().length === 0) {
+    return { ok: false, reason: "expected production host is not configured" };
+  }
+
+  if (parsed.host.toLowerCase() !== expectedHost.toLowerCase()) {
+    return {
+      ok: false,
+      reason: `registration URL host "${parsed.host}" != expected prod host "${expectedHost}"`,
+    };
+  }
+
+  if (!hasPublishedRegistration) {
+    return {
+      ok: false,
+      reason: "no PUBLISHED REGISTRATION LandingPage found for this workshop's CTA slug",
+    };
+  }
+
+  // If a slug was supplied, the URL path must actually end with it (guards
+  // against a stale / mismatched slug sneaking through).
+  if (expectedRegistrationSlug) {
+    const path = parsed.pathname.replace(/\/+$/, "");
+    if (!path.endsWith(`/${expectedRegistrationSlug}`)) {
+      return {
+        ok: false,
+        reason:
+          `registration URL path "${parsed.pathname}" does not end with the published ` +
+          `REGISTRATION slug "/${expectedRegistrationSlug}"`,
+      };
+    }
+  }
+
+  return { ok: true };
+}
+
+// ─── Price preflight (Task 9) ──────────────────────────────────────────────────
+
+export interface PricePreflightInput {
+  /** The `{{price}}` value as rendered by buildWorkshopVariables (e.g. "$497"). */
+  renderedPrice: string;
+  /** Whether the operator passed `--allow-price <workshopId>` for this row. */
+  hasExplicitException: boolean;
+}
+
+export interface PricePreflightResult {
+  ok: boolean;
+  reason?: string;
+}
+
+/**
+ * Price preflight = FAIL, not flag (claudex R2-Low1). A rendered price of
+ * `TBD` or `Free` (the two buildWorkshopVariables fallbacks that indicate we
+ * could NOT confirm a real checkout amount) FAILS the row — unless the operator
+ * has passed an explicit `--allow-price <workshopId>` exception (e.g. a workshop
+ * that legitimately de-emphasizes price). A confirmed dollar amount passes.
+ *
+ * NOTE: buildWorkshopVariables derives `price` directly from the workshop's
+ * pricingTier / priceCents / isFree, i.e. the SAME source the registration
+ * checkout uses — so a non-TBD, non-Free dollar string IS the registration
+ * amount. There is no separate checkout amount to diverge from. We therefore
+ * only need to reject the two "unknown" sentinels.
+ */
+export function checkPricePreflight(input: PricePreflightInput): PricePreflightResult {
+  const { renderedPrice, hasExplicitException } = input;
+  if (hasExplicitException) return { ok: true };
+
+  const trimmed = (renderedPrice ?? "").trim();
+  if (trimmed === "" || trimmed.toUpperCase() === "TBD" || trimmed.toLowerCase() === "free") {
+    return {
+      ok: false,
+      reason:
+        `rendered price is "${trimmed || "(empty)"}" — cannot confirm a checkout amount. ` +
+        `Pass --allow-price <workshopId> to ship this row with an explicit exception.`,
+    };
+  }
+  return { ok: true };
+}
+
+// ─── Coach-photo preflight (Task 7) ────────────────────────────────────────────
+
+/**
+ * Coach-photo preflight: the artifact renders `<img src="{{coach_photo}}">`.
+ * A workshop whose coach has an empty profileImage would ship an empty <img>
+ * src. Require a non-empty coach.profileImage; rows without it are SKIPPED +
+ * flagged (the runner reports them). Pure check on the resolved value.
+ */
+export function hasCoachPhoto(profileImage: string | null | undefined): boolean {
+  return !!profileImage && profileImage.trim().length > 0;
+}
+
+// ─── Targeting decision (Task 7) ───────────────────────────────────────────────
+
+export type SkipReason =
+  | "bespoke-or-category-scoped" // current customHtml != expected old render
+  | "source-template-mismatch" // sourceTemplateId != old global template id
+  | "missing-coach-photo"
+  | "cta-preflight-failed"
+  | "price-preflight-failed"
+  | "new-value-invalid" // rendered NEW value failed validateNewValue
+  | "no-workshop-variables" // buildWorkshopVariables returned null
+  | "empty-current-customhtml"; // row has no customHtml to compare/replace
+
+export type RowDecision =
+  | { kind: "target" }
+  | { kind: "no-op" } // already on the new design (new render == current)
+  | { kind: "skip"; reason: SkipReason; detail?: string };
+
+export interface TargetingInput {
+  /** The row's CURRENT stored customHtml (the interpolated per-workshop snapshot). */
+  currentCustomHtml: string | null | undefined;
+  /**
+   * The per-workshop EXPECTED OLD render: the BACKED-UP old global template
+   * re-interpolated with THIS workshop's vars + REGISTRATION slug, strict
+   * sanitized. Provided by the runner via the injected reinterpolate fn.
+   */
+  expectedOldRender: string;
+  /** The per-workshop NEW render (the new artifact interpolated for this workshop). */
+  newRender: string;
+  /** This LandingPage row's sourceTemplateId (may be null on legacy rows). */
+  sourceTemplateId: string | null | undefined;
+  /** The OLD global SOLO_LANDING PageTemplate id (from Script 1's backup). */
+  oldGlobalTemplateId: string;
+}
+
+/**
+ * Decide whether a single SOLO_LANDING LandingPage row is a backfill TARGET.
+ *
+ * Targeting precisely (claudex R2-High1, R3-High1):
+ *   1. If the row has no current customHtml → SKIP (nothing to compare/replace).
+ *   2. If sourceTemplateId is set AND != the old global template id → SKIP
+ *      (this page was cloned from a DIFFERENT template — bespoke/category).
+ *      A null sourceTemplateId is permitted (legacy rows) and falls through to
+ *      the content check, which is the authoritative signal.
+ *   3. Compute sha(currentCustomHtml). If it equals sha(newRender) → NO-OP
+ *      (already on the new design — idempotent).
+ *   4. If it equals sha(expectedOldRender) → TARGET (still on the old global
+ *      design rendered for THIS workshop).
+ *   5. Otherwise → SKIP "bespoke-or-category-scoped" (hand-edited / different
+ *      design — we must NEVER clobber it).
+ *
+ * The preflights (coach photo / CTA / price / new-value validity) are applied by
+ * the runner AFTER a row is decided a TARGET; they can downgrade a target to a
+ * skip with their own reason.
+ */
+export function decideRow(input: TargetingInput): RowDecision {
+  const current = input.currentCustomHtml;
+  if (!current || current.trim().length === 0) {
+    return { kind: "skip", reason: "empty-current-customhtml" };
+  }
+
+  if (
+    input.sourceTemplateId &&
+    input.sourceTemplateId.trim().length > 0 &&
+    input.sourceTemplateId !== input.oldGlobalTemplateId
+  ) {
+    return {
+      kind: "skip",
+      reason: "source-template-mismatch",
+      detail: `sourceTemplateId=${input.sourceTemplateId} != old global ${input.oldGlobalTemplateId}`,
+    };
+  }
+
+  const currentSha = sha256(current);
+  if (currentSha === sha256(input.newRender)) {
+    return { kind: "no-op" };
+  }
+  if (currentSha === sha256(input.expectedOldRender)) {
+    return { kind: "target" };
+  }
+  return {
+    kind: "skip",
+    reason: "bespoke-or-category-scoped",
+    detail: `current SHA ${currentSha.slice(0, 12)}… matches neither the per-workshop old nor new render`,
+  };
+}
+
+// ─── Per-row plan ──────────────────────────────────────────────────────────────
+
+export interface KajabiRowPlan {
+  landingPageId: string;
+  workshopId: string;
+  slug: string;
+  oldSha: string;
+  newSha: string;
+  oldUpdatedAt: Date;
+  oldCustomHtml: string;
+  newCustomHtml: string;
+  /** "target" rows are written; "no-op"/"skip" rows are reported only. */
+  decision: RowDecision["kind"];
+  skipReason?: SkipReason;
+  skipDetail?: string;
+  /** Sanitizer audit on the NEW render — non-empty blocks a clean apply. */
+  strippedTags: string[];
+  strippedAttrs: string[];
+  sanitizerStripped: boolean;
+  /** NEW-value validation result (design marker / no unresolved / CTA href). */
+  validation: NewValueValidation;
+}
+
+// ─── Backup / report file shapes ───────────────────────────────────────────────
+
+export interface KajabiBackupEntry {
+  landingPageId: string;
+  workshopId: string;
+  slug: string;
+  oldCustomHtml: string;
+  oldUpdatedAt: string; // ISO
+  oldSha: string;
+  newSha: string;
+}
+
+export interface KajabiBackupFile {
+  kind: "solo-landing-kajabi-backfill";
+  runId: string;
+  createdAt: string; // ISO
+  databaseHost: string;
+  /** The OLD global template id targeted (for the rollback inventory). */
+  oldGlobalTemplateId: string;
+  /** SHA of the new global template customHtml at apply time (rollout window). */
+  newGlobalSha: string;
+  entries: KajabiBackupEntry[];
+}
+
+/** Construct one backup entry from a target plan about to be written. */
+export function toKajabiBackupEntry(plan: KajabiRowPlan): KajabiBackupEntry {
+  return {
+    landingPageId: plan.landingPageId,
+    workshopId: plan.workshopId,
+    slug: plan.slug,
+    oldCustomHtml: plan.oldCustomHtml,
+    oldUpdatedAt: plan.oldUpdatedAt.toISOString(),
+    oldSha: plan.oldSha,
+    newSha: plan.newSha,
+  };
+}
+
+// ─── Expected-count gate (Task 7) ──────────────────────────────────────────────
+
+export interface ExpectCountResult {
+  ok: boolean;
+  reason?: string;
+}
+
+/**
+ * Apply is refused unless the operator-supplied `--expect-count N` exactly
+ * matches the number of TARGET rows the dry-run found (claudex R3 / Task 7).
+ * `expected === undefined` (flag not passed) FAILS for an apply — the operator
+ * MUST assert the count.
+ */
+export function checkExpectedCount(
+  matchedTargets: number,
+  expected: number | undefined,
+): ExpectCountResult {
+  if (expected === undefined) {
+    return {
+      ok: false,
+      reason:
+        `--expect-count <N> is required for --apply. The dry-run matched ` +
+        `${matchedTargets} target row(s); re-run with --expect-count ${matchedTargets}.`,
+    };
+  }
+  if (expected !== matchedTargets) {
+    return {
+      ok: false,
+      reason:
+        `--expect-count ${expected} does NOT match the ${matchedTargets} target row(s) found. ` +
+        `Aborting (a drift in target count means the targeting changed under you).`,
+    };
+  }
+  return { ok: true };
+}
+
+// ─── Template-update (Script 1) CAS plan ────────────────────────────────────────
+
+export interface TemplateUpdatePlan {
+  templateId: string;
+  oldSha: string;
+  newSha: string;
+  oldUpdatedAt: Date;
+  oldCustomHtml: string;
+  newCustomHtml: string;
+  /** True when newSha === oldSha — nothing to do (idempotent). */
+  isNoOp: boolean;
+}
+
+export interface TemplateBackupFile {
+  kind: "solo-landing-template-update";
+  runId: string;
+  createdAt: string; // ISO
+  databaseHost: string;
+  templateId: string;
+  oldUpdatedAt: string; // ISO
+  oldSha: string;
+  newSha: string;
+  oldCustomHtml: string;
+}
+
+/**
+ * CAS-guard decision for the template update: refuse to write unless the live
+ * row's updatedAt + SHA still match what the operator captured/expects. Returns
+ * a decision; the runner performs the actual conditional update.
+ */
+export interface TemplateCasInput {
+  liveUpdatedAt: Date;
+  liveSha: string;
+  expectedUpdatedAt?: Date;
+  expectedOldSha?: string;
+}
+
+export interface TemplateCasResult {
+  ok: boolean;
+  reason?: string;
+}
+
+export function checkTemplateCas(input: TemplateCasInput): TemplateCasResult {
+  const { liveUpdatedAt, liveSha, expectedUpdatedAt, expectedOldSha } = input;
+  if (expectedOldSha !== undefined && liveSha !== expectedOldSha) {
+    return {
+      ok: false,
+      reason:
+        `live template SHA ${liveSha.slice(0, 12)}… != expected ${expectedOldSha.slice(0, 12)}… ` +
+        `— the template changed since you captured the expected value. Aborting.`,
+    };
+  }
+  if (expectedUpdatedAt !== undefined && liveUpdatedAt.getTime() !== expectedUpdatedAt.getTime()) {
+    return {
+      ok: false,
+      reason:
+        `live template updatedAt ${liveUpdatedAt.toISOString()} != expected ` +
+        `${expectedUpdatedAt.toISOString()} — concurrent edit. Aborting.`,
+    };
+  }
+  return { ok: true };
+}
+
+// ─── CLI flag parsing (shared shape, kajabi-specific flags) ─────────────────────
+
+export const OVERRIDE_FLAG = "--i-know-this-is-prod";
+
+export type Mode = "dry-run" | "apply" | "restore";
+
+export interface KajabiParsedArgs {
+  mode: Mode;
+  hasOverride: boolean;
+  restoreFile?: string;
+  /** Path to Script 1's OLD template backup (the expected-old-render source). */
+  oldTemplateBackup?: string;
+  /** Path to the NEW artifact HTML (default resolved by the CLI wrapper). */
+  newTemplate?: string;
+  /** Single-page canary by slug. */
+  slug?: string;
+  /** Batch size cap. */
+  limit?: number;
+  /** Operator-asserted target count. */
+  expectCount?: number;
+  /** Per-workshop price exceptions. */
+  allowPrice: string[];
+}
+
+function readNumberFlag(argv: string[], flag: string): number | undefined {
+  const idx = argv.indexOf(flag);
+  if (idx < 0) return undefined;
+  const raw = argv[idx + 1];
+  if (raw === undefined) return undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function readStringFlag(argv: string[], flag: string): string | undefined {
+  const idx = argv.indexOf(flag);
+  if (idx < 0) return undefined;
+  return argv[idx + 1];
+}
+
+function readRepeatableFlag(argv: string[], flag: string): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === flag && argv[i + 1] !== undefined) out.push(argv[i + 1]);
+  }
+  return out;
+}
+
+export function parseKajabiArgs(argv: string[]): KajabiParsedArgs {
+  const hasOverride = argv.includes(OVERRIDE_FLAG);
+  const common = {
+    hasOverride,
+    oldTemplateBackup: readStringFlag(argv, "--old-template-backup"),
+    newTemplate: readStringFlag(argv, "--new-template"),
+    slug: readStringFlag(argv, "--slug"),
+    limit: readNumberFlag(argv, "--limit"),
+    expectCount: readNumberFlag(argv, "--expect-count"),
+    allowPrice: readRepeatableFlag(argv, "--allow-price"),
+  };
+
+  const restoreIdx = argv.indexOf("--restore");
+  if (restoreIdx >= 0) {
+    return { mode: "restore", restoreFile: argv[restoreIdx + 1], ...common };
+  }
+  if (argv.includes("--apply")) {
+    return { mode: "apply", ...common };
+  }
+  return { mode: "dry-run", ...common };
+}

--- a/src/src/lib/scripts/solo-landing-kajabi-runner.ts
+++ b/src/src/lib/scripts/solo-landing-kajabi-runner.ts
@@ -77,7 +77,6 @@ export interface DbClient {
       where: { id: string; updatedAt: Date };
       data: { customHtml: string };
     }): Promise<{ count: number }>;
-    update(args: { where: { id: string }; data: { customHtml: string } }): Promise<unknown>;
   };
   auditLog: {
     create(args: { data: AuditCreateData }): Promise<unknown>;

--- a/src/src/lib/scripts/solo-landing-kajabi-runner.ts
+++ b/src/src/lib/scripts/solo-landing-kajabi-runner.ts
@@ -1,0 +1,696 @@
+/**
+ * solo-landing-kajabi-runner.ts
+ *
+ * DB-touching orchestration for the GLOBAL SOLO_LANDING Kajabi rollout, written
+ * with DEPENDENCY INJECTION so it is unit-testable with a mocked Prisma client
+ * and mocked interpolation/sanitize functions. The CLI wrappers
+ * (scripts/update-solo-landing-template.ts, scripts/backfill-solo-landing-kajabi.ts)
+ * wire the real Prisma client + the real lib pipeline into these runners.
+ *
+ * Every function here is pure-of-globals: all I/O (DB, fs, audit) is passed in.
+ */
+
+import {
+  sha256,
+  decideRow,
+  validateNewValue,
+  checkCtaPreflight,
+  checkPricePreflight,
+  hasCoachPhoto,
+  toKajabiBackupEntry,
+  checkTemplateCas,
+  type KajabiRowPlan,
+  type KajabiBackupFile,
+  type KajabiBackupEntry,
+  type TemplateUpdatePlan,
+  type TemplateBackupFile,
+  type SkipReason,
+} from "@/lib/scripts/solo-landing-kajabi-core";
+
+// ─── Injected dependency contracts (minimal Prisma surface) ──────────────────
+
+export interface PageTemplateRow {
+  id: string;
+  categoryId: string | null;
+  isActive: boolean;
+  customHtml: string | null;
+  updatedAt: Date;
+}
+
+export interface LandingPageRow {
+  id: string;
+  workshopId: string;
+  slug: string;
+  customHtml: string | null;
+  updatedAt: Date;
+  categoryId: string | null;
+  sourceTemplateId: string | null;
+}
+
+/** Per-workshop facts the preflights need (resolved by the runner). */
+export interface WorkshopFacts {
+  /** coach.profileImage (for the coach-photo preflight). */
+  coachProfileImage: string | null;
+  /** Resolved registration URL embedded for this workshop. */
+  registrationUrl: string;
+  /** The REGISTRATION LandingPage slug (if one exists, regardless of status). */
+  registrationSlug: string | null;
+  /** Whether that REGISTRATION LandingPage is PUBLISHED. */
+  registrationPublished: boolean;
+  /** Rendered {{price}} for this workshop. */
+  renderedPrice: string;
+}
+
+export interface DbClient {
+  pageTemplate: {
+    findMany(args: unknown): Promise<PageTemplateRow[]>;
+    findUnique(args: unknown): Promise<PageTemplateRow | null>;
+    updateMany(args: {
+      where: { id: string; updatedAt: Date };
+      data: { customHtml: string };
+    }): Promise<{ count: number }>;
+  };
+  landingPage: {
+    findMany(args: unknown): Promise<LandingPageRow[]>;
+    findUnique(args: unknown): Promise<{ customHtml?: string | null } | null>;
+    updateMany(args: {
+      where: { id: string; updatedAt: Date };
+      data: { customHtml: string };
+    }): Promise<{ count: number }>;
+    update(args: { where: { id: string }; data: { customHtml: string } }): Promise<unknown>;
+  };
+  auditLog: {
+    create(args: { data: AuditCreateData }): Promise<unknown>;
+  };
+}
+
+export interface AuditCreateData {
+  entityType: string;
+  entityId: string;
+  action: string;
+  performedBy: string;
+  changes: string; // JSON
+}
+
+export interface SanitizeOutcome {
+  sanitized: string;
+  strippedTags: string[];
+  strippedAttrs: string[];
+}
+
+/**
+ * Re-interpolate ONE template's customHtml for ONE workshop via the exact
+ * two-pass auto-build pipeline. Injected so tests can stub it without loading
+ * buildWorkshopVariables / interpolate / sanitize. Returns null when the
+ * workshop has no variables (not found).
+ */
+export type Reinterpolate = (
+  workshopId: string,
+  templateCustomHtml: string,
+) => Promise<SanitizeOutcome | null>;
+
+/** Resolve the per-workshop preflight facts (DB-backed). Injected for tests. */
+export type ResolveWorkshopFacts = (workshopId: string) => Promise<WorkshopFacts | null>;
+
+// ════════════════════════════════════════════════════════════════════════════
+//  Script 1 — guarded TEMPLATE update
+// ════════════════════════════════════════════════════════════════════════════
+
+export interface ResolveGlobalTemplateResult {
+  template: PageTemplateRow;
+}
+
+/**
+ * Locate the single global SOLO_LANDING PageTemplate: templateType=SOLO_LANDING,
+ * categoryId null, isActive true. >1 match FAILS loudly (we never guess which
+ * global template to overwrite). 0 active matches also fails.
+ */
+export async function resolveGlobalSoloTemplate(db: DbClient): Promise<PageTemplateRow> {
+  const rows = await db.pageTemplate.findMany({
+    where: { templateType: "SOLO_LANDING", categoryId: null, isActive: true },
+    select: { id: true, categoryId: true, isActive: true, customHtml: true, updatedAt: true },
+  });
+  if (rows.length === 0) {
+    throw new Error(
+      "No active global SOLO_LANDING PageTemplate (templateType=SOLO_LANDING, categoryId=null, isActive=true) found.",
+    );
+  }
+  if (rows.length > 1) {
+    throw new Error(
+      `Expected exactly ONE active global SOLO_LANDING PageTemplate, found ${rows.length}: ` +
+        `${rows.map((r) => r.id).join(", ")}. Refusing to guess which to overwrite.`,
+    );
+  }
+  return rows[0];
+}
+
+export interface BuildTemplatePlanInput {
+  /** The sanitized NEW artifact (already run through sanitizeCustomHtml save-time). */
+  newSanitized: string;
+}
+
+/** Build the template-update plan (pure-ish: only the global-template lookup is DB). */
+export async function buildTemplateUpdatePlan(
+  db: DbClient,
+  input: BuildTemplatePlanInput,
+): Promise<TemplateUpdatePlan> {
+  const tpl = await resolveGlobalSoloTemplate(db);
+  const oldCustomHtml = tpl.customHtml ?? "";
+  const oldSha = sha256(oldCustomHtml);
+  const newSha = sha256(input.newSanitized);
+  return {
+    templateId: tpl.id,
+    oldSha,
+    newSha,
+    oldUpdatedAt: tpl.updatedAt,
+    oldCustomHtml,
+    newCustomHtml: input.newSanitized,
+    isNoOp: oldSha === newSha,
+  };
+}
+
+export interface ApplyTemplateDeps {
+  /** Write the template backup; returns the file path. */
+  writeBackup: (plan: TemplateUpdatePlan) => Promise<string>;
+  operator: string;
+  runId: string;
+  /** Operator-supplied expected old SHA (optional — read-then-CAS if absent). */
+  expectedOldSha?: string;
+  /** Operator-supplied expected updatedAt (optional). */
+  expectedUpdatedAt?: Date;
+}
+
+export interface ApplyTemplateResult {
+  status: "applied" | "no-op" | "cas-abort";
+  backupFile?: string;
+  reason?: string;
+}
+
+/**
+ * Apply the template update under CAS. Order: verify CAS against the captured
+ * plan + any operator-supplied expectations → back up → conditional updateMany
+ * (where id + updatedAt) → audit. A concurrent edit (count 0) is a clean abort
+ * (no clobber, no partial state).
+ */
+export async function applyTemplateUpdate(
+  db: DbClient,
+  plan: TemplateUpdatePlan,
+  deps: ApplyTemplateDeps,
+): Promise<ApplyTemplateResult> {
+  if (plan.isNoOp) {
+    return { status: "no-op", reason: "template already on the new artifact (SHA match)" };
+  }
+
+  const cas = checkTemplateCas({
+    liveUpdatedAt: plan.oldUpdatedAt,
+    liveSha: plan.oldSha,
+    expectedUpdatedAt: deps.expectedUpdatedAt,
+    expectedOldSha: deps.expectedOldSha,
+  });
+  if (!cas.ok) {
+    return { status: "cas-abort", reason: cas.reason };
+  }
+
+  const backupFile = await deps.writeBackup(plan);
+
+  const res = await db.pageTemplate.updateMany({
+    where: { id: plan.templateId, updatedAt: plan.oldUpdatedAt },
+    data: { customHtml: plan.newCustomHtml },
+  });
+  if (res.count === 0) {
+    return {
+      status: "cas-abort",
+      backupFile,
+      reason: "CAS updateMany matched 0 rows — concurrent edit since plan was built.",
+    };
+  }
+
+  await db.auditLog.create({
+    data: {
+      entityType: "PageTemplate",
+      entityId: plan.templateId,
+      action: "SOLO_LANDING_TEMPLATE_UPDATE",
+      performedBy: deps.operator,
+      changes: JSON.stringify({
+        runId: deps.runId,
+        oldSha: plan.oldSha,
+        newSha: plan.newSha,
+        backupFile,
+      }),
+    },
+  });
+
+  return { status: "applied", backupFile };
+}
+
+export interface RestoreTemplateResult {
+  status: "restored" | "cas-abort" | "no-op";
+  reason?: string;
+}
+
+/**
+ * Restore the template from a template backup, CAS-guarded on the NEW sha we
+ * wrote (so we never clobber a later legitimate edit). Audited.
+ */
+export async function restoreTemplateFromBackup(
+  db: DbClient,
+  backup: TemplateBackupFile,
+  deps: { operator: string; runId: string },
+): Promise<RestoreTemplateResult> {
+  if (backup.kind !== "solo-landing-template-update") {
+    throw new Error("Not a recognised template-update backup.");
+  }
+  const live = await db.pageTemplate.findUnique({
+    where: { id: backup.templateId },
+    select: { id: true, categoryId: true, isActive: true, customHtml: true, updatedAt: true },
+  });
+  if (!live) {
+    return { status: "cas-abort", reason: "template row no longer exists." };
+  }
+  const liveSha = sha256(live.customHtml ?? "");
+  if (liveSha === backup.oldSha) {
+    return { status: "no-op", reason: "template already on the pre-update value." };
+  }
+  if (liveSha !== backup.newSha) {
+    return {
+      status: "cas-abort",
+      reason:
+        `live template SHA ${liveSha.slice(0, 12)}… is neither the value we wrote ` +
+        `nor the pre-update value — refusing to clobber a later edit.`,
+    };
+  }
+
+  const res = await db.pageTemplate.updateMany({
+    where: { id: backup.templateId, updatedAt: live.updatedAt },
+    data: { customHtml: backup.oldCustomHtml },
+  });
+  if (res.count === 0) {
+    return { status: "cas-abort", reason: "CAS updateMany matched 0 rows during restore." };
+  }
+
+  await db.auditLog.create({
+    data: {
+      entityType: "PageTemplate",
+      entityId: backup.templateId,
+      action: "SOLO_LANDING_TEMPLATE_RESTORE",
+      performedBy: deps.operator,
+      changes: JSON.stringify({
+        runId: deps.runId,
+        restoredToSha: backup.oldSha,
+        fromSha: backup.newSha,
+      }),
+    },
+  });
+  return { status: "restored" };
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+//  Script 2 — guarded BACKFILL of existing pages
+// ════════════════════════════════════════════════════════════════════════════
+
+export interface BuildBackfillInput {
+  /** OLD global SOLO_LANDING template id (from Script 1's backup). */
+  oldGlobalTemplateId: string;
+  /** The BACKED-UP old global template customHtml (Script 1 backup). */
+  oldTemplateCustomHtml: string;
+  /** The NEW artifact HTML (explicit — NOT read from the current active template). */
+  newTemplateCustomHtml: string;
+  /** Expected production host for the CTA preflight. */
+  expectedHost: string;
+  /** Per-workshop price exceptions (workshop ids). */
+  allowPriceWorkshopIds: string[];
+  /** Canary: only this slug. */
+  slug?: string;
+  /** Batch cap on the number of CANDIDATE rows scanned. */
+  limit?: number;
+}
+
+export interface BuildBackfillResult {
+  plans: KajabiRowPlan[];
+  /** Convenience counts for the report. */
+  counts: {
+    candidates: number;
+    targets: number;
+    noops: number;
+    skips: number;
+  };
+}
+
+/**
+ * Build the per-row backfill plan. For each candidate SOLO_LANDING LandingPage:
+ *   1. resolve per-workshop facts + the two renders (old + new) via injected fns;
+ *   2. decideRow (sourceTemplateId + content match) → target / no-op / skip;
+ *   3. for TARGETs, run the coach-photo / CTA / price / new-value preflights;
+ *      any failing preflight downgrades the target to a skip with its reason.
+ */
+export async function buildBackfillPlans(
+  db: DbClient,
+  reinterpolate: Reinterpolate,
+  resolveFacts: ResolveWorkshopFacts,
+  input: BuildBackfillInput,
+): Promise<BuildBackfillResult> {
+  const where: Record<string, unknown> = { template: "SOLO_LANDING" };
+  if (input.slug) where.slug = input.slug;
+
+  const pages: LandingPageRow[] = await db.landingPage.findMany({
+    where,
+    select: {
+      id: true,
+      workshopId: true,
+      slug: true,
+      customHtml: true,
+      updatedAt: true,
+      categoryId: true,
+      sourceTemplateId: true,
+    },
+    orderBy: { createdAt: "asc" },
+    ...(input.limit !== undefined ? { take: input.limit } : {}),
+  });
+
+  const allowPrice = new Set(input.allowPriceWorkshopIds);
+  const plans: KajabiRowPlan[] = [];
+
+  for (const page of pages) {
+    const facts = await resolveFacts(page.workshopId);
+    const oldOutcome = await reinterpolate(page.workshopId, input.oldTemplateCustomHtml);
+    const newOutcome = await reinterpolate(page.workshopId, input.newTemplateCustomHtml);
+
+    // Workshop variables missing (workshop not found) → skip.
+    if (!facts || !oldOutcome || !newOutcome) {
+      plans.push(
+        makeSkipPlan(page, "no-workshop-variables", "buildWorkshopVariables returned null"),
+      );
+      continue;
+    }
+
+    const decision = decideRow({
+      currentCustomHtml: page.customHtml,
+      expectedOldRender: oldOutcome.sanitized,
+      newRender: newOutcome.sanitized,
+      sourceTemplateId: page.sourceTemplateId,
+      oldGlobalTemplateId: input.oldGlobalTemplateId,
+    });
+
+    if (decision.kind === "no-op") {
+      plans.push(makeDecisionPlan(page, newOutcome, "no-op"));
+      continue;
+    }
+    if (decision.kind === "skip") {
+      plans.push(makeSkipPlan(page, decision.reason, decision.detail));
+      continue;
+    }
+
+    // decision.kind === "target" — run the preflights against the NEW render.
+    const validation = validateNewValue(newOutcome.sanitized);
+    const sanitizerStripped =
+      newOutcome.strippedTags.length > 0 || newOutcome.strippedAttrs.length > 0;
+
+    if (!hasCoachPhoto(facts.coachProfileImage)) {
+      plans.push(makeSkipPlan(page, "missing-coach-photo", "coach.profileImage is empty"));
+      continue;
+    }
+    const cta = checkCtaPreflight({
+      registrationUrl: facts.registrationUrl,
+      expectedHost: input.expectedHost,
+      hasPublishedRegistration: facts.registrationPublished,
+      expectedRegistrationSlug: facts.registrationSlug ?? undefined,
+    });
+    if (!cta.ok) {
+      plans.push(makeSkipPlan(page, "cta-preflight-failed", cta.reason));
+      continue;
+    }
+    const price = checkPricePreflight({
+      renderedPrice: facts.renderedPrice,
+      hasExplicitException: allowPrice.has(page.workshopId),
+    });
+    if (!price.ok) {
+      plans.push(makeSkipPlan(page, "price-preflight-failed", price.reason));
+      continue;
+    }
+    if (!validation.ok) {
+      plans.push(
+        makeSkipPlan(
+          page,
+          "new-value-invalid",
+          `marker=${validation.hasDesignMarker} noUnresolved=${validation.noUnresolvedTokens}` +
+            ` cta=${validation.hasCtaHref} firstToken=${validation.firstUnresolvedToken ?? "—"}`,
+        ),
+      );
+      continue;
+    }
+
+    plans.push({
+      landingPageId: page.id,
+      workshopId: page.workshopId,
+      slug: page.slug,
+      oldSha: sha256(page.customHtml ?? ""),
+      newSha: sha256(newOutcome.sanitized),
+      oldUpdatedAt: page.updatedAt,
+      oldCustomHtml: page.customHtml ?? "",
+      newCustomHtml: newOutcome.sanitized,
+      decision: "target",
+      strippedTags: newOutcome.strippedTags,
+      strippedAttrs: newOutcome.strippedAttrs,
+      sanitizerStripped,
+      validation,
+    });
+  }
+
+  const targets = plans.filter((p) => p.decision === "target").length;
+  const noops = plans.filter((p) => p.decision === "no-op").length;
+  const skips = plans.filter((p) => p.decision === "skip").length;
+
+  return {
+    plans,
+    counts: { candidates: pages.length, targets, noops, skips },
+  };
+}
+
+function makeSkipPlan(page: LandingPageRow, reason: SkipReason, detail?: string): KajabiRowPlan {
+  return {
+    landingPageId: page.id,
+    workshopId: page.workshopId,
+    slug: page.slug,
+    oldSha: sha256(page.customHtml ?? ""),
+    newSha: "",
+    oldUpdatedAt: page.updatedAt,
+    oldCustomHtml: page.customHtml ?? "",
+    newCustomHtml: "",
+    decision: "skip",
+    skipReason: reason,
+    skipDetail: detail,
+    strippedTags: [],
+    strippedAttrs: [],
+    sanitizerStripped: false,
+    validation: validateNewValue(""),
+  };
+}
+
+function makeDecisionPlan(
+  page: LandingPageRow,
+  newOutcome: SanitizeOutcome,
+  decision: "no-op",
+): KajabiRowPlan {
+  return {
+    landingPageId: page.id,
+    workshopId: page.workshopId,
+    slug: page.slug,
+    oldSha: sha256(page.customHtml ?? ""),
+    newSha: sha256(newOutcome.sanitized),
+    oldUpdatedAt: page.updatedAt,
+    oldCustomHtml: page.customHtml ?? "",
+    newCustomHtml: newOutcome.sanitized,
+    decision,
+    strippedTags: newOutcome.strippedTags,
+    strippedAttrs: newOutcome.strippedAttrs,
+    sanitizerStripped:
+      newOutcome.strippedTags.length > 0 || newOutcome.strippedAttrs.length > 0,
+    validation: validateNewValue(newOutcome.sanitized),
+  };
+}
+
+// ─── applyBackfill ─────────────────────────────────────────────────────────────
+
+export interface ApplyBackfillResult {
+  updated: number;
+  skipped: number; // CAS aborts during apply
+  blocked: number; // sanitizer strips → whole apply blocked
+  backupFile?: string;
+}
+
+export interface ApplyBackfillDeps {
+  /** Persist the backup of the TARGET plans; returns the path. */
+  writeBackup: (targets: KajabiRowPlan[]) => Promise<string>;
+  operator: string;
+  runId: string;
+  newGlobalSha: string;
+}
+
+/**
+ * Apply only the TARGET plans. Blocks the whole apply (no writes) if any target
+ * had sanitizer strips. Backs up FIRST, then CAS-writes each row (where id +
+ * updatedAt), then writes a single AuditLog summarising the run.
+ */
+export async function applyBackfillPlans(
+  db: DbClient,
+  plans: KajabiRowPlan[],
+  deps: ApplyBackfillDeps,
+): Promise<ApplyBackfillResult> {
+  const targets = plans.filter((p) => p.decision === "target");
+  if (targets.length === 0) return { updated: 0, skipped: 0, blocked: 0 };
+
+  const stripped = targets.filter((p) => p.sanitizerStripped);
+  if (stripped.length > 0) {
+    return { updated: 0, skipped: 0, blocked: stripped.length };
+  }
+
+  const backupFile = await deps.writeBackup(targets);
+
+  let updated = 0;
+  let skipped = 0;
+  const updatedIds: string[] = [];
+  const skippedIds: string[] = [];
+  for (const p of targets) {
+    const res = await db.landingPage.updateMany({
+      where: { id: p.landingPageId, updatedAt: p.oldUpdatedAt },
+      data: { customHtml: p.newCustomHtml },
+    });
+    if (res.count === 0) {
+      skipped++;
+      skippedIds.push(p.landingPageId);
+      continue;
+    }
+    updated++;
+    updatedIds.push(p.landingPageId);
+  }
+
+  await db.auditLog.create({
+    data: {
+      entityType: "LandingPage",
+      entityId: `solo-landing-kajabi-backfill:${deps.runId}`,
+      action: "SOLO_LANDING_BACKFILL_APPLY",
+      performedBy: deps.operator,
+      changes: JSON.stringify({
+        runId: deps.runId,
+        newGlobalSha: deps.newGlobalSha,
+        backupFile,
+        updated,
+        casSkipped: skipped,
+        updatedIds,
+        skippedIds,
+        // skipped-during-targeting (non-target) IDs + reasons for the trail.
+        targetingSkips: plans
+          .filter((p) => p.decision === "skip")
+          .map((p) => ({ id: p.landingPageId, slug: p.slug, reason: p.skipReason })),
+      }),
+    },
+  });
+
+  return { updated, skipped, blocked: 0, backupFile };
+}
+
+// ─── restoreBackfill ────────────────────────────────────────────────────────────
+
+export interface RestoreBackfillResult {
+  restored: number;
+  skipped: number;
+}
+
+/**
+ * Restore old per-row values from a backfill backup. CAS-guarded: only restores
+ * a row whose CURRENT value still hashes to the newSha we wrote (nobody edited
+ * it after our apply). Audited.
+ */
+export async function restoreBackfill(
+  db: DbClient,
+  backup: KajabiBackupFile,
+  deps: { operator: string; runId: string },
+): Promise<RestoreBackfillResult> {
+  if (backup.kind !== "solo-landing-kajabi-backfill" || !Array.isArray(backup.entries)) {
+    throw new Error("Not a recognised solo-landing-kajabi backfill backup.");
+  }
+  let restored = 0;
+  let skipped = 0;
+  const restoredIds: string[] = [];
+  for (const entry of backup.entries as KajabiBackupEntry[]) {
+    const current = await db.landingPage.findUnique({
+      where: { id: entry.landingPageId },
+      select: { customHtml: true },
+    });
+    if (!current) {
+      skipped++;
+      continue;
+    }
+    const currentSha = sha256(current.customHtml ?? "");
+    if (entry.newSha && currentSha !== entry.newSha) {
+      skipped++;
+      continue;
+    }
+    await db.landingPage.update({
+      where: { id: entry.landingPageId },
+      data: { customHtml: entry.oldCustomHtml },
+    });
+    restored++;
+    restoredIds.push(entry.landingPageId);
+  }
+
+  await db.auditLog.create({
+    data: {
+      entityType: "LandingPage",
+      entityId: `solo-landing-kajabi-restore:${deps.runId}`,
+      action: "SOLO_LANDING_BACKFILL_RESTORE",
+      performedBy: deps.operator,
+      changes: JSON.stringify({
+        runId: deps.runId,
+        fromBackupRunId: backup.runId,
+        restored,
+        skipped,
+        restoredIds,
+      }),
+    },
+  });
+
+  return { restored, skipped };
+}
+
+// ─── Rollback-window inventory (Task 10) ───────────────────────────────────────
+
+export interface InventoryResult {
+  /** Pages currently carrying the new global SHA (post-patch window-aware). */
+  onNewGlobalSha: string[];
+}
+
+/**
+ * Find SOLO_LANDING pages whose CURRENT customHtml hashes to the supplied
+ * per-workshop new render. Because the new render is per-workshop, the caller
+ * supplies a predicate that, for each page, knows the expected new SHA. Here we
+ * provide the cheap variant: list all SOLO_LANDING slugs + current SHAs so the
+ * operator (or the rollback path) can identify pages created AFTER the template
+ * patch that already carry a new-design render (they won't be in any backfill
+ * backup). Documented in the runbook.
+ */
+export async function inventorySoloPages(
+  db: DbClient,
+): Promise<Array<{ id: string; slug: string; sha: string; sourceTemplateId: string | null }>> {
+  const pages: LandingPageRow[] = await db.landingPage.findMany({
+    where: { template: "SOLO_LANDING" },
+    select: {
+      id: true,
+      workshopId: true,
+      slug: true,
+      customHtml: true,
+      updatedAt: true,
+      categoryId: true,
+      sourceTemplateId: true,
+    },
+    orderBy: { createdAt: "asc" },
+  });
+  return pages.map((p) => ({
+    id: p.id,
+    slug: p.slug,
+    sha: sha256(p.customHtml ?? ""),
+    sourceTemplateId: p.sourceTemplateId,
+  }));
+}
+
+export { toKajabiBackupEntry };

--- a/src/src/lib/scripts/solo-landing-kajabi-runner.ts
+++ b/src/src/lib/scripts/solo-landing-kajabi-runner.ts
@@ -72,7 +72,7 @@ export interface DbClient {
   };
   landingPage: {
     findMany(args: unknown): Promise<LandingPageRow[]>;
-    findUnique(args: unknown): Promise<{ customHtml?: string | null } | null>;
+    findUnique(args: unknown): Promise<{ customHtml?: string | null; updatedAt?: Date } | null>;
     updateMany(args: {
       where: { id: string; updatedAt: Date };
       data: { customHtml: string };
@@ -103,10 +103,15 @@ export interface SanitizeOutcome {
  * two-pass auto-build pipeline. Injected so tests can stub it without loading
  * buildWorkshopVariables / interpolate / sanitize. Returns null when the
  * workshop has no variables (not found).
+ *
+ * Fix 3 (P2): `registrationUrl` is now passed in by the runner so the
+ * implementation can skip its own REGISTRATION lookup — avoids a duplicate
+ * db.landingPage.findUnique per workshop (resolveFacts already fetched it).
  */
 export type Reinterpolate = (
   workshopId: string,
   templateCustomHtml: string,
+  registrationUrl: string,
 ) => Promise<SanitizeOutcome | null>;
 
 /** Resolve the per-workshop preflight facts (DB-backed). Injected for tests. */
@@ -372,8 +377,10 @@ export async function buildBackfillPlans(
 
   for (const page of pages) {
     const facts = await resolveFacts(page.workshopId);
-    const oldOutcome = await reinterpolate(page.workshopId, input.oldTemplateCustomHtml);
-    const newOutcome = await reinterpolate(page.workshopId, input.newTemplateCustomHtml);
+    // Fix 3 (P2): pass the pre-resolved registrationUrl so reinterpolate can skip its own lookup.
+    const regUrl = facts?.registrationUrl ?? "";
+    const oldOutcome = await reinterpolate(page.workshopId, input.oldTemplateCustomHtml, regUrl);
+    const newOutcome = await reinterpolate(page.workshopId, input.newTemplateCustomHtml, regUrl);
 
     // Workshop variables missing (workshop not found) → skip.
     if (!facts || !oldOutcome || !newOutcome) {
@@ -615,21 +622,30 @@ export async function restoreBackfill(
   for (const entry of backup.entries as KajabiBackupEntry[]) {
     const current = await db.landingPage.findUnique({
       where: { id: entry.landingPageId },
-      select: { customHtml: true },
+      select: { customHtml: true, updatedAt: true },
     });
     if (!current) {
       skipped++;
       continue;
     }
     const currentSha = sha256(current.customHtml ?? "");
-    if (entry.newSha && currentSha !== entry.newSha) {
+    // Fix 1 (P1): fail-safe — skip unless newSha is present AND the live SHA matches it.
+    // Previously: `if (entry.newSha && currentSha !== entry.newSha) skip` which
+    // fell through to an unconditional write when newSha was falsy (corrupt backup).
+    if (!entry.newSha || currentSha !== entry.newSha) {
       skipped++;
       continue;
     }
-    await db.landingPage.update({
-      where: { id: entry.landingPageId },
+    // Fix 2 (P1): CAS on updatedAt (mirrors applyBackfillPlans) to prevent TOCTOU.
+    const res = await db.landingPage.updateMany({
+      where: { id: entry.landingPageId, updatedAt: current.updatedAt as Date },
       data: { customHtml: entry.oldCustomHtml },
     });
+    if (res.count === 0) {
+      // Concurrent edit between findUnique and updateMany — skip, do not clobber.
+      skipped++;
+      continue;
+    }
     restored++;
     restoredIds.push(entry.landingPageId);
   }

--- a/src/src/lib/scripts/solo-landing-kajabi-runner.ts
+++ b/src/src/lib/scripts/solo-landing-kajabi-runner.ts
@@ -671,22 +671,21 @@ export async function restoreBackfill(
 // ─── Rollback-window inventory (Task 10) ───────────────────────────────────────
 
 export interface InventoryResult {
-  /** Pages currently carrying the new global SHA (post-patch window-aware). */
-  onNewGlobalSha: string[];
+  id: string;
+  slug: string;
+  sha: string;
+  sourceTemplateId: string | null;
 }
 
 /**
- * Find SOLO_LANDING pages whose CURRENT customHtml hashes to the supplied
- * per-workshop new render. Because the new render is per-workshop, the caller
- * supplies a predicate that, for each page, knows the expected new SHA. Here we
- * provide the cheap variant: list all SOLO_LANDING slugs + current SHAs so the
- * operator (or the rollback path) can identify pages created AFTER the template
- * patch that already carry a new-design render (they won't be in any backfill
- * backup). Documented in the runbook.
+ * List every SOLO_LANDING page with its current customHtml SHA + sourceTemplateId,
+ * so the operator (or the rollback path) can identify pages created AFTER the
+ * template patch that already carry a new-design render — these won't be in any
+ * backfill backup. Documented in the runbook (Task 10, rollout-window inventory).
  */
 export async function inventorySoloPages(
   db: DbClient,
-): Promise<Array<{ id: string; slug: string; sha: string; sourceTemplateId: string | null }>> {
+): Promise<InventoryResult[]> {
   const pages: LandingPageRow[] = await db.landingPage.findMany({
     where: { template: "SOLO_LANDING" },
     select: {

--- a/src/src/lib/scripts/solo-landing-kajabi-runner.ts
+++ b/src/src/lib/scripts/solo-landing-kajabi-runner.ts
@@ -72,7 +72,7 @@ export interface DbClient {
   };
   landingPage: {
     findMany(args: unknown): Promise<LandingPageRow[]>;
-    findUnique(args: unknown): Promise<{ customHtml?: string | null; updatedAt?: Date } | null>;
+    findUnique(args: unknown): Promise<{ customHtml?: string | null; updatedAt: Date } | null>;
     updateMany(args: {
       where: { id: string; updatedAt: Date };
       data: { customHtml: string };
@@ -623,7 +623,10 @@ export async function restoreBackfill(
       where: { id: entry.landingPageId },
       select: { customHtml: true, updatedAt: true },
     });
-    if (!current) {
+    if (!current || current.updatedAt == null) {
+      // Defense-in-depth: a missing record OR a missing updatedAt must skip.
+      // A CAS on `updatedAt: undefined` would let Prisma drop the filter and
+      // reduce the guard to `where:{id}` only, clobbering a legitimately-edited page.
       skipped++;
       continue;
     }
@@ -637,7 +640,7 @@ export async function restoreBackfill(
     }
     // Fix 2 (P1): CAS on updatedAt (mirrors applyBackfillPlans) to prevent TOCTOU.
     const res = await db.landingPage.updateMany({
-      where: { id: entry.landingPageId, updatedAt: current.updatedAt as Date },
+      where: { id: entry.landingPageId, updatedAt: current.updatedAt },
       data: { customHtml: entry.oldCustomHtml },
     });
     if (res.count === 0) {


### PR DESCRIPTION
Closes Jeff's June-8 ask: *"get the master class landing page to look as close to this the kajabi page as you can … help me generate the code."*

## What this is
A new **global SOLO_LANDING** custom-HTML block (TEMPLATE-02) modeled on the Kajabi master-class page (`scalingupus.mykajabi.com/...claire-mula`): white editorial layout, Fira Sans / Open Sans, four-color SU hero + coach card, **About / What's Included / Why Attend**, callout, price + blue **Register Here** buy-bar, dark footer. Token-driven, **generic + format-neutral** (it's the global solo-landing template — every single-coach workshop), `.su-mc`-scoped (no global leak).

Artifact: [`docs/specs/master-class-landing-kajabi.html`](docs/specs/master-class-landing-kajabi.html) (single source of truth; tests load it). Spec + 15-task plan in `docs/specs/master-class-landing-kajabi*.md`.

## Why it's mostly tooling
The HTML is the easy part; the risk is propagating it across **every public solo landing page**. Hardened via `/grill-with-docs` + a **3-round claudex/Codex adversarial review** (senior-eng / security / ops). The review caught two flaws and they're fixed here:
- targeting by **per-workshop re-render of the old template** (the interpolated `LandingPage.customHtml` never equals the raw template hash — a raw-hash gate would skip every row);
- coach photo stays an `<img src>` (a `background-image:url('{{token}}')` would be a CSS-injection vector — sanitizer passes `style` through unparsed).

## Contents
- **Guard tests (48):** sanitize survives (no `<svg>`/`<link>`/`<iframe>`, `@import`/tokens kept), interpolate + strict re-sanitize (https survives, `javascript:` stripped from href **and** img src), empty-data degrade, render-path, artifact↔spec sync, fonts/responsive/icon presence.
- **Guarded migration tooling:** CAS-guarded `update-solo-landing-template.ts` + `backfill-solo-landing-kajabi.ts` (per-workshop old-render targeting + `--expect-count`, CTA preflight [absolute-https-prod-host + published REGISTRATION], coach-photo + price preflights, `--slug` canary, `--limit` batch, `AuditLog` on every mutation, JSON backup, dry-run/apply/restore). Prod-guarded; reversible.
- **Operator runbook:** `docs/runbooks/solo-landing-kajabi-rollout.md` (canary → cohort → full + rollback).

## Tests / build
180 tests across 7 suites green; ESLint clean; `CI=true npx next build --turbopack` clean. No schema migration, no new API route, no runtime code change.

## Rollout (after merge, separate confirmed step)
Canary-first: update the global template → dry-run inventory → `--slug` the Martin Segnitz page → verify → cohort → full backfill. Not run by this PR.

## Known residuals (surfaced in dry-run reports, not blockers)
- Rollout-window: workshops approved between template-update and full backfill aren't in the backfill backup (mitigate w/ approval-freeze or `--inventory`).
- Empty coach-photo rows are **skipped** by preflight (consider a platform default-avatar before broad rollout).
- Price preflight assumes `buildWorkshopVariables` stays the `{{price}}` source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a global `SOLO_LANDING` Kajabi-style landing template (`TEMPLATE-02`) together with guarded migration tooling — Script 1 (CAS-protected template update) and Script 2 (per-workshop backfill with targeting, preflights, backup, audit, and restore). All three previously-flagged P1 issues from prior review rounds are addressed in this version: the fail-safe `entry.newSha` CAS guard in `restoreBackfill`, the `updateMany`-on-`updatedAt` TOCTOU fix, and the `updatedAt: Date` addition to `DbClient.landingPage.findUnique`.

- **Template + targeting**: 176-line Kajabi-faithful HTML artifact (`.su-mc`-scoped, token-driven, coach-photo as `<img src>` not `background-image`); targeting computes a per-workshop re-render of the backed-up old template and compares SHAs — correct approach for interpolated snapshots.
- **Safety guards**: `--expect-count` gate, sanitizer-strip block on apply, CTA/price/coach-photo/new-value preflights per target row, prod guard (`ASSESSMENT_PROD_EXPECTED_HOST` + `--i-know-this-is-prod`), backup-before-write, and CAS `updateMany` on every write path.
- **Test coverage**: 48 guard tests across 7 suites covering both scripts, every preflight variant, corrupt-backup handling, TOCTOU scenarios, and artifact-sanitize assertions.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the migration tooling is operator-run, not on the live request path, and carries multiple layers of production guards that prevent accidental or destructive writes.

All three previously-flagged issues in restoreBackfill (fail-open CAS guard, TOCTOU between read and write, missing updatedAt in the DB interface) are fully resolved. The apply and restore paths now match in safety: updateMany with where: { id, updatedAt } on every write, fail-safe newSha guard before any restore write, and an explicit updatedAt == null defense-in-depth check. Preflights (CTA, price, coach photo, new-value validity, sanitizer strips) give operators clear signals before any page is touched. The only finding is a minor efficiency nit — two extra buildWorkshopVariables calls per workshop that can't be found, which does not affect correctness.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/src/lib/scripts/solo-landing-kajabi-runner.ts | Core orchestration: CAS/TOCTOU fixes from previous review threads are fully applied — fail-safe entry.newSha guard, updateMany on updatedAt in restore, and updatedAt: Date added to the DbClient.landingPage.findUnique return type. |
| src/src/lib/scripts/solo-landing-kajabi-core.ts | Pure helpers for targeting, preflights, CAS, and arg parsing — side-effect-free and deterministic; no new issues found. |
| src/scripts/backfill-solo-landing-kajabi.ts | CLI wrapper for Script 2: prod guard, per-workshop fact resolution, two-pass render/sanitize, expected-count gate, and CAS backup-before-write; Fix 3 eliminates the duplicate REGISTRATION findUnique per workshop. |
| src/scripts/update-solo-landing-template.ts | Script 1 (template CAS update): prod guard, sanitize-before-write assertion, CAS updateMany on updatedAt, audit log — no issues found. |
| src/src/__tests__/scripts/solo-landing-kajabi-runner.test.ts | 613-line suite covering apply/restore CAS paths, corrupt-backup guard (Fix 1), TOCTOU guard (Fix 2), sanitizer-strip block, and audit trail verification — well-targeted. |
| src/src/__tests__/scripts/solo-landing-kajabi-core.test.ts | 363-line pure-logic tests covering targeting decisions, all preflight variants, expected-count gate, and arg parsing — good coverage. |
| docs/specs/master-class-landing-kajabi.html | Artifact HTML template: uses data-su-mc scoping, {{token}} placeholders for coach photo as img src (not background-image), and a class=btn href={{registration_url}} — design-marker and CTA invariants match the test suite. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Operator CLI] --> B{Mode?}
    B -->|dry-run| C[buildBackfillPlans]
    B -->|apply| D[Prod Guard Check]
    B -->|restore| E[Prod Guard Check]
    B -->|--inventory| F[inventorySoloPages]

    D --> G[buildBackfillPlans]
    G --> H[Per-page loop]
    H --> I[resolveFacts]
    I --> J[reinterpolate x2 old + new template]
    J --> K[decideRow SHA comparison]
    K -->|no-op| L[Report only]
    K -->|skip| L
    K -->|target| M[Run Preflights coach photo / CTA / price / validation]
    M -->|fail| L
    M -->|pass| N[KajabiRowPlan TARGET]

    G --> O{--expect-count gate}
    O -->|mismatch| P[Abort]
    O -->|match| Q[applyBackfillPlans]
    Q --> R{Any sanitizerStripped?}
    R -->|yes| S[Block all writes]
    R -->|no| T[writeBackup JSON]
    T --> U[updateMany CAS where id + updatedAt]
    U --> V[AuditLog create]

    E --> W[restoreBackfill]
    W --> X[findUnique per entry]
    X --> Y{entry.newSha and currentSha == newSha?}
    Y -->|no| Z[skip no clobber]
    Y -->|yes| AA[updateMany CAS where id + updatedAt]
    AA --> AB[AuditLog create]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fsrc%2Flib%2Fscripts%2Fsolo-landing-kajabi-runner.ts%3A378-385%0AWhen%20%60resolveFacts%60%20returns%20%60null%60%20%28workshop%20not%20found%29%2C%20%60reinterpolate%60%20is%20still%20called%20twice%20before%20the%20null%20check%20fires.%20Each%20call%20internally%20invokes%20%60buildWorkshopVariables%60%2C%20adding%20two%20unnecessary%20DB%20round-trips%20per%20missing%20workshop.%20Early-exiting%20when%20%60facts%60%20is%20null%20avoids%20these%20wasted%20queries.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20facts%20%3D%20await%20resolveFacts%28page.workshopId%29%3B%0A%20%20%20%20%2F%2F%20Fix%203%20%28P2%29%3A%20pass%20the%20pre-resolved%20registrationUrl%20so%20reinterpolate%20can%20skip%20its%20own%20lookup.%0A%20%20%20%20if%20%28!facts%29%20%7B%0A%20%20%20%20%20%20plans.push%28%0A%20%20%20%20%20%20%20%20makeSkipPlan%28page%2C%20%22no-workshop-variables%22%2C%20%22buildWorkshopVariables%20returned%20null%22%29%2C%0A%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20continue%3B%0A%20%20%20%20%7D%0A%20%20%20%20const%20regUrl%20%3D%20facts.registrationUrl%3B%0A%20%20%20%20const%20oldOutcome%20%3D%20await%20reinterpolate%28page.workshopId%2C%20input.oldTemplateCustomHtml%2C%20regUrl%29%3B%0A%20%20%20%20const%20newOutcome%20%3D%20await%20reinterpolate%28page.workshopId%2C%20input.newTemplateCustomHtml%2C%20regUrl%29%3B%0A%0A%20%20%20%20%2F%2F%20Workshop%20variables%20missing%20%28workshop%20not%20found%29%20%E2%86%92%20skip.%0A%20%20%20%20if%20%28!oldOutcome%20%7C%7C%20!newOutcome%29%20%7B%0A%60%60%60%0A%0A&repo=jcbdelo26%2Fscaling-up-platform-v2&pr=42&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (10): Last reviewed commit: ["fix(landing): harden restore CAS — requi..."](https://github.com/jcbdelo26/scaling-up-platform-v2/commit/c09218622d8ae8a9e77a4afdfb534bc8c192a3c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36379199)</sub>

<!-- /greptile_comment -->