### PR TITLE
fix(quiz): honest public-flow copy for the Quick Assessment

### DIFF
--- a/src/src/__tests__/components/public-quiz-results.test.tsx
+++ b/src/src/__tests__/components/public-quiz-results.test.tsx
@@ -221,4 +221,19 @@ describe("PublicQuizClient — in-place results + consent + idempotency (Task 7)
     fireEvent.click(screen.getByTestId("quiz-start"));
     expect(screen.queryByTestId("quiz-consent")).not.toBeInTheDocument();
   });
+
+  // ── Public-flow intro copy is accurate (not invited-flow wording) ────────
+  it("uses public lead-magnet intro copy, not invited 'coach who sent this' wording", () => {
+    render(<PublicQuizClient {...baseProps} />);
+
+    // Public, honest eyebrow — not the invited "You're invited".
+    expect(screen.getByText(/free assessment/i)).toBeInTheDocument();
+    expect(screen.queryByText(/you're invited/i)).not.toBeInTheDocument();
+
+    // The misleading invited claims must be gone from the public intro.
+    expect(
+      screen.queryByText(/coach who sent this/i),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/facilitator will follow up/i)).not.toBeInTheDocument();
+  });
 });

--- a/src/src/components/assessments/public-quiz-client.tsx
+++ b/src/src/components/assessments/public-quiz-client.tsx
@@ -157,7 +157,7 @@ export function PublicQuizClient({
         </header>
         <main className="landing-body">
           <section className="hero-card" aria-labelledby="hero-title">
-            <span className="hero-eyebrow">You&apos;re invited</span>
+            <span className="hero-eyebrow">Free assessment</span>
             <h1 className="hero-title" id="hero-title">
               {campaignName}
             </h1>
@@ -167,13 +167,14 @@ export function PublicQuizClient({
               </p>
             ) : (
               <p className="hero-lede">
-                This assessment helps your team see how aligned you are.
-                Your responses are confidential.
+                See how your business scores across the Four Decisions —
+                People, Strategy, Execution, and Cash — and get your results
+                instantly.
               </p>
             )}
             <p className="hero-sub">
-              Most respondents finish in 5–10 minutes. Your responses are
-              shared only with the coach who sent this to you.
+              Most people finish in about 5–10 minutes, and you&apos;ll see
+              your results as soon as you submit.
             </p>
             <div className="hero-stats" aria-label="Assessment details">
               <span>
@@ -196,8 +197,9 @@ export function PublicQuizClient({
               </button>
             </div>
             <p className="hero-fine">
-              Your responses are confidential and shared only with the
-              coach who sent this assessment.
+              Free to take — you&apos;ll get your results on screen. Your
+              responses are also shared with the Scaling Up team and the
+              coach who referred you (if any).
             </p>
           </section>
         </main>
@@ -233,8 +235,9 @@ export function PublicQuizClient({
               About you
             </h1>
             <p className="ty-sub">
-              We use your email to match your responses; your facilitator
-              will follow up with your results.
+              We use your name and email to show you your results and, where
+              applicable, to share them with the Scaling Up team and the
+              coach who referred you.
             </p>
             <div className="survey-question">
               <label className="wf-label" htmlFor="quiz-first-name-input">


### PR DESCRIPTION
The public Quick Assessment reused **invited-flow** copy on its intro + contact screens:
- "You're invited"
- "shared only with **the coach who sent this** to you" / "...this assessment"
- "your **facilitator** will follow up with your results"

For a public lead-magnet nobody was "sent," that's inaccurate — and it **contradicts** the submit consent line ("results … shared with the **Scaling Up team** and the coach who **referred** you (if any)"). The intro promised a confidentiality the next screen contradicts.

**Fix:** reword the intro eyebrow/lede/sub/fine + the contact-step subtext to honest public copy aligned with the consent disclosure (results shown instantly; also shared with the SU team + referring coach if any).

Scope: `public-quiz-client.tsx` is the **public-only** component — the invited `org-survey` flow is untouched. 5 RTL tests green (new test asserts the public wording + absence of the invited phrases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)