### PR TITLE
docs(assessments): category-totals / Five Dysfunctions + Scaling Up Quick Assessment specs + ADR-0008

### DIFF
--- a/docs/adr/0008-public-self-assessments-show-taker-results.md
+++ b/docs/adr/0008-public-self-assessments-show-taker-results.md
@@ -1,0 +1,22 @@
+# ADR-0008 — Public self-assessments show the taker their own results
+
+**Status:** Accepted (planned — applies when the public Scaling Up Quick Assessment, Spec 15, is built). Not yet implemented.
+
+## Context
+The platform's invited-assessment flow **deliberately does not show respondents their own results** — results are delivered by the coach/facilitator, and auto-emailing results to respondents was explicitly deferred (the MVP "D3" policy; the public thank-you page says *"your facilitator will follow up with the results"*). The branded results report is **coach/admin-gated** (`getRespondentReport` requires `canManageCampaign`).
+
+The **Scaling Up Quick Assessment** (Spec 15) is a different beast: a **public, free, self-assessment lead magnet**. The taker's entire incentive to complete it is seeing **their own 4-Decisions scores** immediately, and the source tool (scalinguptoolkit.com/s/ScaleUpQA) shows results to the taker on the spot. Applying the invited policy (bare thank-you, coach follows up) would gut the tool's purpose.
+
+## Decision
+For **PUBLIC self-assessments only**, show the taker **their own results immediately**:
+- The submit POST returns the taker's `ScoreResult` in its response; the client renders the per-category (4 Decisions) results + insight **in-place**.
+- **No persistent public results endpoint / URL / token** — results are shown once, from the submit response, so there is nothing to enumerate or leak.
+- **INVITED campaigns are unchanged** — they keep the coach-delivered, gated-results policy. The divergence is explicit: PUBLIC = self-serve results to the taker; INVITED = coach-gated.
+- The submit response carrying `ScoreResult` must be served **`Cache-Control: no-store`** (it contains the taker's PII + scores) and the result return is **audited** (claudex R2) — see Spec 15 §5c.
+
+## Consequences
+- **+** Restores the lead-magnet value (the taker gets immediate value; the reason the tool "gets a lot of use").
+- **+** Privacy-safe: the taker only ever sees their own answers/score, returned to the same client that submitted them — no GET-by-id results surface to secure.
+- **−** A deliberate, permanent fork in behaviour between PUBLIC and INVITED flows that must stay clear in code + UX (a future reader will wonder why public takers see results when invited ones don't — this ADR is the answer).
+- **−** New work vs the shipped MVP: a respondent-facing results render (the MVP intentionally shipped none).
+- Coach/SU lead routing is handled separately (guarded email on submit; see Spec 15) and is independent of this taker-facing decision.

--- a/docs/specs/v7.6/14-totals-by-category-and-five-dysfunctions.md
+++ b/docs/specs/v7.6/14-totals-by-category-and-five-dysfunctions.md
@@ -1,0 +1,76 @@
+# Spec 14 — Totals by Category + Five Dysfunctions assessment
+
+Status: **plan / contingency** ("just in case" per Jeff's Slack). No build, no DB writes until approved. Assessment-domain; sits in the v7.6 spec library. Engine: `src/src/lib/assessments/scoring.ts`.
+
+## 1. Context (Jeff's asks)
+- **June, 8:40 AM:** "Does the current setup for assessments allow me to do **totals by category**?" — pointing at the **Five Dysfunctions of a Team** team-assessment (Lencioni / Pfeiffer / Wiley, ISBN 0-7879-8618-6). Gabriel replied "checking this now" → this spec closes that.
+- **Escalation (later):** "Ultimately we are going to want the **5 dysfunctions exactly like they have it in their toolset**" (the Esperto / Scaling Up Toolkit version).
+
+## 2. Finding — the platform ALREADY does totals by category
+The scorer emits per-category subtotals today:
+- `ScoreResult.perSection[]` — always (each section: `totalPoints`, `averagePoints`, `achievedCount`, `totalCount`).
+- `ScoreResult.perDomain[]` — when a template groups sections into `domains[]`; each domain carries `averagePoints` + a resolved `tier` (band).
+- The branded results report renders per-section/per-domain breakdowns.
+
+**Live proof:** Scaling Up Full already scores the **4 Decisions** (People / Strategy / Execution / Cash) as domains, each with its own subtotal + band. That *is* totals-by-category.
+
+## 3. Phase 1 — the answer for Jeff (no build)
+Relay to Jeff (paste-ready):
+> **Yes — the platform does totals by category.** You group an assessment's questions into categories, and each category gets its own subtotal + interpretation band on the results report. Scaling Up Full already does this with the 4 Decisions (People/Strategy/Execution/Cash). So a category-scored assessment like the Five Dysfunctions (Trust / Conflict / Commitment / Accountability / Results) fits the model directly.
+
+That unblocks the Slack reply immediately. Everything below is the **ultimate** build.
+
+## 4. Phase 2 — Five Dysfunctions "exactly like the toolset"
+
+### 4.1 Licensing gate (BLOCKER — confirm before any build)
+The Five Dysfunctions Team Assessment (the statements **and** the interpretation text) is **© 2007 Patrick Lencioni, published by Pfeiffer/Wiley — "All rights reserved."** This spec deliberately **does not reproduce that content.** Before we host it on the platform we must confirm Scaling Up holds the right to reproduce/distribute it digitally (their toolset presumably licenses it; that license must extend to our implementation). **Owner decision (Jeff/Scaling Up legal) — do not build until confirmed.**
+
+### 4.2 Content source (when cleared)
+Obtain the **toolset's exact version** — ideally an **Esperto export**, the same way the other assessments were exported into `From Jeff/` (Five Dysfunctions is **not** in that folder yet). Capture verbatim: the rated statements, the response scale, the category→item mapping, the band thresholds, and the per-category interpretation text — from the licensed source, not transcribed here.
+
+### 4.3 Scoring structure (methodology — facts, no copyrighted text)
+The instrument's *method* (not its wording) maps cleanly onto the existing engine:
+- **38 rated statements, 1–5 scale**, grouped into **5 categories**: Trust, Conflict, Commitment, Accountability, Results. Category item counts: 8 / 8 / 7 / 7 / 8 (= 38).
+- **Per-category score = average** of that category's items (sum ÷ count).
+- **Per-category band** on the average: **High ≥ 3.75 · Medium 3.25–3.74 · Low ≤ 3.24**, each with a category-specific interpretation paragraph (sourced from the licensed content).
+- **No reverse-scoring** — every statement is positively worded (high = healthy). ⇒ **No change to the scoring *math* is required** — but see §4.4a: the band *boundaries* need exact half-open semantics, which the current tier resolver/validator may not represent as-is.
+
+### 4.4 Engine mapping (reuses existing `domains` feature — zero scoring-engine changes)
+- Model each of the 5 categories as a **domain with one section**, questions = SLIDER_LIKERT with `scale {min:1, max:5}`.
+- Configure each domain's **tiers** as the 3 bands (`≥3.75` High / `3.25–3.74` Medium / `≤3.24` Low) with the interpretation text as the band message.
+- Result: `perDomain[].averagePoints` = the category average; `perDomain[].tier` = the band. Exactly the Lencioni output, via machinery Scaling Up Full already exercises.
+- *(Presentation choice: questions can be grouped by category as sections, or kept in the source's interleaved order — both score identically since membership is by section, not position. Match the toolset's order.)*
+
+### 4.4a Band-boundary semantics — a second engine gap **[claudex R2 High — confirm before publish]**
+The Lencioni bands are **half-open**: High **≥ 3.75**, Medium **3.25–3.74**, Low **≤ 3.24**. The current per-domain tier model uses **inclusive min/max bounds** with **tiling validation** that requires contiguous ranges. A real boundary score (e.g. **3.25**, or a respondent average like **3.3333…**) can therefore either **fail publish validation** (gap/overlap at the 3.24↔3.25 and 3.74↔3.75 seams) or **fall into the wrong band** depending on rounding. Required before publish: define explicit **half-open / range-comparator** band semantics (or a licensed-toolset banding adapter), and add **boundary tests at 3.24 / 3.25 / 3.74 / 3.75** plus a repeating `3.333…` average. §4.3's "no scoring *math* change" stays true — the *banding* is the work.
+
+### 4.5 The one real engine gap — team/group scoring **[REQUIRED, grill Q4]**
+The instrument is fundamentally a **team** assessment (its purpose is the team's aggregate score per category + the discussion that drives), so the team/group per-category report is **in scope for v1, not optional** — an individual-only replica would be incomplete. The current cross-respondent dashboard (`CampaignTrendsView`) rolls up **per-section** across respondents but **not per-domain**. So the build must add **per-domain aggregation** to that dashboard (small, additive, well-scoped). Individual reports need no engine change; this team rollup is the one required engine addition.
+
+**Canonical aggregation formula (claudex R2 — define up front):** the team score per category = **mean of respondents' per-domain averages** (each respondent → per-domain average; team = mean of those), **not** a pooled mean of raw answers (the two differ when respondents skip items). Carry **n per domain** (respondents contributing) for transparency, and **distinguish "no data"/null from a genuine low score** in the UI. State the partial-response rule (e.g. require all items answered for a respondent to count toward a domain) before implementing. **Dedupe to one submission per respondent** (the campaign's keep-rule) so a re-take can't double-count a person into the team mean.
+
+**Authorization gap to close FIRST (claudex R2 — High).** The trends page/API currently gates only **organization ownership**, not template access or per-campaign read rights — so direct URL/API calls could expose results for templates/admin-created campaigns the actor shouldn't read. Before adding the per-domain aggregate (which would surface licensed Five Dysfunctions data), gate those reads with `canAccessTemplate` and/or `canManageCampaign("read")` for **every included campaign** (or a dedicated team-report route with explicit permissions), and add **URL-tampering regression tests**. Especially important given the licensed content (§4.1).
+
+### 4.6 Report layout
+Match the toolset's presentation (the 5-dysfunction pyramid + per-category band grid). Reuse the branded report components (ADR-0005 scoped brand).
+
+### 4.7 DB-safety (hard constraint — 2 prior prod wipes)
+**No scripts against the prod DB. No `prisma migrate reset`/`dev`/destructive ops.** Create the template through the **app's admin assessment editor** (Metadata/Sections/Questions/Scoring&Tiers tabs) — a guarded, validated, app-mediated path — **or**, if a seed is used, only the existing **additive, fail-closed, content-hash-idempotent DRAFT seeder** (`ensureTemplateVersionContent`) that never mutates published/live rows, run against **staging first**, with an admin reviewing + clicking Publish. Zero schema migration (reuses the frozen `ScoreResult` + `domains` shape).
+
+**Concurrency / last-write-wins [claudex R2 Medium].** Admin draft edits + publish are currently **last-write-wins** with no `contentHash`/CAS guard — two admins editing the same template version can silently overwrite each other's question/scoring changes, or publish stale half-reviewed content. Require an **expected `contentHash` (or `updatedAt`)** on the template **PATCH and publish** mutations, return **409 on mismatch**, and record the hash in the **publish audit** event. (Applies to every template authored this way — Spec 14 and Spec 15 both.)
+
+## 5. Build outline (when licensing is cleared)
+1. Obtain + verify the toolset's exact Five Dysfunctions content (export).
+2. Create the template via the admin editor: 5 domains, 38 SLIDER_LIKERT items (1–5), per-domain bands + interpretation text, source order.
+3. Add per-domain aggregation to `CampaignTrendsView` for the team report (additive).
+4. Report layout to match the toolset (branded components).
+5. Verify scoring against a known sample (category averages + bands); admin publishes from DRAFT.
+
+## 6. Out of scope / open
+- **Licensing confirmation** — gate on §4.1.
+- **Obtaining the toolset export** (not in `From Jeff/` yet).
+- Whether group/team scoring is in v1 (drives §4.5).
+- Reverse-scoring/weighting — **not needed** for Five Dysfunctions; only relevant if a *future* instrument requires it.
+
+## Revision log
+- **R2 (claudex round 2, 2026-06-09):** this reconciliation added §4.4a (half-open band-boundary semantics — corrects the "zero engine change" claim), the §4.7 contentHash/CAS guard on template edit+publish, and the §4.5 submission-dedupe note. The earlier R2 pass had already added the §4.5 canonical aggregation formula and the §4.5 authorization-gap prerequisite (deduped here).

--- a/docs/specs/v7.6/15-scaling-up-quick-assessment.md
+++ b/docs/specs/v7.6/15-scaling-up-quick-assessment.md
@@ -1,0 +1,71 @@
+# Spec 15 — Scaling Up Quick Assessment (the public "website" assessment)
+
+Status: **plan / contingency** ("just in case" per Jeff's Slack). No build, no DB writes until approved. Assessment-domain (v7.6 library). Reuses the existing public-quiz flow + `domains` scoring + branded report/quiz.
+
+## 1. Context (what Jeff means by "the quick assessment")
+Jeff: *"the scaling up quick assessment is the next one i want to see … This one apparently gets a lot of use,"* later clarified as *"the one labeled **website scaling up assessment**"* in the **free** category. Identified in `From Jeff/APP_scaling up assessemnt/`:
+- `Website - Scaling up Assessment/Website-scalingup-assessment.xlsx` — sheets `questions` / `email` / `results`; the results copy is titled **"Scaling Up Quick Assessment - Thank you page,"** signed by Verne Harnish, with a complimentary-coaching follow-up CTA.
+- `SunHub_ScalingUpQuiz/SU-Quiz.xlsx` — "Scaling Up Quiz," **10-pt scale**, public link `https://scalinguptoolkit.com/s/ScaleUpQA`, coach-match follow-up `https://coaches.scalingup.com/coach-match-after-assessment-form`.
+
+So this is the **free, public, lead-generation 4-Decisions self-assessment** — Scaling Up's own content (no third-party copyright; confirm Scaling Up owns it, which it does).
+
+## 2. What it is
+- **Public / free** (no invite) — a marketing/lead-gen quiz coaches share.
+- Scores the **4 Decisions** as categories: **People · Strategy · Execution · Cash**, on a **10-pt scale**.
+- Results page: per-category (4 Decisions) breakdown + an **insight highlighting the lowest-scored Decision** (and the source's guidance to look at the Decision that *precedes* the lowest), plus a **complimentary coaching follow-up CTA** and a Verne Harnish sign-off.
+- Captures the respondent's **email** and (optionally) the **referring coach's email** so results route to the coach + Scaling Up.
+
+## 3. What exists vs. what's new (corrected after `/grill-with-docs`)
+**Exists (light config):** the public-quiz flow (`/quiz/[campaignAlias]` page + submit route, PUBLIC accessMode), respondent name+email + optional `referringCoachEmail` capture, public-campaign resolution (accessMode=PUBLIC + alias + published version = instant live URL), full `perDomain`/`perSection` scoring on submit, rate-limiting, the branded quiz + report components. So a public 4-Decisions quiz *as a quiz* is mostly configuration.
+
+**New build — the lead-magnet value, which is NOT assembly:**
+- **Taker-facing results [Q1, Q2 → ADR-0008].** The public flow currently shows the taker NO score (bare thank-you; the branded report is coach-gated). The submit POST will **return the taker's `ScoreResult`** and the client renders the 4-Decisions results **in-place** — no persistent public results endpoint/token to leak or enumerate. This is a deliberate, scoped exception to the "no taker-facing results" (D3) policy, for PUBLIC self-assessments only (see `docs/adr/0008-public-self-assessments-show-taker-results.md`).
+- **Guarded lead routing [Q3].** `referringCoachEmail` is captured but never routed. On submit, email the taker's info + results to the referring coach **only if it matches a KNOWN active coach** (**trim + lowercase** the email before lookup/storage; match a single ACTIVE coach — claudex R2, avoids casing/format drift fragmenting attribution), otherwise notify only the SU team; always the SU team — closing the open-email-relay abuse vector on this public endpoint. The on-page coaching CTA links out to the coach-match form; CRM/HubSpot deferred.
+
+It also **doubles as the live demo for Spec 14** (a working totals-by-category assessment).
+
+## 4. Design
+- **New template** "Scaling Up Quick Assessment" (alias e.g. `su-quick` / `ScaleUpQA`), **PUBLIC** mode.
+- **4 domains** (People/Strategy/Execution/Cash); SLIDER_LIKERT items, `scale {min:?, max:10}` (confirm the exact min + item set from the source).
+- **Per-Decision result** (`perDomain[].averagePoints`) + overall; optional ScaleUp-style rollup if the source uses one. **Lowest-Decision insight** computed from the per-domain scores (lowest average → highlight + "the Decision that precedes it" note).
+- **Content (questions + results copy)** captured from the **live public quiz** (`scalinguptoolkit.com/s/ScaleUpQA`) + the `Website-scalingup-assessment.xlsx` at build time — Scaling Up's own material.
+- **Lead-gen wiring:** capture respondent email + optional coach email on submit; route results (email to respondent + coach + Scaling Up). Reuse existing assessment email; the coach-match CTA links out (or integrates with the existing follow-up flow). Confirm whether HubSpot/coach-match integration is in v1 or just an outbound link.
+- **Brand:** the shipped branded quiz + report.
+
+## 5. DB-safety (hard constraint — 2 prior prod wipes)
+Same as Spec 14 §4.7: **no scripts against prod, no destructive ops.** Create the template via the **admin assessment editor**, or the **additive fail-closed DRAFT seeder** run against **staging first** + admin Publish. Zero schema migration (reuses `ScoreResult` + `domains` + public-quiz config). Template edits + publish must carry the **contentHash/CAS guard** (Spec 14 §4.7, claudex R2) — no last-write-wins. The PUBLIC-launch path is itself a build prerequisite — see §5c item 1.
+
+## 5b. Privacy & consent (claudex R2 — REQUIRED before collecting public leads)
+The current public-quiz UI implies responses are shared only with the coach/facilitator, but this tool routes results to the **taker** (on-screen, ADR-0008), the **referring coach** (if a known active coach), **and the Scaling Up team**. Before any public lead capture: update the **pre-submit consent/privacy copy** to disclose all recipients, add a **data-retention** statement, and confirm lawful-basis/PII handling for an open lead form. This is a content/compliance prerequisite, not just code.
+
+## 5c. Security & data-integrity requirements (claudex R2 — fold into the build)
+1. **PUBLIC campaign creation gap [High] — corrects §5.** The campaign-create path today produces **DRAFT/INVITED** campaigns and the admin UI **disables PUBLIC mode**, so launching the public quiz would otherwise need a direct DB mutation. v1 must add an **audited, admin-only PUBLIC campaign create/publish flow** (validating `alias` + `accessMode` + open/close window + any `publicConfig`, with a rollback path) — the template editor handles the *template*, but a *public campaign* needs this new guarded flow (keeps us off raw prod scripts).
+2. **No-store on results [High].** Return the `ScoreResult` with `Cache-Control: no-store` (mirror the invited submit route); keep results out of URLs/history so PII/results aren't cached by browsers/proxies/edge.
+3. **Email injection [High].** Escape every lead/result email body (taker name/email, coach fields) through a template-escaping layer; strip control chars from subjects; test with malicious `firstName`/`lastName`/`referringCoachEmail` values (results go to coaches + staff).
+4. **Email abuse / queued delivery [High].** Taker + SU emails ride a public endpoint on an IP-only rate limit — put result emails behind **fail-closed per-email/per-campaign quotas + bot controls + bounce suppression + a queued/outbox delivery path** (not synchronous); send coach mail only after an ACTIVE coach match.
+5. **Idempotency + durable outbox [High].** Add a client attempt-id / idempotency key with a **unique DB constraint**, and enqueue result emails in the same transaction via an **outbox keyed by submissionId + recipient role** — so browser retries / crashes / SMTP partial failures can't duplicate submissions/emails or silently lose them.
+6. **Audit [Medium].** Audit public submission creation, result return, coach match/suppression, recipient list, idempotency key, IP, and user-agent — for spam investigations, attribution disputes, and PII-disclosure reviews.
+
+These move Spec 15 firmly from "assembly" to a real, security-sensitive public-endpoint build.
+
+## 6. Build outline (when approved)
+1. Capture the exact questions + scale + results copy from the live quiz + xlsx (Scaling Up's content).
+2. Create the template via the admin editor: 4 domains, 10-pt items, public mode.
+3. Results layout: 4-Decisions breakdown + lowest-Decision insight + coaching CTA + sign-off (branded report).
+4. Lead-gen: email capture + routing (respondent/coach/Scaling Up); decide coach-match integration vs outbound link.
+5. Verify scoring + the public flow on staging; admin publishes.
+
+## 7. Resolved (grill) + still open
+**Resolved by `/grill-with-docs`:**
+- Taker sees results on screen, returned in the submit response (ADR-0008). [Q1/Q2]
+- Lead routing = guarded email to known-coach + SU team on submit; coaching CTA links out; CRM deferred. [Q3]
+- Coach attribution = taker-entered `referringCoachEmail` (the source model: "if a coach pointed you here and you shared their email"), not per-coach links — per-coach links are a future enhancement.
+
+**Still open (capture-at-build / product calls):**
+- Exact question set + scale floor (0–10 vs 1–10) — capture from the live quiz + xlsx (Scaling Up's own content).
+- Whether respondent email is required vs optional (lead-gen vs friction).
+- Lowest-Decision "precedes" insight copy.
+- Deeper coach-match/HubSpot integration (beyond the outbound link) — later.
+
+## Revision log
+- **R2 (claudex round 2, 2026-06-09):** the earlier R2 pass added §5b (privacy/consent), the consolidated §5c security list (PUBLIC-create gap, no-store, email injection, email-abuse/queued delivery, idempotency + durable outbox, audit), and §3 coach-email normalization. This reconciliation added the §5 contentHash/CAS pointer + publicConfig/rollback detail and removed a redundant duplicate §5c.


### PR DESCRIPTION
**Docs only — no code, no DB, no app behavior change.** Planning/contingency specs from Jeff's Slack asks, hardened via two `/grill-with-docs` passes + a claudex security/data-integrity review.

- **Spec 14** — totals-by-category (already supported via `domains`; Scaling Up Full is the live 4-Decisions example) + the "exactly like the toolset" **Five Dysfunctions** build. Structure/method only — no copyrighted instrument content reproduced. Gated on confirming Lencioni licensing; team/group per-category report required; band-boundary + team-aggregate-formula + trends-authz gaps flagged.
- **Spec 15** — public **Scaling Up Quick Assessment** (free 4-Decisions lead magnet): taker sees results in-place (ADR-0008), guarded coach+SU lead email, and the security/data-integrity requirements (audited PUBLIC-campaign flow, `no-store`, email escaping/outbox/idempotency, consent copy, audit).
- **ADR-0008** — public self-assessments show the taker their own results (scoped exception to the gated-results policy; invited flows unchanged).

Nothing here implements anything; it's the plan of record so it's saved + reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)