### PR TITLE
fix(assessments): Likert slider minimum is selectable (answer '1' could not proceed)

### DIFF
--- a/src/src/__tests__/assessments/public-quiz-pager.test.tsx
+++ b/src/src/__tests__/assessments/public-quiz-pager.test.tsx
@@ -187,7 +187,9 @@ describe("PublicQuizClient — SectionPager wiring", () => {
     expect(screen.queryByText(/send your results to the email/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/email your scoring summary/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/check your spam/i)).not.toBeInTheDocument();
-    // Accurate copy must be present
-    expect(screen.getByText(/facilitator will follow up with your results/i)).toBeInTheDocument();
+    // Invited-flow wording must be absent on the public lead-magnet (PR #47).
+    expect(screen.queryByText(/facilitator will follow up/i)).not.toBeInTheDocument();
+    // Accurate public copy must be present.
+    expect(screen.getByText(/show you your results/i)).toBeInTheDocument();
   });
 });

--- a/src/src/__tests__/components/assessments/question-input.test.tsx
+++ b/src/src/__tests__/components/assessments/question-input.test.tsx
@@ -256,4 +256,24 @@ describe("QuestionInput", () => {
     expect(screen.getByText("0")).toBeInTheDocument();
     expect(screen.getByText("2")).toBeInTheDocument();
   });
+
+  test("12. SLIDER_LIKERT minimum of a 1-based scale commits on pointer release", () => {
+    // Regression for the reported bug: a user who wants to answer the MINIMUM
+    // (e.g. 1 on a 1–5 scale) sees the thumb already resting at 1, but a tap
+    // that the browser treats as a tiny drag fires neither `change` (value
+    // unchanged) nor `click` (movement cancels it) — so 1 never committed and
+    // they couldn't proceed. The component must commit on `pointerup` too.
+    const onChange = jest.fn();
+    render(
+      <QuestionInput
+        question={sliderQuestion}
+        value={undefined}
+        onChange={onChange}
+      />
+    );
+    const slider = screen.getByRole("slider") as HTMLInputElement;
+    expect(slider.value).toBe("1"); // thumb sits at min (1) when unanswered
+    fireEvent.pointerUp(slider);
+    expect(onChange).toHaveBeenCalledWith("S1_Q1", 1);
+  });
 });

--- a/src/src/components/assessments/question-input.tsx
+++ b/src/src/components/assessments/question-input.tsx
@@ -74,6 +74,11 @@ export function QuestionInput({
           aria-valuetext={answered ? String(value) : "Not yet answered"}
           onChange={commit}
           onClick={commit}
+          // Commit on pointer release too: a tap that registers as a tiny drag
+          // (common on trackpads/touch) fires neither `change` (value unchanged
+          // at the resting minimum) nor `click` (movement cancels it), so the
+          // minimum value would never commit and the user couldn't proceed.
+          onPointerUp={commit}
           onKeyUp={(e) => { if (MOVE_KEYS.includes(e.key)) commit(e); }}
           disabled={disabled}
         />


### PR DESCRIPTION
**Reported by the user testing Five Dysfunctions:** *"you can't proceed if the slider is set to 1. What if a user does answer a 1 — they won't be able to proceed."*

**Root cause:** the unanswered slider thumb rests at `min` (1 on a 1–5 scale). To answer the minimum the user must commit that exact value, but a tap that the browser treats as a tiny drag fires neither `change` (value didn't change from the resting min) nor `click` (movement cancels it). So "1" never committed → `isAnswered` false → the required-question gate blocked them. (Clicking exactly was already handled — test 10 — but micro-drag taps on trackpads/touch weren't.)

**Fix:** also commit on `pointerup`, which fires regardless of micro-movement → any tap/drag-release on the slider registers the current value, so the minimum is reliably selectable on every input mode. Regression test added for the 1-based min.

Also realigns a stale `public-quiz-pager` test that still asserted the old `"facilitator will follow up"` copy removed in PR #47 (the Vercel build gate doesn't run Jest, so it was red on `main` unnoticed).

37 tests across 5 suites green; `CI=true npx next build --turbopack` clean. Shared `QuestionInput` → fixes the min for every assessment (Quick, Five Dysfunctions, all others).

🤖 Generated with [Claude Code](https://claude.com/claude-code)