### PR TITLE
fix(assessments): two bugs found launching Five Dysfunctions

### DIFF
--- a/src/prisma/seed-five-dysfunctions.ts
+++ b/src/prisma/seed-five-dysfunctions.ts
@@ -612,9 +612,13 @@ interface QuestionPayload {
 }
 
 function buildQuestions(): QuestionPayload[] {
-  return ALL_QUESTION_DEFS.map((q) => ({
+  // sortOrder must be GLOBALLY unique across all questions (the seed integrity
+  // guard rejects duplicates). The per-section `q.sortOrder` fields restart at
+  // 1, so renumber sequentially over the grouped order (Trust → … → Results),
+  // which both preserves display order and guarantees uniqueness.
+  return ALL_QUESTION_DEFS.map((q, i) => ({
     stableKey: q.stableKey,
-    sortOrder: q.sortOrder,
+    sortOrder: i + 1,
     type: "SLIDER_LIKERT" as const,
     label: q.label,
     sectionStableKey: q.sectionStableKey,

--- a/src/src/__tests__/assessments/five-dysfunctions-seed-content.test.ts
+++ b/src/src/__tests__/assessments/five-dysfunctions-seed-content.test.ts
@@ -121,6 +121,19 @@ describe("buildFiveDysfunctionsContent() — questions", () => {
     expect(uniqueKeys.size).toBe(stableKeys.length);
   });
 
+  // Guards the seed integrity check: sortOrder must be GLOBALLY unique across
+  // all questions (not restart per section), else ensureTemplateVersionContent
+  // throws "duplicate question sortOrder" at seed time.
+  it("all question sortOrders are globally unique (1..38)", () => {
+    const sortOrders = (
+      content.questions as Array<{ sortOrder: number }>
+    ).map((q) => q.sortOrder);
+    expect(new Set(sortOrders).size).toBe(sortOrders.length);
+    expect([...sortOrders].sort((a, b) => a - b)).toEqual(
+      Array.from({ length: 38 }, (_, i) => i + 1),
+    );
+  });
+
   it("every question's sectionStableKey matches an existing section", () => {
     const sectionStableKeys = new Set(
       (content.sections as Array<{ stableKey: string }>).map((s) => s.stableKey)

--- a/src/src/__tests__/lib/assessments/evaluate-access-change.test.ts
+++ b/src/src/__tests__/lib/assessments/evaluate-access-change.test.ts
@@ -85,13 +85,14 @@ function buildTx(state: {
             coachId?: string | { in?: string[] };
             accessGroupId?: string | { in?: string[] };
           };
+          include?: { accessGroup?: unknown };
         }) => {
           const rows = (state.groupCoachRows ?? []).filter(
             (r) => r.accessGroup.deletedAt === null,
           );
           const whereCoachId = args?.where?.coachId;
           const whereGroupId = args?.where?.accessGroupId;
-          return rows.filter((r) => {
+          const filtered = rows.filter((r) => {
             if (typeof whereCoachId === "string" && r.coachId !== whereCoachId)
               return false;
             if (
@@ -114,6 +115,16 @@ function buildTx(state: {
             )
               return false;
             return true;
+          });
+          // Faithful to Prisma: the accessGroup relation is ONLY present when
+          // the caller explicitly includes it. Code that reads
+          // r.accessGroup.deletedAt MUST pass include — else it gets undefined
+          // and throws (the prod bug this guards against).
+          if (args?.include?.accessGroup) return filtered;
+          return filtered.map((r) => {
+            const { accessGroup: _omit, ...rest } = r;
+            void _omit;
+            return rest;
           });
         },
       ),

--- a/src/src/lib/assessments/evaluate-access-change.ts
+++ b/src/src/lib/assessments/evaluate-access-change.ts
@@ -27,7 +27,6 @@
  * `logAudit()` helper — Round 2 M-4).
  */
 
-import { Prisma } from "@prisma/client";
 import { AccessChangeError } from "./errors";
 import { getAccessPolicyVersion } from "@/lib/auth/access-policy-version";
 
@@ -99,6 +98,11 @@ export interface AccessChangeTx {
       where?: {
         coachId?: string | { in?: string[] };
         accessGroupId?: string | { in?: string[] };
+      };
+      include?: {
+        accessGroup?:
+          | boolean
+          | { select?: { id?: boolean; deletedAt?: boolean } };
       };
     }) => Promise<
       Array<{
@@ -308,8 +312,11 @@ export async function evaluateAccessChange(
   }
 
   // Build snapshot covering all groups any affected coach belongs to.
+  // MUST include accessGroup — the loops below read r.accessGroup.deletedAt to
+  // skip archived groups; without the include it is undefined and throws.
   const coachGroupRows = await tx.accessGroupCoach.findMany({
     where: { coachId: { in: affectedCoachIds } },
+    include: { accessGroup: { select: { id: true, deletedAt: true } } },
   });
   const allGroupIds = new Set<string>([change.accessGroupId]);
   for (const r of coachGroupRows) {


### PR DESCRIPTION
Two real bugs surfaced while launching the Five Dysfunctions template to prod.

### 1. Five Dysfunctions seed — duplicate `sortOrder` (P1)
`buildQuestions` restarted `sortOrder` at 1 per section, so `ensureTemplateVersionContent`'s integrity guard threw **"duplicate question sortOrder"** at seed time. The content test passed because it never checked uniqueness. Fix: renumber sequentially over the grouped order (1..38) + add a regression test asserting global uniqueness.

### 2. Access-group template grant — 500 on every add (P1, platform-wide)
`evaluateAccessChange` reads `r.accessGroup.deletedAt` on `accessGroupCoach` rows, but the `findMany` **never included the `accessGroup` relation** → `undefined` → `TypeError: Cannot read properties of undefined (reading 'deletedAt')` → **500 on every "add template to group"** for any group that has coaches. This blocked granting *any* newly-published template to coaches — i.e. the entire invited-coach campaign flow for new templates (confirmed against prod via Vercel logs). Fix: add the `include` (+ permit it in the tx type), drop an unused `Prisma` import.

**Test hardening:** the shared `buildTx` mock returned `accessGroup` regardless of `include`, which is why the bug shipped green. Made the mock faithful to Prisma (strip `accessGroup` unless included), so the existing ADD/REMOVE suite now catches this class of bug.

Both: targeted suites green (FiveD content 33, access-change 12, templates-route 14); `CI=true npx next build --turbopack` clean. Additive — no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)