### PR TITLE
fix(landing): target SOLO_LANDING backfill by design-hash (drop stale sourceTemplateId pre-filter)

### DIFF
--- a/src/src/__tests__/scripts/solo-landing-kajabi-core.test.ts
+++ b/src/src/__tests__/scripts/solo-landing-kajabi-core.test.ts
@@ -45,8 +45,6 @@ const OLD_TEMPLATE = `<div class="old-design">Old · {{coach_name}} · {{registr
 const NEW_TEMPLATE = `<div class="su-mc" ${NEW_DESIGN_MARKER}>New · {{coach_name}} · <a class="btn" href="{{registration_url}}">Register Here</a></div>`;
 
 describe("targeting: decideRow", () => {
-  const oldGlobalTemplateId = "tpl-old-global";
-
   it("TARGET when current customHtml == per-workshop OLD render", () => {
     const vars = { coach_name: "Ada Lovelace", registration_url: `https://${EXPECTED_HOST}/workshop/ada-reg` };
     const oldRender = fakeRender(OLD_TEMPLATE, vars);
@@ -55,8 +53,7 @@ describe("targeting: decideRow", () => {
       currentCustomHtml: oldRender,
       expectedOldRender: oldRender,
       newRender,
-      sourceTemplateId: oldGlobalTemplateId,
-      oldGlobalTemplateId,
+      sourceTemplateId: "tpl-old-global",
     });
     expect(d.kind).toBe("target");
   });
@@ -70,7 +67,6 @@ describe("targeting: decideRow", () => {
       expectedOldRender: oldRender,
       newRender,
       sourceTemplateId: null,
-      oldGlobalTemplateId,
     });
     expect(d.kind).toBe("no-op");
   });
@@ -82,7 +78,6 @@ describe("targeting: decideRow", () => {
       expectedOldRender: fakeRender(OLD_TEMPLATE, vars),
       newRender: fakeRender(NEW_TEMPLATE, vars),
       sourceTemplateId: null,
-      oldGlobalTemplateId,
     });
     expect(d.kind).toBe("skip");
     if (d.kind === "skip") expect(d.reason).toBe("bespoke-or-category-scoped");
@@ -99,8 +94,7 @@ describe("targeting: decideRow", () => {
       currentCustomHtml: oldRender,
       expectedOldRender: oldRender,
       newRender: fakeRender(NEW_TEMPLATE, vars),
-      sourceTemplateId: "tpl-stale-standard", // stale FK — doesn't match oldGlobalTemplateId
-      oldGlobalTemplateId,
+      sourceTemplateId: "tpl-stale-standard", // stale FK — informational only; design-hash is authoritative
     });
     expect(d.kind).toBe("target");
   });
@@ -111,7 +105,6 @@ describe("targeting: decideRow", () => {
       expectedOldRender: "x",
       newRender: "y",
       sourceTemplateId: null,
-      oldGlobalTemplateId,
     });
     expect(d.kind).toBe("skip");
     if (d.kind === "skip") expect(d.reason).toBe("empty-current-customhtml");
