### PR TITLE
feat(assessments): polished two-screen participant intro (welcome + distinct section)

### DIFF
--- a/src/src/__tests__/assessments/org-survey-pager.test.tsx
+++ b/src/src/__tests__/assessments/org-survey-pager.test.tsx
@@ -21,7 +21,7 @@
  */
 
 import React from "react";
-import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, cleanup, within } from "@testing-library/react";
 
 const mockPush = jest.fn();
 jest.mock("next/navigation", () => ({
@@ -94,8 +94,8 @@ function mockMeFetch() {
 /** Render + advance through the intro phase into the pager (ready phase). */
 async function reachPager() {
   render(<OrgSurveyClient campaignAlias={ALIAS} />);
-  // intro phase: "Start Assessment"
-  const start = await screen.findByRole("button", { name: /start assessment/i });
+  // intro phase: "Start the assessment →" (approved participant welcome CTA)
+  const start = await screen.findByRole("button", { name: /start the assessment/i });
   fireEvent.click(start);
 }
 
@@ -228,5 +228,24 @@ describe("OrgSurveyClient — SectionPager wiring + hidden-orphan fix", () => {
       localStorage.getItem(invitedDraftKey(RESPONDENT_KEY)) as string,
     );
     expect(saved.q1).toBe(2);
+  });
+
+  it("Screen 1 (welcome) renders the value-prop list with INVITED team framing + stat chips from real data", async () => {
+    render(<OrgSurveyClient campaignAlias={ALIAS} />);
+    // Wait for the intro (welcome) phase to render after /me resolves.
+    await screen.findByRole("button", { name: /start the assessment/i });
+
+    const expectations = screen.getByTestId("welcome-expectations");
+    // INVITED team framing — "feed the team picture", NOT the public lead-magnet copy.
+    expect(within(expectations).getByText(/feed the team picture/i)).toBeInTheDocument();
+
+    // Stat chips reflect the real counts (2 questions; 1 defined section) and the
+    // derived 0–3 scale (from the slider question).
+    const stats = screen.getByTestId("welcome-stats");
+    expect(within(stats).getByText("2")).toBeInTheDocument();
+    expect(within(stats).getByText("0–3")).toBeInTheDocument();
+
+    // Invited fine print mentions the facilitator/coach (team framing kept).
+    expect(screen.getByText(/facilitator or coach/i)).toBeInTheDocument();
   });
 });

--- a/src/src/__tests__/assessments/public-quiz-pager.test.tsx
+++ b/src/src/__tests__/assessments/public-quiz-pager.test.tsx
@@ -12,7 +12,7 @@
  */
 
 import React from "react";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 
 const mockPush = jest.fn();
 jest.mock("next/navigation", () => ({
@@ -191,5 +191,22 @@ describe("PublicQuizClient — SectionPager wiring", () => {
     expect(screen.queryByText(/facilitator will follow up/i)).not.toBeInTheDocument();
     // Accurate public copy must be present.
     expect(screen.getByText(/show you your results/i)).toBeInTheDocument();
+  });
+
+  it("Screen 1 (welcome) renders the value-prop 'what to expect' list and stat chips from ACTUAL data", () => {
+    render(<PublicQuizClient {...baseProps} />);
+    // The de-bared welcome renders the value-prop expectation list...
+    const expectations = screen.getByTestId("welcome-expectations");
+    expect(expectations).toBeInTheDocument();
+    expect(within(expectations).getByText(/honest & confidential/i)).toBeInTheDocument();
+    // ...and the stat chips reflect the real counts (2 questions, 2 sections)
+    // and the derived 0–3 scale — NOT hardcoded 38/5/1–5.
+    const stats = screen.getByTestId("welcome-stats");
+    // 2 questions + 2 sections → both chips read "2"; the scale chip reads "0–3".
+    expect(within(stats).getAllByText("2")).toHaveLength(2);
+    expect(within(stats).getByText("0–3")).toBeInTheDocument(); // derived from the slider scale
+    expect(within(stats).queryByText("38")).not.toBeInTheDocument();
+    // The expectation row also states the real count + scale.
+    expect(within(expectations).getByText(/2 short statements, rated 0–3\./i)).toBeInTheDocument();
   });
 });

--- a/src/src/__tests__/assessments/section-pager.test.tsx
+++ b/src/src/__tests__/assessments/section-pager.test.tsx
@@ -40,6 +40,48 @@ describe("SectionPager", () => {
     expect(container.querySelector(".su-intro-num")).toBeInTheDocument();
   });
 
+  it("Screen 2 is DISTINCT: renders the domain accent rail + a 'What this section covers' callout from section.description", () => {
+    const secs: PagerSection[] = [
+      { stableKey: "S1", sortOrder: 1, name: "People", description: "How you attract and keep the right people.", domain: "People", partLabel: "Decision 1" },
+    ];
+    const qs: PagerQuestion[] = [
+      { stableKey: "q1", sortOrder: 1, sectionStableKey: "S1", type: "SLIDER_LIKERT", label: "Q1", isRequired: true, scale: { min: 0, max: 3, step: 1, anchorMin: "lo", anchorMax: "hi" } },
+    ];
+    const pages = buildSectionPages(secs, qs);
+    const { container } = render(
+      <SectionPager pages={pages} answers={{}} onAnswerChange={jest.fn()} onSubmit={jest.fn()} submitting={false} />,
+    );
+    // Domain accent rail present (the distinct visual hook).
+    expect(container.querySelector(".su-intro-rail")).toBeInTheDocument();
+    // "What this section covers" callout wraps the section description.
+    expect(screen.getByText(/what this section covers/i)).toBeInTheDocument();
+    expect(screen.getByText("How you attract and keep the right people.")).toBeInTheDocument();
+    // The step label uses the section's partLabel ("Decision 1"), not "Section N of M".
+    expect(screen.getByText("Decision 1")).toBeInTheDocument();
+  });
+
+  it("section-intro hides the 'What this section covers' callout when there is no description", () => {
+    // An empty section (no questions) opens on its intro slide even with no
+    // description — the right place to assert the callout degrades gracefully.
+    const secs: PagerSection[] = [
+      { stableKey: "S0", sortOrder: 1, name: "Strategy", domain: "Strategy" },
+      { stableKey: "S1", sortOrder: 2, name: "Section One" },
+    ];
+    const qs: PagerQuestion[] = [
+      { stableKey: "q1", sortOrder: 1, sectionStableKey: "S1", type: "SLIDER_LIKERT", label: "Q1", isRequired: true, scale: { min: 0, max: 3, step: 1, anchorMin: "lo", anchorMax: "hi" } },
+    ];
+    const pages = buildSectionPages(secs, qs);
+    const { container } = render(
+      <SectionPager pages={pages} answers={{}} onAnswerChange={jest.fn()} onSubmit={jest.fn()} submitting={false} />,
+    );
+    // Section title still renders; the covers callout degrades gracefully (absent).
+    expect(screen.getByRole("heading", { name: "Strategy" })).toBeInTheDocument();
+    expect(screen.queryByText(/what this section covers/i)).not.toBeInTheDocument();
+    expect(container.querySelector(".su-intro-covers")).not.toBeInTheDocument();
+    // The accent rail is still present (domain accent always shows).
+    expect(container.querySelector(".su-intro-rail")).toBeInTheDocument();
+  });
+
   it("Begin section advances to that section's questions (S0 has no questions → straight to S1)", () => {
     setup();
     fireEvent.click(screen.getByRole("button", { name: /begin section/i }));

--- a/src/src/app/(public)/quiz/[campaignAlias]/page.tsx
+++ b/src/src/app/(public)/quiz/[campaignAlias]/page.tsx
@@ -65,22 +65,20 @@ export default async function PublicQuizPage({
     campaign.openAt <= now &&
     (campaign.closeAt === null || campaign.closeAt >= now);
 
+  // Render the client directly (no constrained wrapper) so the full-bleed
+  // branded welcome shell matches the org-survey flow + the approved mockup.
   return (
-    <div className="min-h-screen bg-background py-10 px-4">
-      <div className="max-w-2xl mx-auto">
-        <PublicQuizClient
-          campaignAlias={campaignAlias}
-          campaignName={campaign.name}
-          campaignDescription={campaign.description}
-          templateName={campaign.template.name}
-          isOpen={isOpen}
-          status={campaign.status}
-          openAtIso={campaign.openAt.toISOString()}
-          closeAtIso={campaign.closeAt ? campaign.closeAt.toISOString() : null}
-          sections={version.sections as unknown}
-          questions={version.questions as unknown}
-        />
-      </div>
-    </div>
+    <PublicQuizClient
+      campaignAlias={campaignAlias}
+      campaignName={campaign.name}
+      campaignDescription={campaign.description}
+      templateName={campaign.template.name}
+      isOpen={isOpen}
+      status={campaign.status}
+      openAtIso={campaign.openAt.toISOString()}
+      closeAtIso={campaign.closeAt ? campaign.closeAt.toISOString() : null}
+      sections={version.sections as unknown}
+      questions={version.questions as unknown}
+    />
   );
 }

--- a/src/src/components/assessments/assessment-welcome.tsx
+++ b/src/src/components/assessments/assessment-welcome.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+/**
+ * Assessment participant — shared WELCOME ("Screen 1") building blocks.
+ *
+ * The approved participant intro redesign has two distinct screens:
+ *   1. a de-bared WELCOME / invitation (this module), and
+ *   2. a DISTINCT section intro (rendered by SectionPager).
+ *
+ * Both the PUBLIC quiz (PublicQuizClient) and the INVITED survey
+ * (OrgSurveyClient) render the same value-prop "what to expect" list + stat
+ * chips, but with FLOW-SPECIFIC copy (public lead-magnet vs invited team
+ * framing). These presentational pieces take the copy as props so the wording
+ * stays owned by each flow.
+ *
+ * Scope (ADR-0005): every class lives under `.su-welcome-*`, styled ONLY inside
+ * the `.su-assessment-brand` scope (the participant lane wrapper). No global
+ * selectors, no design-token changes, zero leak to the admin/coach `.wf-scope`
+ * UI.
+ */
+
+import React from "react";
+
+/** Branded app-shell header — white Scaling Up logo on the purple bar. */
+export function WelcomeShellHeader({ caption }: { caption?: string }) {
+  return (
+    <header className="su-welcome-shell" role="banner">
+      <img
+        className="su-welcome-logo"
+        src="/brand/su-logo-white.svg"
+        alt="Scaling Up"
+      />
+      {caption ? <span className="su-welcome-shell-caption">{caption}</span> : null}
+    </header>
+  );
+}
+
+export interface WelcomeExpectationsProps {
+  /** e.g. "About 10 minutes" — derived from the question count. */
+  timeLabel: string;
+  /** Actual number of questions (NOT hardcoded). */
+  questionCount: number;
+  /** e.g. "1–5" — derived from the slider scale. */
+  scaleLabel: string;
+  /** Flow-specific sub for the "honest & confidential" row. */
+  confidentialSub: string;
+  /** Flow-specific sub for the "category scores" row. */
+  scoresSub: string;
+}
+
+/**
+ * The "what to expect" value-prop list (3 rows: icon + bold label + muted sub).
+ * Time + question count + scale are derived from real data; the confidential /
+ * scores subs differ per flow (public vs invited).
+ */
+export function WelcomeExpectations({
+  timeLabel,
+  questionCount,
+  scaleLabel,
+  confidentialSub,
+  scoresSub,
+}: WelcomeExpectationsProps) {
+  return (
+    <ul className="su-welcome-expect" data-testid="welcome-expectations">
+      <li className="su-welcome-expect-item">
+        <span className="su-welcome-expect-ic" aria-hidden="true">
+          {"⏱"}
+        </span>
+        <span className="su-welcome-expect-text">
+          <b>{timeLabel}</b>
+          <span>
+            {questionCount} short {questionCount === 1 ? "statement" : "statements"}, rated {scaleLabel}.
+          </span>
+        </span>
+      </li>
+      <li className="su-welcome-expect-item">
+        <span className="su-welcome-expect-ic" aria-hidden="true">
+          {"🔒"}
+        </span>
+        <span className="su-welcome-expect-text">
+          <b>Honest &amp; confidential</b>
+          <span>{confidentialSub}</span>
+        </span>
+      </li>
+      <li className="su-welcome-expect-item">
+        <span className="su-welcome-expect-ic" aria-hidden="true">
+          {"📊"}
+        </span>
+        <span className="su-welcome-expect-text">
+          <b>Your category scores</b>
+          <span>{scoresSub}</span>
+        </span>
+      </li>
+    </ul>
+  );
+}
+
+/** The three stat chips (questions / sections / scale) — all from real data. */
+export function WelcomeStats({
+  questionCount,
+  sectionCount,
+  scaleLabel,
+}: {
+  questionCount: number;
+  sectionCount: number;
+  scaleLabel: string;
+}) {
+  return (
+    <div className="su-welcome-meta" aria-label="Assessment details" data-testid="welcome-stats">
+      <div className="su-welcome-chip">
+        <b>{questionCount}</b>
+        <span>{questionCount === 1 ? "question" : "questions"}</span>
+      </div>
+      <div className="su-welcome-chip">
+        <b>{sectionCount}</b>
+        <span>{sectionCount === 1 ? "section" : "sections"}</span>
+      </div>
+      <div className="su-welcome-chip">
+        <b>{scaleLabel}</b>
+        <span>scale</span>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Derive a human scale label ("1–5", "0–3") from the first SLIDER_LIKERT
+ * question's scale. Falls back to "rating" when no slider scale is present
+ * (e.g. an all-qualitative survey).
+ */
+export function deriveScaleLabel(
+  questions: Array<{ type: string; scale?: { min: number; max: number } }>,
+): string {
+  const slider = questions.find(
+    (q) => q.type === "SLIDER_LIKERT" && q.scale && typeof q.scale.min === "number" && typeof q.scale.max === "number",
+  );
+  if (slider?.scale) {
+    return `${slider.scale.min}–${slider.scale.max}`;
+  }
+  return "rating";
+}
+
+/**
+ * Derive an honest time estimate from the question count (~10 questions/min,
+ * rounded to a friendly band). Always "About N minutes".
+ */
+export function deriveTimeEstimate(questionCount: number): string {
+  if (questionCount <= 0) return "A few minutes";
+  // Bucket to friendly numbers: small banks stay ~5, larger ones scale.
+  if (questionCount <= 15) return "About 5 minutes";
+  if (questionCount <= 30) return "About 10 minutes";
+  if (questionCount <= 50) return "About 15 minutes";
+  return `About ${Math.round(questionCount / 10) * 5} minutes`;
+}

--- a/src/src/components/assessments/org-survey-client.tsx
+++ b/src/src/components/assessments/org-survey-client.tsx
@@ -27,6 +27,13 @@ import {
   useAnswerDraft,
   invitedDraftKey,
 } from "@/lib/assessments/use-answer-draft";
+import {
+  WelcomeShellHeader,
+  WelcomeExpectations,
+  WelcomeStats,
+  deriveScaleLabel,
+  deriveTimeEstimate,
+} from "@/components/assessments/assessment-welcome";
 
 interface ScaleConfig {
   min: number;
@@ -195,6 +202,13 @@ export function OrgSurveyClient({ campaignAlias }: { campaignAlias: string }) {
     return [...phase.data.questions].sort((a, b) => a.sortOrder - b.sortOrder);
   }, [phase]);
 
+  // Welcome stat chips + expectation copy derive from the ACTUAL data.
+  const scaleLabel = useMemo(() => deriveScaleLabel(sortedQuestions), [sortedQuestions]);
+  const timeEstimate = useMemo(
+    () => deriveTimeEstimate(sortedQuestions.length),
+    [sortedQuestions.length],
+  );
+
   async function handleSubmit() {
     if (phase.kind !== "ready") return;
 
@@ -294,38 +308,52 @@ export function OrgSurveyClient({ campaignAlias }: { campaignAlias: string }) {
   }
 
   if (phase.kind === "intro") {
+    // Screen 1 — de-bared WELCOME / invitation (approved participant mockup).
+    // Branded app-shell header + "what to expect" value-prop list + stat chips
+    // (actual counts + derived scale) + strong purple CTA. INVITED copy: team
+    // framing, shared with the facilitator/coach.
+    const orgName = phase.data.campaign.organizationName ?? undefined;
     return (
-      <div className="ty-page">
-        <header className="ty-header">
-          <span className="ty-brand">Scaling Up</span>
-          <span>You&apos;re invited</span>
-        </header>
-        <main className="ty-body">
-          <section className="ty-card" aria-labelledby="invite-title">
-            <span className="hero-eyebrow">You&apos;re invited</span>
-            <h1 className="ty-title" id="invite-title">
+      <div className="su-welcome-page">
+        <WelcomeShellHeader caption={orgName ?? "Team Assessment"} />
+        <main className="su-welcome-body">
+          <section className="su-welcome-card" aria-labelledby="invite-title">
+            <span className="su-welcome-eyebrow">You&apos;re invited</span>
+            <h1 className="su-welcome-title" id="invite-title">
               {phase.data.campaign.name}
             </h1>
-            <p className="ty-lede">
-              You&apos;ve been invited to take this assessment. Click below
-              when you&apos;re ready to begin.
+            <p className="su-welcome-lede">
+              A quick, confidential check on how your team works together. You
+              can answer in one sitting or come back later — your link stays
+              active.
             </p>
-            <p className="ty-sub">
-              You can answer in one sitting or come back later — your link
-              stays active.
-            </p>
-            <div className="hero-cta-row">
+            <WelcomeExpectations
+              timeLabel={timeEstimate}
+              questionCount={sortedQuestions.length}
+              scaleLabel={scaleLabel}
+              confidentialSub="Your individual answers feed the team picture."
+              scoresSub="See where the team stands across each category."
+            />
+            <WelcomeStats
+              questionCount={sortedQuestions.length}
+              sectionCount={sortedSections.length}
+              scaleLabel={scaleLabel}
+            />
+            <div className="su-welcome-cta-row">
               <button
                 type="button"
                 onClick={() => setPhase({ kind: "ready", data: phase.data })}
-                className="wf-btn wf-btn-primary hero-cta"
+                className="su-welcome-cta"
               >
-                Start Assessment
+                Start the assessment →
               </button>
             </div>
+            <p className="su-welcome-fine">
+              Shared with your facilitator or coach to discuss as a team.
+            </p>
           </section>
         </main>
-        <footer className="ty-footer">Powered by Scaling Up</footer>
+        <footer className="su-welcome-foot">Powered by Scaling Up</footer>
       </div>
     );
   }

--- a/src/src/components/assessments/public-quiz-client.tsx
+++ b/src/src/components/assessments/public-quiz-client.tsx
@@ -9,6 +9,13 @@ import {
   type PagerQuestion,
 } from "@/lib/assessments/section-pages";
 import { useAnswerDraft, publicDraftKey } from "@/lib/assessments/use-answer-draft";
+import {
+  WelcomeShellHeader,
+  WelcomeExpectations,
+  WelcomeStats,
+  deriveScaleLabel,
+  deriveTimeEstimate,
+} from "@/components/assessments/assessment-welcome";
 import { BrandedReport } from "@/components/assessments/BrandedReport";
 import type { RespondentReport, QuestionMeta } from "@/lib/assessments/respondent-report";
 import type { ScoreResult } from "@/lib/assessments/scoring";
@@ -101,6 +108,14 @@ export function PublicQuizClient({
     [sections],
   );
 
+  // Welcome stat chips + expectation copy derive from the ACTUAL data (never
+  // hardcoded counts/scale).
+  const scaleLabel = useMemo(() => deriveScaleLabel(sortedQuestions), [sortedQuestions]);
+  const timeEstimate = useMemo(
+    () => deriveTimeEstimate(sortedQuestions.length),
+    [sortedQuestions.length],
+  );
+
   const [step, setStep] = useState<Step>(isOpen ? "intro" : "error");
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
@@ -148,62 +163,59 @@ export function PublicQuizClient({
   }
 
   if (step === "intro") {
-    // WF17 / participant-public-landing — hero-card layout
+    // Screen 1 — de-bared WELCOME / invitation (approved participant mockup).
+    // Branded app-shell header (white logo) + "what to expect" value-prop list
+    // + stat chips (actual counts + derived scale) + strong purple CTA.
     return (
-      <div className="landing-page">
-        <header className="landing-header">
-          <span className="landing-brand">Scaling Up</span>
-          <span>{templateName}</span>
-        </header>
-        <main className="landing-body">
-          <section className="hero-card" aria-labelledby="hero-title">
-            <span className="hero-eyebrow">Free assessment</span>
-            <h1 className="hero-title" id="hero-title">
+      <div className="su-welcome-page">
+        <WelcomeShellHeader caption={templateName} />
+        <main className="su-welcome-body">
+          <section className="su-welcome-card" aria-labelledby="hero-title">
+            <span className="su-welcome-eyebrow">Free assessment</span>
+            <h1 className="su-welcome-title" id="hero-title">
               {campaignName}
             </h1>
             {campaignDescription ? (
-              <p className="hero-lede" style={{ whiteSpace: "pre-line" }}>
+              <p className="su-welcome-lede" style={{ whiteSpace: "pre-line" }}>
                 {campaignDescription}
               </p>
             ) : (
-              <p className="hero-lede">
+              <p className="su-welcome-lede">
                 See how your business scores across the Four Decisions —
                 People, Strategy, Execution, and Cash — and get your results
                 instantly.
               </p>
             )}
-            <p className="hero-sub">
-              Most people finish in about 5–10 minutes, and you&apos;ll see
-              your results as soon as you submit.
-            </p>
-            <div className="hero-stats" aria-label="Assessment details">
-              <span>
-                <strong>{sortedQuestions.length}</strong> questions
-              </span>
-              <span className="hero-stats__dot" />
-              <span>
-                <strong>{sortedSections.length}</strong>{" "}
-                {sortedSections.length === 1 ? "section" : "sections"}
-              </span>
-            </div>
-            <div className="hero-cta-row">
+            <WelcomeExpectations
+              timeLabel={timeEstimate}
+              questionCount={sortedQuestions.length}
+              scaleLabel={scaleLabel}
+              confidentialSub="Your results are shown to you the moment you submit."
+              scoresSub="See where you stand across each category."
+            />
+            <WelcomeStats
+              questionCount={sortedQuestions.length}
+              sectionCount={sortedSections.length}
+              scaleLabel={scaleLabel}
+            />
+            <div className="su-welcome-cta-row">
               <button
                 type="button"
                 onClick={() => setStep("info")}
-                className="wf-btn wf-btn-primary hero-cta"
+                className="su-welcome-cta"
                 data-testid="quiz-start"
               >
-                Start Assessment
+                Start the assessment →
               </button>
             </div>
-            <p className="hero-fine">
+            <p className="su-welcome-fine">
               Free to take — you&apos;ll get your results on screen. Your
               responses are also shared with the Scaling Up team and the
               coach who referred you (if any).
             </p>
           </section>
         </main>
-        <footer className="landing-footer">Powered by Scaling Up</footer>
+        <footer className="su-welcome-foot">Powered by Scaling Up</footer>
       </div>
     );
   }

--- a/src/src/components/assessments/section-pager.tsx
+++ b/src/src/components/assessments/section-pager.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { isAnswered, type SectionPage } from "@/lib/assessments/section-pages";
 import { QuestionInput } from "@/components/assessments/question-input";
 import { AssessmentShellHeader } from "@/components/assessments/AssessmentShellHeader";
+import { domainColor } from "@/lib/assessments/report-presentation";
 
 type AnswersMap = Record<string, number | string | string[]>;
 interface SectionPagerProps {
@@ -83,6 +84,14 @@ export function SectionPager({ pages, answers, onAnswerChange, onSubmit, submitt
   const introForwardLabel = isLast && !hasQuestions ? "Submit" : "Begin section →";
   const questionCount = page.questions.length;
 
+  // Domain accent for the section-intro rail + number badge. Neutral grey when
+  // the section carries no domain (report-presentation handles the fallback).
+  const accent = domainColor(page.domain ?? "");
+  // Step label = the section's own partLabel ("Fundamental 1" in the mockup)
+  // when present. The shell header already carries the canonical "Section N of
+  // M", so we degrade gracefully (omit the step label) rather than duplicate it.
+  const stepLabel = page.partLabel?.trim() ? page.partLabel : null;
+
   return (
     <div className="su-assessment-brand survey-section">
       <AssessmentShellHeader
@@ -96,27 +105,39 @@ export function SectionPager({ pages, answers, onAnswerChange, onSubmit, submitt
       </div>
 
       {view === "intro" ? (
-        <section className="su-intro-slide" aria-labelledby="su-intro-heading">
-          {/* S-curve brand motif */}
-          <svg className="su-intro-swoosh" viewBox="0 0 480 420" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-            <path d="M500 30 C 300 30 350 220 200 270 C 90 305 80 420 -30 440 L 560 440 L 560 30 Z" fill="rgba(255,255,255,0.10)" />
-          </svg>
+        <section
+          className="su-intro-slide"
+          aria-labelledby="su-intro-heading"
+          style={{ ["--su-section-accent" as string]: accent }}
+        >
+          {/* Domain accent rail — colored top bar (neutral when no domain). */}
+          <div className="su-intro-rail" aria-hidden="true" />
           <div className="su-intro-kicker">
             <span className="su-intro-num" aria-hidden="true">{String(sectionIndex + 1).padStart(2, "0")}</span>
-            {page.partLabel ? <span className="su-intro-label">{page.partLabel}</span> : null}
+            <span className="su-intro-stepblock">
+              {stepLabel ? <span className="su-intro-label">{stepLabel}</span> : null}
+              <h2
+                id="su-intro-heading"
+                ref={headingRef}
+                tabIndex={-1}
+                className="su-intro-title"
+              >
+                {page.name}
+              </h2>
+            </span>
           </div>
-          <h2
-            id="su-intro-heading"
-            ref={headingRef}
-            tabIndex={-1}
-            className="su-intro-title"
-          >
-            {page.name}
-          </h2>
-          {page.description ? (
-            <p className="su-intro-desc">{page.description}</p>
+          {page.description?.trim() ? (
+            <div className="su-intro-covers">
+              <span className="su-intro-covers-k">What this section covers</span>
+              <p className="su-intro-desc">{page.description}</p>
+            </div>
           ) : null}
           <div className="su-intro-meta">
+            {questionCount > 0 ? (
+              <span className="su-intro-estimate">
+                {questionCount} question{questionCount !== 1 ? "s" : ""}
+              </span>
+            ) : <span />}
             <button
               type="button"
               className="su-intro-begin"
@@ -125,11 +146,6 @@ export function SectionPager({ pages, answers, onAnswerChange, onSubmit, submitt
             >
               {introForwardLabel}
             </button>
-            {questionCount > 0 ? (
-              <span className="su-intro-estimate">
-                {questionCount} question{questionCount !== 1 ? "s" : ""}
-              </span>
-            ) : null}
           </div>
           <div className="survey-nav su-intro-back-row">
             <button type="button" className="wf-btn wf-btn-ghost su-intro-back" onClick={handleBack}>← Back</button>

--- a/src/src/styles/wireframes-scoped.css
+++ b/src/src/styles/wireframes-scoped.css
@@ -1344,129 +1344,340 @@
 }
 
 /* ===========================================================
-   Section intro slide — purple hero with S-curve motif.
-   Matches /tmp/su-assessment-mockups/quiz.html .slide block.
-   Scoped inside .su-assessment-brand only.
+   Section intro slide ("Screen 2") — DISTINCT white card with a
+   per-domain accent rail + number badge + "what this section covers"
+   callout. Reads as a different beat from the welcome (Screen 1).
+   Matches the approved participant mockup screen 2.
+   Scoped inside .su-assessment-brand only (ADR-0005).
+   The domain accent is fed via the --su-section-accent custom property
+   set inline from domainColor(section.domain) (neutral grey fallback).
    =========================================================== */
 .su-assessment-brand .su-intro-slide {
+  --su-section-accent: #6b6480;            /* fallback; overridden inline */
   position: relative;
-  background: hsl(var(--primary));       /* #522583 purple */
-  color: #fff;
+  background: #fff;
+  color: var(--su-ink, #2b2440);
+  border: 1px solid #ece8f2;
   border-radius: 14px;
-  padding: 3.25rem 3rem 2.5rem;
+  padding: 1.75rem 1.75rem 1.5rem;
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  min-height: 360px;
   margin-bottom: 0;
+  box-shadow: 0 18px 50px -28px rgba(82, 37, 131, 0.35);
 }
 
-/* S-curve SVG motif — absolute, bottom-right, decorative */
-.su-assessment-brand .su-intro-swoosh {
+/* Domain accent rail — colored top bar (the distinct visual hook). */
+.su-assessment-brand .su-intro-rail {
   position: absolute;
-  right: -40px;
-  bottom: -60px;
-  width: 480px;
-  pointer-events: none;
-  z-index: 0;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 6px;
+  background: var(--su-section-accent);
 }
 
-/* Section number + part label row */
+/* Number badge + step label + section name row */
 .su-assessment-brand .su-intro-kicker {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  position: relative;
-  z-index: 1;
-  margin-bottom: 0.75rem;
+  gap: 0.875rem;
+  margin: 0.5rem 0 0.25rem;
 }
 .su-assessment-brand .su-intro-num {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 46px;
+  height: 46px;
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--su-section-accent) 14%, #fff);
+  border: 1.5px solid color-mix(in srgb, var(--su-section-accent) 35%, #fff);
+  /* Darken the digit toward black so it stays legible on the light tint for
+     light-luminance domains (People/Cash) — WCAG-AA large text across domains. */
+  color: color-mix(in srgb, var(--su-section-accent) 64%, #000);
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-  font-weight: 700;
-  font-size: 4rem;
-  line-height: 0.9;
-  color: var(--fd-orange, #f7a600);       /* Four Decisions orange accent */
+  font-weight: 800;
+  font-size: 1.25rem;
+  line-height: 1;
   letter-spacing: -0.02em;
+}
+.su-assessment-brand .su-intro-stepblock {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  min-width: 0;
 }
 .su-assessment-brand .su-intro-label {
   font-size: 0.75rem;
-  letter-spacing: 0.18em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
-  opacity: 0.85;
-  font-weight: 600;
-  white-space: nowrap;
+  color: #6b6480;
+  font-weight: 700;
 }
 
 /* Section title heading */
 .su-assessment-brand .su-intro-title {
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-weight: 700;
-  font-size: 2.25rem;
-  line-height: 1.08;
-  max-width: 600px;
-  margin: 0 0 0.9rem;
-  color: #fff;
-  position: relative;
-  z-index: 1;
+  font-size: 1.5rem;
+  line-height: 1.18;
+  margin: 0;
+  color: var(--su-ink, #2b2440);
+  letter-spacing: -0.01em;
 }
 
-/* Intro description paragraph — from section.description (ADR-0004) */
+/* "What this section covers" callout — wraps section.description (ADR-0004).
+   Hidden entirely (not rendered) when there's no description. */
+.su-assessment-brand .su-intro-covers {
+  background: #faf8fd;
+  border: 1px solid #ece8f2;
+  border-radius: 12px;
+  padding: 0.875rem 1rem;
+  margin: 1rem 0 0.25rem;
+}
+.su-assessment-brand .su-intro-covers-k {
+  display: block;
+  font-size: 0.6875rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #6b6480;
+  font-weight: 700;
+  margin-bottom: 0.375rem;
+}
 .su-assessment-brand .su-intro-desc {
-  max-width: 540px;
-  font-size: 1rem;
-  line-height: 1.6;
-  opacity: 0.92;
-  margin: 0 0 1.5rem;
+  font-size: 0.9375rem;
+  line-height: 1.55;
+  color: var(--su-ink, #2b2440);
+  margin: 0;
   white-space: pre-line;
-  position: relative;
-  z-index: 1;
 }
 
 /* Begin button + question-count estimate row */
 .su-assessment-brand .su-intro-meta {
   display: flex;
   align-items: center;
-  gap: 1.125rem;
-  position: relative;
-  z-index: 1;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-top: 1.125rem;
 }
 .su-assessment-brand .su-intro-begin {
-  background: var(--fd-orange, #f7a600);
-  color: #3a2400;
+  background: hsl(var(--primary));         /* #522583 purple CTA */
+  color: #fff;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-weight: 700;
-  font-size: 1rem;
+  font-size: 0.9375rem;
   border: none;
-  border-radius: 9px;
-  padding: 0.8rem 1.75rem;
+  border-radius: 10px;
+  padding: 0.75rem 1.25rem;
   cursor: pointer;
   transition: opacity 0.12s;
   white-space: nowrap;
+  box-shadow: 0 10px 22px -12px rgba(82, 37, 131, 0.7);
 }
-.su-assessment-brand .su-intro-begin:hover { opacity: 0.88; }
+.su-assessment-brand .su-intro-begin:hover { opacity: 0.9; }
 .su-assessment-brand .su-intro-begin:disabled { opacity: 0.45; cursor: not-allowed; }
 .su-assessment-brand .su-intro-estimate {
   font-size: 0.8125rem;
-  opacity: 0.8;
+  color: #6b6480;
 }
 
-/* Back nav row — ghost link below the hero content */
+/* Back nav row — ghost link below the card content */
 .su-assessment-brand .su-intro-back-row {
-  position: relative;
-  z-index: 1;
-  margin-top: 1.5rem;
+  margin-top: 0.75rem;
   justify-content: flex-start;
 }
 .su-assessment-brand .su-intro-back {
-  color: rgba(255, 255, 255, 0.75);
+  color: #6b6480;
   font-size: 0.875rem;
 }
-.su-assessment-brand .su-intro-back:hover { color: #fff; background: transparent; }
+.su-assessment-brand .su-intro-back:hover { color: hsl(var(--primary)); background: transparent; }
 
 @media (max-width: 640px) {
-  .su-assessment-brand .su-intro-slide { padding: 2.25rem 1.5rem 2rem; min-height: 280px; }
-  .su-assessment-brand .su-intro-num { font-size: 2.75rem; }
-  .su-assessment-brand .su-intro-title { font-size: 1.625rem; }
-  .su-assessment-brand .su-intro-swoosh { width: 280px; right: -20px; bottom: -40px; }
+  .su-assessment-brand .su-intro-slide { padding: 1.5rem 1.25rem 1.25rem; }
+  .su-assessment-brand .su-intro-title { font-size: 1.3125rem; }
+  .su-assessment-brand .su-intro-meta { flex-wrap: wrap; }
+}
+
+/* ===========================================================
+   Welcome ("Screen 1") — de-bared invitation / lead-magnet.
+   Branded app-shell header (white logo on purple) + value-prop
+   "what to expect" list + stat chips + strong purple CTA.
+   Shared by the PUBLIC quiz and the INVITED survey (copy differs
+   per flow, styling is identical). Scoped to .su-assessment-brand
+   only (ADR-0005) — no global selectors, no token changes.
+   =========================================================== */
+.su-assessment-brand .su-welcome-page {
+  min-height: 100vh;
+  background: hsl(var(--background));
+  display: flex;
+  flex-direction: column;
+}
+.su-assessment-brand .su-welcome-shell {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  background: hsl(var(--primary));         /* #522583 purple */
+  color: #fff;
+  padding: 0.875rem 1.25rem;
+}
+.su-assessment-brand .su-welcome-logo {
+  height: 26px;
+  width: auto;
+  display: block;
+  flex: 0 0 auto;
+}
+.su-assessment-brand .su-welcome-shell-caption {
+  font-size: 0.8125rem;
+  color: rgba(255, 255, 255, 0.82);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+.su-assessment-brand .su-welcome-body {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1.25rem;
+}
+.su-assessment-brand .su-welcome-card {
+  background: #fff;
+  border: 1px solid #ece8f2;
+  border-radius: 16px;
+  box-shadow: 0 18px 50px -24px rgba(82, 37, 131, 0.45);
+  padding: 2rem 1.75rem;
+  max-width: 32rem;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+}
+.su-assessment-brand .su-welcome-eyebrow {
+  display: inline-block;
+  align-self: flex-start;
+  font-size: 0.6875rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.13em;
+  color: hsl(var(--primary));
+  background: #f0e9fa;
+  padding: 0.3125rem 0.6875rem;
+  border-radius: 999px;
+}
+.su-assessment-brand .su-welcome-title {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 1.625rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  line-height: 1.18;
+  margin: 0.875rem 0 0.5rem;
+  color: var(--su-ink, #2b2440);
+}
+.su-assessment-brand .su-welcome-lede {
+  font-size: 0.9375rem;
+  color: #6b6480;
+  margin: 0;
+  line-height: 1.55;
+}
+
+/* value-prop "what to expect" list — icon + bold label + muted sub */
+.su-assessment-brand .su-welcome-expect {
+  list-style: none;
+  display: grid;
+  gap: 0.6875rem;
+  margin: 1.125rem 0 1.25rem;
+  padding: 0;
+}
+.su-assessment-brand .su-welcome-expect-item {
+  display: flex;
+  gap: 0.6875rem;
+  align-items: flex-start;
+}
+.su-assessment-brand .su-welcome-expect-ic {
+  flex: 0 0 28px;
+  height: 28px;
+  border-radius: 9px;
+  background: #f0e9fa;
+  color: hsl(var(--primary));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.875rem;
+}
+.su-assessment-brand .su-welcome-expect-text {
+  display: flex;
+  flex-direction: column;
+}
+.su-assessment-brand .su-welcome-expect-text b {
+  font-size: 0.84375rem;
+  color: var(--su-ink, #2b2440);
+}
+.su-assessment-brand .su-welcome-expect-text span {
+  font-size: 0.78125rem;
+  color: #6b6480;
+}
+
+/* stat chips — questions / sections / scale (actual data) */
+.su-assessment-brand .su-welcome-meta {
+  display: flex;
+  gap: 0.5rem;
+  margin: 0 0 1.25rem;
+}
+.su-assessment-brand .su-welcome-chip {
+  flex: 1;
+  background: #faf8fd;
+  border: 1px solid #ece8f2;
+  border-radius: 12px;
+  padding: 0.625rem;
+  text-align: center;
+}
+.su-assessment-brand .su-welcome-chip b {
+  display: block;
+  font-size: 1.1875rem;
+  color: hsl(var(--primary));
+}
+.su-assessment-brand .su-welcome-chip span {
+  font-size: 0.6875rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #6b6480;
+}
+
+/* strong full-width purple CTA */
+.su-assessment-brand .su-welcome-cta-row {
+  display: flex;
+}
+.su-assessment-brand .su-welcome-cta {
+  display: block;
+  width: 100%;
+  border: 0;
+  border-radius: 12px;
+  background: hsl(var(--primary));
+  color: #fff;
+  font-size: 0.9375rem;
+  font-weight: 700;
+  padding: 0.875rem;
+  cursor: pointer;
+  letter-spacing: 0.01em;
+  box-shadow: 0 10px 22px -10px rgba(82, 37, 131, 0.7);
+  transition: opacity 0.12s;
+}
+.su-assessment-brand .su-welcome-cta:hover { opacity: 0.92; }
+.su-assessment-brand .su-welcome-fine {
+  font-size: 0.71875rem;
+  color: #6b6480;
+  text-align: center;
+  margin: 0.8125rem 0 0;
+}
+.su-assessment-brand .su-welcome-foot {
+  padding: 1.25rem;
+  text-align: center;
+  font-size: 0.75rem;
+  color: hsl(var(--muted-foreground));
+  border-top: 1px solid hsl(var(--border));
+  background: hsl(var(--card));
 }


### PR DESCRIPTION
Addresses the user's UX feedback ("the invitation card looks bare, then you get the nice welcome — confusing"). Direction chosen by the user: **two screens, both polished and distinct**. Designed via brainstorm → a frontend-design mockup the user approved ("this looks immaculate").

**Screen 1 — Welcome / invitation (de-bared):** new shared `<AssessmentWelcome>` blocks (`WelcomeShellHeader` + `WelcomeExpectations` + `WelcomeStats`) used by BOTH the public quiz and the invited org-survey — branded app-shell header, a "what to expect" value-prop list, **data-derived** stat chips (questions/sections/scale — not hardcoded), strong CTA, honest fine print. Public keeps the lead-magnet copy; invited keeps team framing.

**Screen 2 — Section intro (now distinct):** the `SectionPager` section slide gets a per-domain **accent rail** (`domainColor`, neutral fallback) + number badge + a **"What this section covers"** callout (from `section.description`, hidden when absent) + segmented progress. Reads as a different beat from the welcome, so the two no longer feel redundant.

**Scope (ADR-0005):** all new CSS scoped under `.su-assessment-brand` — zero global-token change, zero leak to the blue admin/coach UI.

**Review (adversarial workflow, 3 lenses):** **HIGH FIDELITY** to the approved mockup · **FULLY SCOPED** (no leak) · a11y **PASS**. Fixes applied from review: render the quiz route client **full-bleed** (it was constrained to `max-w-2xl`, making the new full-bleed welcome shell look inset vs the org-survey flow), **darken the section number badge** for legible contrast on light domains (People/Cash), drop a dead var.

41 tests / 5 suites green (4 new); `CI=true npx next build --turbopack` clean. Shared components → both the Quick Assessment and Five Dysfunctions (and all others) get the polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)