@@ -130,7 +123,6 @@ describe("targeting: decideRow", () => {
 
     // And each workshop's row is correctly targeted against ITS OWN old render,
     // while a cross-applied old render would NOT match (proving per-workshop hashing).
-    const oldGlobalTemplateId = "tpl-old-global";
     const adaNew = fakeRender(NEW_TEMPLATE, {
       coach_name: "Ada Lovelace",
       registration_url: `https://${EXPECTED_HOST}/workshop/ada-reg`,
@@ -140,7 +132,6 @@ describe("targeting: decideRow", () => {
       expectedOldRender: adaOld,
       newRender: adaNew,
       sourceTemplateId: null,
-      oldGlobalTemplateId,
     });
     expect(adaCorrect.kind).toBe("target");
 
@@ -149,7 +140,6 @@ describe("targeting: decideRow", () => {
       expectedOldRender: turingOld, // wrong workshop's render
       newRender: adaNew,
       sourceTemplateId: null,
-      oldGlobalTemplateId,
     });
     expect(adaWrong.kind).toBe("skip");
   });

--- a/src/src/__tests__/scripts/solo-landing-kajabi-core.test.ts
+++ b/src/src/__tests__/scripts/solo-landing-kajabi-core.test.ts
@@ -88,19 +88,21 @@ describe("targeting: decideRow", () => {
     if (d.kind === "skip") expect(d.reason).toBe("bespoke-or-category-scoped");
   });
 
-  it("SKIP when sourceTemplateId points at a DIFFERENT template (category-scoped)", () => {
+  it("TARGET when sourceTemplateId is stale/mismatched but current customHtml == expectedOldRender", () => {
+    // Prod reality: every existing SOLO_LANDING page has a stale sourceTemplateId
+    // (points at an empty "Standard" template) even when the page renders the old
+    // global design. Design-hash match is the authoritative signal; sourceTemplateId
+    // is informational only and must NOT block a real target.
     const vars = { coach_name: "Ada", registration_url: `https://${EXPECTED_HOST}/workshop/ada-reg` };
     const oldRender = fakeRender(OLD_TEMPLATE, vars);
     const d = decideRow({
-      // even if the CONTENT happens to match the old render, a foreign source wins.
       currentCustomHtml: oldRender,
       expectedOldRender: oldRender,
       newRender: fakeRender(NEW_TEMPLATE, vars),
-      sourceTemplateId: "tpl-category-scoped",
+      sourceTemplateId: "tpl-stale-standard", // stale FK — doesn't match oldGlobalTemplateId
       oldGlobalTemplateId,
     });
-    expect(d.kind).toBe("skip");
-    if (d.kind === "skip") expect(d.reason).toBe("source-template-mismatch");
+    expect(d.kind).toBe("target");
   });
 
   it("SKIP empty current customHtml", () => {

--- a/src/src/__tests__/scripts/solo-landing-kajabi-runner.test.ts
+++ b/src/src/__tests__/scripts/solo-landing-kajabi-runner.test.ts
@@ -415,7 +415,10 @@ describe("Script 2 — buildBackfillPlans targeting + preflights", () => {
     expect(withException.plans[0].decision).toBe("target");
   });
 
-  it("skips a row whose sourceTemplateId points at a different template", async () => {
+  it("targets a row whose sourceTemplateId is stale/mismatched when content matches old design", async () => {
+    // Stale sourceTemplateId no longer gates targeting — design-hash match is
+    // the authoritative signal.  A page with a mismatched FK but old-design
+    // content is a real target and must NOT be skipped.
     const { db } = backfillDb([
       {
         id: "lp1",
@@ -424,11 +427,11 @@ describe("Script 2 — buildBackfillPlans targeting + preflights", () => {
         customHtml: render(OLD_TPL, WS.ws1),
         updatedAt: new Date(),
         categoryId: "cat-x",
-        sourceTemplateId: "tpl-category-scoped",
+        sourceTemplateId: "tpl-stale-standard", // stale FK — doesn't match oldGlobalTemplateId
       },
     ]);
     const { plans } = await buildBackfillPlans(db, injectedReinterpolate(), injectedFacts(), baseInput);
-    expect(plans[0].skipReason).toBe("source-template-mismatch");
+    expect(plans[0].decision).toBe("target");
   });
 });
 

--- a/src/src/lib/scripts/solo-landing-kajabi-core.ts
+++ b/src/src/lib/scripts/solo-landing-kajabi-core.ts
@@ -258,7 +258,6 @@ export function hasCoachPhoto(profileImage: string | null | undefined): boolean 
 
 export type SkipReason =
   | "bespoke-or-category-scoped" // current customHtml != expected old render
-  | "source-template-mismatch" // sourceTemplateId != old global template id
   | "missing-coach-photo"
   | "cta-preflight-failed"
   | "price-preflight-failed"
@@ -291,18 +290,23 @@ export interface TargetingInput {
 /**
  * Decide whether a single SOLO_LANDING LandingPage row is a backfill TARGET.
  *
- * Targeting precisely (claudex R2-High1, R3-High1):
+ * Targeting is based entirely on design-hash matching (claudex R2-High1, R3-High1):
  *   1. If the row has no current customHtml → SKIP (nothing to compare/replace).
- *   2. If sourceTemplateId is set AND != the old global template id → SKIP
- *      (this page was cloned from a DIFFERENT template — bespoke/category).
- *      A null sourceTemplateId is permitted (legacy rows) and falls through to
- *      the content check, which is the authoritative signal.
- *   3. Compute sha(currentCustomHtml). If it equals sha(newRender) → NO-OP
+ *   2. Compute sha(currentCustomHtml). If it equals sha(newRender) → NO-OP
  *      (already on the new design — idempotent).
- *   4. If it equals sha(expectedOldRender) → TARGET (still on the old global
+ *   3. If it equals sha(expectedOldRender) → TARGET (still on the old global
  *      design rendered for THIS workshop).
- *   5. Otherwise → SKIP "bespoke-or-category-scoped" (hand-edited / different
+ *   4. Otherwise → SKIP "bespoke-or-category-scoped" (hand-edited / different
  *      design — we must NEVER clobber it).
+ *
+ * NOTE: sourceTemplateId is intentionally NOT used as a gate. Prod investigation
+ * found every existing SOLO_LANDING LandingPage has a stale sourceTemplateId
+ * (all point at an empty "Standard" template) even when the page actually renders
+ * the old global design. Gating on sourceTemplateId therefore wrongly skips real
+ * targets. The design-hash match against the per-workshop expectedOldRender is
+ * the authoritative, safe signal — it prevents clobbering bespoke pages without
+ * the false-negative of a stale FK. sourceTemplateId is kept on TargetingInput
+ * for operator visibility in the per-row report only.
  *
  * The preflights (coach photo / CTA / price / new-value validity) are applied by
  * the runner AFTER a row is decided a TARGET; they can downgrade a target to a
@@ -312,18 +316,6 @@ export function decideRow(input: TargetingInput): RowDecision {
   const current = input.currentCustomHtml;
   if (!current || current.trim().length === 0) {
     return { kind: "skip", reason: "empty-current-customhtml" };
-  }
-
-  if (
-    input.sourceTemplateId &&
-    input.sourceTemplateId.trim().length > 0 &&
-    input.sourceTemplateId !== input.oldGlobalTemplateId
-  ) {
-    return {
-      kind: "skip",
-      reason: "source-template-mismatch",
-      detail: `sourceTemplateId=${input.sourceTemplateId} != old global ${input.oldGlobalTemplateId}`,
-    };
   }
 
   const currentSha = sha256(current);

--- a/src/src/lib/scripts/solo-landing-kajabi-core.ts
+++ b/src/src/lib/scripts/solo-landing-kajabi-core.ts
@@ -283,8 +283,6 @@ export interface TargetingInput {
   newRender: string;
   /** This LandingPage row's sourceTemplateId (may be null on legacy rows). */
   sourceTemplateId: string | null | undefined;
-  /** The OLD global SOLO_LANDING PageTemplate id (from Script 1's backup). */
-  oldGlobalTemplateId: string;
 }
 
 /**

--- a/src/src/lib/scripts/solo-landing-kajabi-runner.ts
+++ b/src/src/lib/scripts/solo-landing-kajabi-runner.ts
@@ -394,7 +394,6 @@ export async function buildBackfillPlans(
       expectedOldRender: oldOutcome.sanitized,
       newRender: newOutcome.sanitized,
       sourceTemplateId: page.sourceTemplateId,
-      oldGlobalTemplateId: input.oldGlobalTemplateId,
     });
 
     if (decision.kind === "no-op") {


### PR DESCRIPTION
Follow-on to #42. A read-only prod investigation (canary dry-run) found that **every** existing SOLO_LANDING `LandingPage` carries a stale `sourceTemplateId` — all point at an empty "Standard" template, even the pages that actually render the "TEST"/"E&V" design. So the backfill's `sourceTemplateId` hard-skip ("source-template-mismatch") wrongly skipped real targets (it skipped the live Martin page).

## Change
- `decideRow`: removed the `sourceTemplateId` pre-filter. Targeting is now **purely the per-workshop design-hash match** — a page is a `target` only if its current `customHtml` EXACTLY equals the OLD template re-rendered for that workshop; `no-op` if it equals the NEW render; otherwise `bespoke-or-category-scoped` skip. The hash match alone prevents clobbering (a page on any other design won't match), so the sourceTemplateId gate was redundant + harmful given stale prod data.
- `sourceTemplateId` kept on the report row (informational), no longer gates.
- Removed `source-template-mismatch` from `SkipReason`.
- Tests: a stale/mismatched `sourceTemplateId` with a matching old-design render now correctly **targets**.

## Tests / build
59/59 solo-landing tests green; ESLint clean; `CI=true npx next build --turbopack` clean. No schema/runtime change.

## Context
Prod has 4 experimental SOLO_LANDING templates (active one named "TEST") and only 2 of 6 pages carry a real design; the local prod env's `APP_URL` is also stale (localhost) — both tracked separately before the actual canary apply. This PR only fixes the targeting logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the `sourceTemplateId` pre-filter from `decideRow` after a prod investigation confirmed that every existing `SOLO_LANDING` `LandingPage` carries a stale `sourceTemplateId` (all pointing at an empty "Standard" template), causing the backfill to incorrectly skip real targets. Targeting is now driven exclusively by a per-workshop design-hash match against `expectedOldRender`.

- **Core logic change**: Deleted the `sourceTemplateId !== oldGlobalTemplateId` gate and the `source-template-mismatch` skip reason; the SHA comparison against `expectedOldRender` is now the sole arbiter of whether a page is on the old global design.
- **Tests updated**: The previous \"skip on FK mismatch\" test is replaced with \"target when FK is stale but content matches old render,\" covering the exact prod scenario that caused the false-negative skip.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the hash-based targeting is strictly more precise than the removed FK check, and all 59 tests pass against the updated behavior.

The removal of the sourceTemplateId gate is well-justified and the design-hash approach correctly handles the stale-FK prod reality. The only loose end is that oldGlobalTemplateId remains on TargetingInput but is no longer consulted anywhere inside decideRow, leaving its presence undocumented.

src/src/lib/scripts/solo-landing-kajabi-core.ts — specifically the oldGlobalTemplateId field on TargetingInput now that it is unused within decideRow.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/src/lib/scripts/solo-landing-kajabi-core.ts | Removed sourceTemplateId gate and source-template-mismatch SkipReason; decideRow now targets purely on hash match. oldGlobalTemplateId remains on TargetingInput but is no longer referenced inside decideRow. |
| src/src/__tests__/scripts/solo-landing-kajabi-core.test.ts | Updated the source-template-mismatch test to verify the new behavior (target when FK is stale but content matches); all other targeting invariants remain covered. |
| src/src/__tests__/scripts/solo-landing-kajabi-runner.test.ts | Runner-level integration test updated to expect decision: target instead of skipReason: source-template-mismatch for a stale-FK row with matching content. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[decideRow called] --> B{currentCustomHtml empty?}
    B -- yes --> C[SKIP: empty-current-customhtml]
    B -- no --> D[sha = SHA-256 of currentCustomHtml]
    D --> E{sha == SHA-256 of newRender?}
    E -- yes --> F[NO-OP: already on new design]
    E -- no --> G{sha == SHA-256 of expectedOldRender?}
    G -- yes --> H[TARGET: still on old global design]
    G -- no --> I[SKIP: bespoke-or-category-scoped]
    style C fill:#f99,stroke:#c33
    style F fill:#fc9,stroke:#c90
    style H fill:#9f9,stroke:#090
    style I fill:#f99,stroke:#c33
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/src/lib/scripts/solo-landing-kajabi-core.ts`, line 287-288 ([link](https://github.com/jcbdelo26/scaling-up-platform-v2/blob/5ad308e6beaa148e820813600e9d8332455e8653/src/src/lib/scripts/solo-landing-kajabi-core.ts#L287-L288)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`oldGlobalTemplateId` is now dead inside `decideRow`**

   The only place `oldGlobalTemplateId` was read in `decideRow` was the removed `sourceTemplateId !== input.oldGlobalTemplateId` comparison. The field remains on `TargetingInput` with no usage in the function. The PR comment explains why `sourceTemplateId` is kept (operator reporting), but doesn't address `oldGlobalTemplateId`. If the runner still uses this value independently (e.g. for backup metadata), a short comment here would clarify the intent; if it's genuinely unused anywhere post-removal, the field can be dropped to avoid confusion for future readers.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fsrc%2Flib%2Fscripts%2Fsolo-landing-kajabi-core.ts%0ALine%3A%20287-288%0A%0AComment%3A%0A**%60oldGlobalTemplateId%60%20is%20now%20dead%20inside%20%60decideRow%60**%0A%0AThe%20only%20place%20%60oldGlobalTemplateId%60%20was%20read%20in%20%60decideRow%60%20was%20the%20removed%20%60sourceTemplateId%20!%3D%3D%20input.oldGlobalTemplateId%60%20comparison.%20The%20field%20remains%20on%20%60TargetingInput%60%20with%20no%20usage%20in%20the%20function.%20The%20PR%20comment%20explains%20why%20%60sourceTemplateId%60%20is%20kept%20%28operator%20reporting%29%2C%20but%20doesn't%20address%20%60oldGlobalTemplateId%60.%20If%20the%20runner%20still%20uses%20this%20value%20independently%20%28e.g.%20for%20backup%20metadata%29%2C%20a%20short%20comment%20here%20would%20clarify%20the%20intent%3B%20if%20it's%20genuinely%20unused%20anywhere%20post-removal%2C%20the%20field%20can%20be%20dropped%20to%20avoid%20confusion%20for%20future%20readers.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=jcbdelo26%2Fscaling-up-platform-v2&pr=43&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fsrc%2Flib%2Fscripts%2Fsolo-landing-kajabi-core.ts%3A287-288%0A**%60oldGlobalTemplateId%60%20is%20now%20dead%20inside%20%60decideRow%60**%0A%0AThe%20only%20place%20%60oldGlobalTemplateId%60%20was%20read%20in%20%60decideRow%60%20was%20the%20removed%20%60sourceTemplateId%20!%3D%3D%20input.oldGlobalTemplateId%60%20comparison.%20The%20field%20remains%20on%20%60TargetingInput%60%20with%20no%20usage%20in%20the%20function.%20The%20PR%20comment%20explains%20why%20%60sourceTemplateId%60%20is%20kept%20%28operator%20reporting%29%2C%20but%20doesn't%20address%20%60oldGlobalTemplateId%60.%20If%20the%20runner%20still%20uses%20this%20value%20independently%20%28e.g.%20for%20backup%20metadata%29%2C%20a%20short%20comment%20here%20would%20clarify%20the%20intent%3B%20if%20it's%20genuinely%20unused%20anywhere%20post-removal%2C%20the%20field%20can%20be%20dropped%20to%20avoid%20confusion%20for%20future%20readers.%0A%0A&repo=jcbdelo26%2Fscaling-up-platform-v2&pr=43&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(landing): target backfill by design-..."](https://github.com/jcbdelo26/scaling-up-platform-v2/commit/5ad308e6beaa148e820813600e9d8332455e8653) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36429888)</sub>

<!-- /greptile_comment -->