### PR TITLE
feat(assessments): polished results report + report emails + per-coach links (Spec 16)

### DIFF
--- a/docs/specs/v7.6/16-quick-assessment-report-emails-and-coach-links.md
+++ b/docs/specs/v7.6/16-quick-assessment-report-emails-and-coach-links.md
@@ -1,0 +1,44 @@
+# Spec 16 — Quick Assessment: polished results report, report emails, per-coach links
+
+> Status: APPROVED (brainstorm + frontend-design mockup approved by the user 2026-06-11). Build target.
+> Builds on Spec 15 (Quick Assessment) + ADR-0008 (public self-assessments show the taker their results in-place).
+
+## Problem (from live testing)
+
+The public Quick Assessment is live, but: (1) the results page is the **bare, unstyled** `BrandedReport` (its detailed styling was deferred in PR #41 — per-statement rows render with the score digit jammed onto the text); (2) a bare public link has **no coach attribution** ("which coach gets the lead?"); (3) **nobody receives a copy** — the taker sees it once on screen, the SU team gets only a lead-alert summary, the coach gets nothing.
+
+## Decisions (approved)
+
+- **Lead model:** keep the **public website link** (leads → Scaling Up team) AND add **per-coach attributed links** (`?coach=<ref>`); the existing active-coach guard validates — a bad/inactive ref silently falls back to SU-team-only.
+- **Distribution:** **email the taker a copy** of their report + send the **referring coach the full report** (upgraded from the lead alert); the **SU team keeps the lead-alert summary**.
+- **Email format:** **HTML email, report rendered inline** (no attachment, no persistent/guessable results URL — preserves ADR-0008's privacy stance).
+- **Report look:** the approved mockup (`/tmp/su-report-mockup/index.html`) — cover → overall ring/band → per-decision cards (Four-Decisions colors) → score-summary table → detailed breakdown with **aligned score chips** → conclusion + coach CTA → footer. Email/print-safe single column.
+
+## §1 — Report rendering (on-screen)
+
+Implement the approved detailed styling for `BrandedReport` (cover, overall ring + band + meta, per-domain cards with bars, clean score-summary table, **fixed** per-statement rows with right-aligned score chips, conclusion + CTA, footer/provenance). All CSS scoped under `.su-public-brand .su-report` (ADR-0005 — zero leak to admin/coach). Drives both the public in-place results AND the invited `(report)` route (same component).
+
+## §2 — Email-safe report HTML builder
+
+New `src/src/lib/assessments/report-email.ts` → `buildReportEmailHtml({ report, recipientRole })`: returns inline-styled, table-layout **email-safe** HTML matching the mockup (email clients drop external CSS + many features). HTML-escape all interpolated values. Pure + unit-tested. Reuses `report-presentation.ts` helpers. The coach version may add a short "your client just completed this" lead-in; the taker version is "your results."
+
+## §3 — Distribution (durable outbox + Inngest worker)
+
+Extend the existing outbox/worker (Spec 15). New/changed `emailType` + `recipientRole` rows enqueued **in the submission transaction**:
+- `TAKER_COPY` → the taker (always; their submitted email). Report HTML via §2.
+- `REFERRING_COACH` → the active referring coach **(full report via §2, upgraded from the lead-alert)**.
+- `SU_TEAM` → unchanged lead-alert summary (only when an SU address is configured).
+Idempotent (the `@@unique([submissionId, recipientRole])` already enforces one row per role); the worker sends each via SMTP with the existing backoff/cron drain. No schema change (`emailType`/`recipientRole` are String columns; the outbox model already exists) — **additive, zero migration**.
+
+## §4 — Per-coach attribution
+
+- `public-quiz-client.tsx`: read `?coach=<ref>` (`useSearchParams`) and send it as `referringCoachEmail` in the submit body. The existing `findActiveCoachByEmail` open-relay guard validates it (active, non-expired coach only); anything else → SU-team-only. (`ref` is the coach's email for v1.)
+- Coach portal: a **"Copy my assessment link"** affordance that yields `${APP_URL}/quiz/<publicQuickAlias>?coach=<coachEmail>`, where `<publicQuickAlias>` resolves to the active PUBLIC campaign of the `scaling-up-quick` template. If that resolution is non-trivial, ship the capture (above) first and flag the button as a fast follow.
+
+## §5 — Consent / privacy
+
+Update the consent line + contact-step copy to disclose the **emailed copy** (to the taker, and the full report to the referring coach if any). The active-coach guard prevents a report from being emailed to an arbitrary address. No persistent public results endpoint (ADR-0008 preserved — the report travels inside the email, not via a URL).
+
+## §6 — Safety / process
+
+Additive only — **no migration**. TDD; build gate `CI=true npx next build --turbopack`. Brand stays scoped (ADR-0005). Adversarial review before merge (Greptile dropped → superpowers code-reviewer). Stop at a green PR.

--- a/src/src/__tests__/api/quick-assessment-submit.test.ts
+++ b/src/src/__tests__/api/quick-assessment-submit.test.ts
@@ -350,25 +350,45 @@ describe("new submission — inngest.send", () => {
 /*  Task 6 new behavior: outbox rows                                          */
 /* -------------------------------------------------------------------------- */
 describe("outbox enqueue", () => {
-  it("enqueues 0 outbox rows when SU team address is blank and no coach", async () => {
-    // No env vars set → suTeamAddress = ""
-    await POST(makeRequest(VALID_BODY) as never, makeParams() as never);
-    expect(txMock.assessmentEmailOutbox.create).not.toHaveBeenCalled();
-  });
+  /** Helper: pull recipientRole values from the txMock create calls. */
+  function enqueuedRoles(): string[] {
+    return txMock.assessmentEmailOutbox.create.mock.calls.map(
+      (c: Array<{ data: { recipientRole: string } }>) => c[0].data.recipientRole,
+    );
+  }
 
-  it("enqueues 1 SU_TEAM row when SU address is set and no coach", async () => {
-    process.env.QUICK_ASSESSMENT_TEAM_EMAIL = "team@scalingup.com";
+  it("ALWAYS enqueues a TAKER_COPY row even with blank SU address and no coach (Spec 16 §3)", async () => {
+    // No env vars set → suTeamAddress = ""; no coach → only TAKER_COPY.
     await POST(makeRequest(VALID_BODY) as never, makeParams() as never);
 
     expect(txMock.assessmentEmailOutbox.create).toHaveBeenCalledTimes(1);
     const call = txMock.assessmentEmailOutbox.create.mock.calls[0][0];
-    expect(call.data.recipientRole).toBe("SU_TEAM");
-    expect(call.data.recipientEmail).toBe("team@scalingup.com");
-    expect(call.data.emailType).toBe("QUICK_ASSESSMENT_LEAD");
+    expect(call.data.recipientRole).toBe("TAKER_COPY");
+    expect(call.data.recipientEmail).toBe("jane@example.com");
     expect(call.data.submissionId).toBe("sub-1");
+    expect(call.data.bodyHtml).toContain("<table");
   });
 
-  it("enqueues 2 rows (SU_TEAM + REFERRING_COACH) when SU address set and active coach found", async () => {
+  it("enqueues TAKER_COPY + SU_TEAM when SU address is set and no coach", async () => {
+    process.env.QUICK_ASSESSMENT_TEAM_EMAIL = "team@scalingup.com";
+    await POST(makeRequest(VALID_BODY) as never, makeParams() as never);
+
+    expect(txMock.assessmentEmailOutbox.create).toHaveBeenCalledTimes(2);
+    const roles = enqueuedRoles();
+    expect(roles).toContain("TAKER_COPY");
+    expect(roles).toContain("SU_TEAM");
+    expect(roles).not.toContain("REFERRING_COACH");
+
+    // SU_TEAM row carries the unchanged lead-alert email type + address.
+    const su = txMock.assessmentEmailOutbox.create.mock.calls
+      .map((c: Array<{ data: { recipientRole: string; recipientEmail: string; emailType: string } }>) => c[0].data)
+      .find((d: { recipientRole: string }) => d.recipientRole === "SU_TEAM");
+    expect(su).toBeDefined();
+    expect(su!.recipientEmail).toBe("team@scalingup.com");
+    expect(su!.emailType).toBe("QUICK_ASSESSMENT_LEAD");
+  });
+
+  it("enqueues 3 rows (TAKER_COPY + REFERRING_COACH + SU_TEAM) when SU address set and active coach found", async () => {
     process.env.QUICK_ASSESSMENT_TEAM_EMAIL = "team@scalingup.com";
     // Active coach returned by findUnique
     (db.coach.findUnique as jest.Mock).mockResolvedValue({
@@ -386,12 +406,34 @@ describe("outbox enqueue", () => {
     };
     await POST(makeRequest(bodyWithCoach) as never, makeParams() as never);
 
-    expect(txMock.assessmentEmailOutbox.create).toHaveBeenCalledTimes(2);
-    const roles = txMock.assessmentEmailOutbox.create.mock.calls.map(
-      (c: Array<{ data: { recipientRole: string } }>) => c[0].data.recipientRole,
-    );
+    expect(txMock.assessmentEmailOutbox.create).toHaveBeenCalledTimes(3);
+    const roles = enqueuedRoles();
+    expect(roles).toContain("TAKER_COPY");
     expect(roles).toContain("SU_TEAM");
     expect(roles).toContain("REFERRING_COACH");
+
+    // The REFERRING_COACH row is the FULL report (not the lead alert).
+    const coachRow = txMock.assessmentEmailOutbox.create.mock.calls
+      .map((c: Array<{ data: { recipientRole: string; recipientEmail: string; bodyHtml: string } }>) => c[0].data)
+      .find((d: { recipientRole: string }) => d.recipientRole === "REFERRING_COACH");
+    expect(coachRow).toBeDefined();
+    expect(coachRow!.recipientEmail).toBe("coach@example.com");
+    expect(coachRow!.bodyHtml).toContain("<table");
+  });
+
+  it("REFERRING_COACH row is NOT enqueued when the coach is not active (guard returns null)", async () => {
+    process.env.QUICK_ASSESSMENT_TEAM_EMAIL = "team@scalingup.com";
+    // db.coach.findUnique default mock returns null → no active coach.
+    const bodyWithCoach = {
+      ...VALID_BODY,
+      referringCoachEmail: "ghost@example.com",
+    };
+    await POST(makeRequest(bodyWithCoach) as never, makeParams() as never);
+
+    const roles = enqueuedRoles();
+    expect(roles).toContain("TAKER_COPY");
+    expect(roles).toContain("SU_TEAM");
+    expect(roles).not.toContain("REFERRING_COACH");
   });
 
   it("outbox rows are created inside the transaction (via txMock)", async () => {

--- a/src/src/__tests__/assessments/report-email.test.ts
+++ b/src/src/__tests__/assessments/report-email.test.ts
@@ -1,0 +1,364 @@
+/**
+ * Spec 16 §2 — buildReportEmailHtml unit tests.
+ *
+ * The email-safe report HTML builder renders a RespondentReport into inline-
+ * styled, table-layout HTML that survives Outlook/Gmail (no external CSS, no
+ * flex/grid). Pure — no DB, no network. Reuses report-presentation.ts for
+ * band / headline / domain-color logic. Every interpolated value HTML-escaped.
+ *
+ * These tests assert:
+ *  - the overall score (headline metric) renders
+ *  - the per-domain (or per-section) scores render
+ *  - a taker name containing <script> is HTML-escaped (no raw tag)
+ *  - the body has NO external CSS deps (<link rel=stylesheet>, <style>@import)
+ *  - the body uses NO layout that breaks email (display:flex / display:grid)
+ *  - subject differs by recipientRole
+ */
+
+import { buildReportEmailHtml } from "@/lib/assessments/report-email";
+import type { RespondentReport } from "@/lib/assessments/respondent-report";
+import type { ScoreResult } from "@/lib/assessments/scoring";
+
+// ── Fixture builders ─────────────────────────────────────────────────────────
+
+function baseReport(overrides: Partial<RespondentReport> = {}): RespondentReport {
+  return {
+    respondentName: "Monks Koala",
+    jobTitle: null,
+    companyName: "Acme Corp",
+    assessmentName: "Scaling Up 4 Decisions Assessment",
+    campaignLabel: null,
+    submittedAt: new Date("2026-06-11T10:00:00Z"),
+    result: {} as ScoreResult,
+    sections: [],
+    questionByKey: {},
+    questionsByKey: {},
+    rawAnswers: [],
+    scoringConfig: {},
+    provenance: {
+      submissionId: "sub-1",
+      versionId: "ver-1",
+      contentHash: "abcdef0123456789",
+      templateName: "Scaling Up 4 Decisions Assessment",
+    },
+    degraded: false,
+    ...overrides,
+  };
+}
+
+/** SU 4-Decisions style report — domains + scaleUpScore + per-section rows. */
+function fourDecisionsReport(
+  overrides: Partial<RespondentReport> = {},
+): RespondentReport {
+  const result: ScoreResult = {
+    perQuestion: [
+      { stableKey: "q1", value: 3, achieved: false },
+      { stableKey: "q2", value: 9, achieved: true },
+    ],
+    perSection: [
+      {
+        stableKey: "s_people",
+        name: "People",
+        totalPoints: 36,
+        averagePoints: 4.5,
+        achievedCount: 1,
+        totalCount: 2,
+      },
+      {
+        stableKey: "s_cash",
+        name: "Cash",
+        totalPoints: 64,
+        averagePoints: 8,
+        achievedCount: 2,
+        totalCount: 2,
+      },
+    ],
+    perDomain: [
+      {
+        key: "people",
+        label: "People",
+        averagePoints: 4.5,
+        answeredSectionCount: 1,
+        totalSectionCount: 1,
+        tier: null,
+      },
+      {
+        key: "cash",
+        label: "Cash",
+        averagePoints: 8,
+        answeredSectionCount: 1,
+        totalSectionCount: 1,
+        tier: null,
+      },
+    ],
+    overallTotal: 184,
+    overallAverage: 5.75,
+    countAchieved: 1,
+    tier: { label: "Developing", message: "You have built a solid foundation." },
+    tierMetricValue: 5.75,
+    scaleUpScore: 58,
+    unansweredKeys: [],
+  };
+  return baseReport({
+    result,
+    sections: [
+      {
+        stableKey: "s_people",
+        name: "People",
+        domain: "people",
+        questions: [{ stableKey: "q1" }],
+      },
+      {
+        stableKey: "s_cash",
+        name: "Cash",
+        domain: "cash",
+        questions: [{ stableKey: "q2" }],
+      },
+    ],
+    questionByKey: {
+      q1: "Our employees are highly engaged.",
+      q2: "Our financial statements are accurate and timely.",
+    },
+    questionsByKey: {
+      q1: {
+        type: "SLIDER_LIKERT",
+        label: "Our employees are highly engaged.",
+        sectionStableKey: "s_people",
+        min: 0,
+        max: 10,
+      },
+      q2: {
+        type: "SLIDER_LIKERT",
+        label: "Our financial statements are accurate and timely.",
+        sectionStableKey: "s_cash",
+        min: 0,
+        max: 10,
+      },
+    },
+    rawAnswers: [
+      { stableKey: "q1", value: 3 },
+      { stableKey: "q2", value: 9 },
+    ],
+    scoringConfig: {
+      tierMetric: "overallAvg",
+      passThreshold: 0,
+      scaleUpScore: true,
+      tiers: [{ minMetric: 0, label: "Developing", message: "" }],
+      domains: [
+        { key: "people", label: "People", tiers: [] },
+        { key: "cash", label: "Cash", tiers: [] },
+      ],
+    },
+    ...overrides,
+  });
+}
+
+/** Neutral (QSP/LVA) — single tier, passThreshold 0, no domains. */
+function neutralReport(): RespondentReport {
+  const result: ScoreResult = {
+    perQuestion: [{ stableKey: "q1", value: 4, achieved: true }],
+    perSection: [
+      {
+        stableKey: "s1",
+        name: "Priorities",
+        totalPoints: 4,
+        averagePoints: 4,
+        achievedCount: 1,
+        totalCount: 1,
+      },
+    ],
+    overallTotal: 4,
+    overallAverage: 4,
+    countAchieved: 1,
+    tier: { label: "Submitted", message: "" },
+    tierMetricValue: 4,
+    unansweredKeys: [],
+  };
+  return baseReport({
+    assessmentName: "Quarterly Strategy Pulse",
+    result,
+    sections: [
+      { stableKey: "s1", name: "Priorities", questions: [{ stableKey: "q1" }] },
+    ],
+    questionByKey: { q1: "We have a clear top priority" },
+    questionsByKey: {
+      q1: { type: "SLIDER_LIKERT", label: "We have a clear top priority", sectionStableKey: "s1" },
+    },
+    rawAnswers: [{ stableKey: "q1", value: 4 }],
+    scoringConfig: {
+      tierMetric: "overallAvg",
+      passThreshold: 0,
+      tiers: [{ minMetric: 0, label: "Submitted", message: "" }],
+    },
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe("buildReportEmailHtml — overall score", () => {
+  it("renders the overall headline metric (ScaleUp score)", () => {
+    const { bodyHtml } = buildReportEmailHtml({
+      report: fourDecisionsReport(),
+      recipientRole: "TAKER_COPY",
+    });
+    expect(bodyHtml).toContain("58");
+    expect(bodyHtml).toContain("Developing");
+  });
+
+  it("renders a neutral 'Submitted' overall for a neutral template", () => {
+    const { bodyHtml } = buildReportEmailHtml({
+      report: neutralReport(),
+      recipientRole: "TAKER_COPY",
+    });
+    expect(bodyHtml).toContain("Submitted");
+  });
+});
+
+describe("buildReportEmailHtml — per-domain / per-section scores", () => {
+  it("renders each per-domain row with its score", () => {
+    const { bodyHtml } = buildReportEmailHtml({
+      report: fourDecisionsReport(),
+      recipientRole: "TAKER_COPY",
+    });
+    expect(bodyHtml).toContain("People");
+    expect(bodyHtml).toContain("Cash");
+    // section totals / averages surfaced
+    expect(bodyHtml).toContain("36");
+    expect(bodyHtml).toContain("64");
+    expect(bodyHtml).toContain("4.5");
+    expect(bodyHtml).toContain("8");
+  });
+
+  it("renders per-section rows when there are no domains (neutral)", () => {
+    const { bodyHtml } = buildReportEmailHtml({
+      report: neutralReport(),
+      recipientRole: "TAKER_COPY",
+    });
+    expect(bodyHtml).toContain("Priorities");
+  });
+});
+
+describe("buildReportEmailHtml — HTML escaping", () => {
+  it("escapes a taker name containing <script> in the HTML body (not raw tag)", () => {
+    const report = fourDecisionsReport({
+      respondentName: '<script>alert("xss")</script>',
+    });
+    const { bodyHtml, subject } = buildReportEmailHtml({
+      report,
+      recipientRole: "REFERRING_COACH",
+    });
+    // Body must HTML-escape the name — never emit a raw <script> tag.
+    expect(bodyHtml).not.toContain("<script>");
+    expect(bodyHtml).toContain("&lt;script&gt;");
+    // Subject is a plain-text MIME header — must NOT HTML-escape; the raw
+    // (control-stripped) name goes in verbatim so the inbox shows it correctly.
+    expect(subject).not.toContain("&lt;script&gt;");
+    expect(subject).toContain("<script>");
+  });
+
+  it("escapes a malicious section name (rendered in the score table)", () => {
+    const report = fourDecisionsReport();
+    // Corrupt a section name with markup; it surfaces in the score-summary row.
+    report.result.perSection[0] = {
+      ...report.result.perSection[0],
+      name: "<img src=x onerror=1>",
+    };
+    // Section name also comes from the parsed version sections JSON; corrupt both.
+    report.sections = [
+      { stableKey: "s_people", name: "<img src=x onerror=1>", domain: "people", questions: [{ stableKey: "q1" }] },
+      { stableKey: "s_cash", name: "Cash", domain: "cash", questions: [{ stableKey: "q2" }] },
+    ];
+    const { bodyHtml } = buildReportEmailHtml({
+      report,
+      recipientRole: "TAKER_COPY",
+    });
+    expect(bodyHtml).not.toContain("<img src=x");
+    expect(bodyHtml).toContain("&lt;img src=x");
+  });
+});
+
+describe("buildReportEmailHtml — email safety", () => {
+  it("has NO external stylesheet or @import dependencies", () => {
+    const { bodyHtml } = buildReportEmailHtml({
+      report: fourDecisionsReport(),
+      recipientRole: "TAKER_COPY",
+    });
+    expect(bodyHtml).not.toMatch(/<link[^>]+stylesheet/i);
+    expect(bodyHtml).not.toContain("@import");
+  });
+
+  it("uses NO flex/grid layout (Outlook-safe table layout only)", () => {
+    const { bodyHtml } = buildReportEmailHtml({
+      report: fourDecisionsReport(),
+      recipientRole: "TAKER_COPY",
+    });
+    expect(bodyHtml).not.toMatch(/display\s*:\s*flex/i);
+    expect(bodyHtml).not.toMatch(/display\s*:\s*grid/i);
+  });
+
+  it("uses a <table> for layout", () => {
+    const { bodyHtml } = buildReportEmailHtml({
+      report: fourDecisionsReport(),
+      recipientRole: "TAKER_COPY",
+    });
+    expect(bodyHtml).toMatch(/<table/i);
+  });
+});
+
+describe("buildReportEmailHtml — subject by role", () => {
+  it("taker subject is 'Your Scaling Up 4 Decisions results'", () => {
+    const { subject } = buildReportEmailHtml({
+      report: fourDecisionsReport(),
+      recipientRole: "TAKER_COPY",
+    });
+    expect(subject).toBe("Your Scaling Up 4 Decisions results");
+  });
+
+  it("coach subject embeds the plain taker name (no HTML entities) + 'completed'", () => {
+    const { subject } = buildReportEmailHtml({
+      report: fourDecisionsReport({ respondentName: "Jane Doe" }),
+      recipientRole: "REFERRING_COACH",
+    });
+    expect(subject).toContain("Jane Doe");
+    expect(subject).toContain("completed");
+    expect(subject).toContain("Scaling Up 4 Decisions");
+    // Must be plain text — MIME headers must not contain HTML entities.
+    expect(subject).not.toContain("&");
+  });
+
+  it("coach subject with apostrophe in name is NOT HTML-escaped", () => {
+    const { subject } = buildReportEmailHtml({
+      report: fourDecisionsReport({ respondentName: "O'Brien" }),
+      recipientRole: "REFERRING_COACH",
+    });
+    // Plain text — apostrophe passes through, not encoded as &#x27;
+    expect(subject).toContain("O'Brien");
+    expect(subject).not.toContain("&#x27;");
+    expect(subject).not.toContain("&amp;");
+  });
+
+  it("coach subject strips control characters from taker name (header injection guard)", () => {
+    const { subject } = buildReportEmailHtml({
+      report: fourDecisionsReport({ respondentName: "Eve\r\nBcc: evil@ex.com" }),
+      recipientRole: "REFERRING_COACH",
+    });
+    // Control chars (\r\n) stripped — header injection prevented.
+    expect(subject).not.toContain("\r");
+    expect(subject).not.toContain("\n");
+    expect(subject).toContain("Eve");
+  });
+
+  it("the two roles produce different subjects", () => {
+    const report = fourDecisionsReport({ respondentName: "Jane Doe" });
+    const taker = buildReportEmailHtml({ report, recipientRole: "TAKER_COPY" });
+    const coach = buildReportEmailHtml({ report, recipientRole: "REFERRING_COACH" });
+    expect(taker.subject).not.toBe(coach.subject);
+  });
+
+  it("the coach body carries a 'your client' lead-in the taker body does not", () => {
+    const report = fourDecisionsReport({ respondentName: "Jane Doe" });
+    const taker = buildReportEmailHtml({ report, recipientRole: "TAKER_COPY" });
+    const coach = buildReportEmailHtml({ report, recipientRole: "REFERRING_COACH" });
+    expect(taker.bodyHtml).not.toBe(coach.bodyHtml);
+  });
+});

--- a/src/src/__tests__/components/public-quiz-results.test.tsx
+++ b/src/src/__tests__/components/public-quiz-results.test.tsx
@@ -20,6 +20,8 @@ Object.defineProperty(globalThis, "crypto", {
 });
 
 const mockPush = jest.fn();
+// Mutable search-param store so individual tests can simulate `?coach=<ref>`.
+let mockSearchParams: Record<string, string> = {};
 jest.mock("next/navigation", () => ({
   useRouter: () => ({
     push: mockPush,
@@ -28,7 +30,9 @@ jest.mock("next/navigation", () => ({
     back: jest.fn(),
     forward: jest.fn(),
   }),
-  useSearchParams: () => ({ get: jest.fn() }),
+  useSearchParams: () => ({
+    get: (key: string) => mockSearchParams[key] ?? null,
+  }),
   usePathname: () => "/",
 }));
 
@@ -129,6 +133,7 @@ describe("PublicQuizClient — in-place results + consent + idempotency (Task 7)
     jest.clearAllMocks();
     localStorage.clear();
     sessionStorage.clear();
+    mockSearchParams = {};
   });
 
   // ── T7-1: Consent line visible during the form step ─────────────────────
@@ -235,5 +240,72 @@ describe("PublicQuizClient — in-place results + consent + idempotency (Task 7)
       screen.queryByText(/coach who sent this/i),
     ).not.toBeInTheDocument();
     expect(screen.queryByText(/facilitator will follow up/i)).not.toBeInTheDocument();
+  });
+
+  // ── §4: ?coach=<ref> is forwarded as referringCoachEmail in the POST body ──
+  it("sends the ?coach= param as referringCoachEmail in the submit body", async () => {
+    mockSearchParams = { coach: "coach@example.com" };
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        success: true,
+        data: {
+          submissionId: "sub_1",
+          scoreResult: scoreResultFixture,
+          redirectUrl: `/quiz/${ALIAS}/thank-you`,
+        },
+      }),
+    });
+
+    render(<PublicQuizClient {...baseProps} />);
+    reachFormStep();
+
+    fireEvent.change(screen.getByRole("slider"), { target: { value: "6" } });
+    fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.referringCoachEmail).toBe("coach@example.com");
+  });
+
+  it("omits referringCoachEmail entirely when no ?coach= param is present", async () => {
+    // mockSearchParams reset to {} in beforeEach → no coach.
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        success: true,
+        data: {
+          submissionId: "sub_1",
+          scoreResult: scoreResultFixture,
+          redirectUrl: `/quiz/${ALIAS}/thank-you`,
+        },
+      }),
+    });
+
+    render(<PublicQuizClient {...baseProps} />);
+    reachFormStep();
+
+    fireEvent.change(screen.getByRole("slider"), { target: { value: "6" } });
+    fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body).not.toHaveProperty("referringCoachEmail");
+  });
+
+  // ── §5: consent + info copy disclose the emailed copy honestly ──────────
+  it("consent line discloses the emailed copy + full report to the referring coach", () => {
+    render(<PublicQuizClient {...baseProps} />);
+    reachFormStep();
+
+    const consent = screen.getByTestId("quiz-consent");
+    expect(consent).toHaveTextContent(/emailed to you/i);
+    expect(consent).toHaveTextContent(/full report/i);
   });
 });

--- a/src/src/app/(portal)/portal/assessments/page.tsx
+++ b/src/src/app/(portal)/portal/assessments/page.tsx
@@ -13,6 +13,7 @@ import { PlusCircle } from "lucide-react";
 import { db } from "@/lib/db";
 import { requireCoach } from "@/lib/auth/authorization";
 import { FadeUp } from "@/components/ui/animated";
+import { CopyUrlButton } from "@/components/ui/copy-url-button";
 import {
   CampaignsListWithFilter,
   type CampaignListItem,
@@ -22,8 +23,37 @@ import {
   type CampaignStatusMetricsInput,
 } from "@/lib/assessments/campaign-status-metrics";
 
+const APP_URL =
+  process.env.APP_URL || "https://scaling-up-platform-v2.vercel.app";
+
+/**
+ * Spec 16 §4 — resolve the active PUBLIC campaign of the `scaling-up-quick`
+ * template so the coach can copy a per-coach attributed share link
+ * (`${APP_URL}/quiz/<alias>?coach=<coachEmail>`). Returns the campaign alias,
+ * or null when no active PUBLIC quick-assessment campaign exists yet.
+ */
+async function resolvePublicQuickAlias(): Promise<string | null> {
+  const campaign = await db.assessmentCampaign.findFirst({
+    where: {
+      accessMode: "PUBLIC",
+      status: "ACTIVE",
+      template: { alias: "scaling-up-quick" },
+    },
+    select: { alias: true },
+    orderBy: { createdAt: "desc" },
+  });
+  return campaign?.alias ?? null;
+}
+
 export default async function CoachAssessmentsPage() {
   const { coach } = await requireCoach();
+
+  // §4 — per-coach attributed share link for the public Quick Assessment.
+  const publicQuickAlias = await resolvePublicQuickAlias();
+  const coachLink =
+    publicQuickAlias && coach.email
+      ? `${APP_URL}/quiz/${publicQuickAlias}?coach=${encodeURIComponent(coach.email)}`
+      : null;
 
   // Single round-trip: include participants (for respondentId → invitation join)
   // and invitations (for staged-progress metrics).
@@ -104,6 +134,35 @@ export default async function CoachAssessmentsPage() {
           </Link>
         </div>
       </FadeUp>
+
+      {coachLink && (
+        <FadeUp delay={0.05}>
+          <div className="rounded-xl border border-border bg-card p-4">
+            <div className="flex items-start justify-between gap-4">
+              <div className="min-w-0">
+                <h2 className="text-sm font-semibold text-foreground">
+                  Your Quick Assessment link
+                </h2>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  Share this link to attribute new Quick Assessment leads to you.
+                  Takers see their results on screen and by email; you receive the
+                  full report.
+                </p>
+                <code
+                  className="mt-2 block truncate text-xs text-muted-foreground"
+                  data-testid="coach-quick-link"
+                  title={coachLink}
+                >
+                  {coachLink}
+                </code>
+              </div>
+              <div className="flex-shrink-0 pt-1">
+                <CopyUrlButton url={coachLink} />
+              </div>
+            </div>
+          </div>
+        </FadeUp>
+      )}
 
       <FadeUp delay={0.1}>
         {items.length === 0 ? (

--- a/src/src/app/api/quiz/[campaignAlias]/submit/route.ts
+++ b/src/src/app/api/quiz/[campaignAlias]/submit/route.ts
@@ -44,10 +44,13 @@ import {
 } from "@/lib/assessments/scoring";
 import {
   findActiveCoachByEmail,
-  resolveLeadRecipients,
   buildLeadEmail,
   lowestDecision,
 } from "@/lib/assessments/quick-assessment-lead";
+import {
+  buildReportEmailHtml,
+  buildRespondentReportFromSubmission,
+} from "@/lib/assessments/report-email";
 import { logAudit } from "@/lib/audit";
 import { inngest } from "@/inngest/client";
 
@@ -229,23 +232,78 @@ export async function POST(
       averagePoints: d.averagePoints,
     }));
 
-    // Resolve recipients; filter out a blank SU address before building emails.
-    const allRecipients = resolveLeadRecipients({
-      suTeamAddress,
-      activeCoachEmail: coach?.email ?? null,
+    // Build the per-respondent report ONCE, server-side, from the data we
+    // already hold (no DB round-trip). Shared by both report emails so the
+    // taker and coach copies are byte-identical (Spec 16 §3).
+    const respondentReport = buildRespondentReportFromSubmission({
+      result,
+      publicTaker: data.publicTaker,
+      assessmentName,
+      campaignLabel: null, // campaignLabel is not rendered in the email body
+      sections: version.sections,
+      questions: allQuestions,
+      scoringConfig: version.scoringConfig,
+      submittedAt: now,
+      submissionId: "", // provenance not rendered in the email body
+      referringCoachEmail: data.referringCoachEmail ?? null,
     });
-    const recipients = allRecipients.filter((r) => r.email.length > 0);
 
-    const outboxPayloads = recipients.map((r) => {
+    // Assemble the outbox payloads. Each entry carries the rendered subject +
+    // bodyHtml so the worker (role-agnostic) can send it verbatim.
+    //   - TAKER_COPY      → always, to the taker; full branded report (§2).
+    //   - REFERRING_COACH → only when an active coach resolved; full report.
+    //   - SU_TEAM         → only when an SU address is configured; lead-alert
+    //                       summary (unchanged from before).
+    const outboxPayloads: Array<{
+      recipient: { role: string; email: string };
+      subject: string;
+      bodyHtml: string;
+    }> = [];
+
+    // TAKER_COPY — always (the taker submitted their own email + consented).
+    {
+      const { subject, bodyHtml } = buildReportEmailHtml({
+        report: respondentReport,
+        recipientRole: "TAKER_COPY",
+      });
+      outboxPayloads.push({
+        recipient: { role: "TAKER_COPY", email: data.publicTaker.email },
+        subject,
+        bodyHtml,
+      });
+    }
+
+    // REFERRING_COACH — full report (upgrade from the old lead alert), only
+    // when the open-relay guard resolved an active coach.
+    const activeCoachEmail = coach?.email?.trim().toLowerCase() ?? "";
+    if (activeCoachEmail.length > 0) {
+      const { subject, bodyHtml } = buildReportEmailHtml({
+        report: respondentReport,
+        recipientRole: "REFERRING_COACH",
+      });
+      outboxPayloads.push({
+        recipient: { role: "REFERRING_COACH", email: activeCoachEmail },
+        subject,
+        bodyHtml,
+      });
+    }
+
+    // SU_TEAM — unchanged lead-alert summary, only when an SU address is set.
+    const suEmail = suTeamAddress.trim().toLowerCase();
+    if (suEmail.length > 0) {
       const { subject, bodyHtml } = buildLeadEmail({
         taker: data.publicTaker,
         assessmentName,
         perDomain: domainInputs,
         lowestLabel: lowest?.label ?? null,
-        recipientRole: r.role,
+        recipientRole: "SU_TEAM",
       });
-      return { recipient: r, subject, bodyHtml };
-    });
+      outboxPayloads.push({
+        recipient: { role: "SU_TEAM", email: suEmail },
+        subject,
+        bodyHtml,
+      });
+    }
 
     // -----------------------------------------------------------------------
     // Transactional write: submission + outbox rows in a single DB transaction

--- a/src/src/components/assessments/BrandedReport.tsx
+++ b/src/src/components/assessments/BrandedReport.tsx
@@ -41,6 +41,16 @@ import {
 
 const LOGO_SRC = "/brand/su-logo-white.svg";
 
+// WCAG-AA contrast-safe text colors for the per-decision average numerals.
+// Bright domain colors (People #f7a600 = 2.02:1, Cash #95c11f = 2.12:1) fail
+// the 3.0:1 large-text threshold on white. Use darkened variants per mockup.
+const DOMAIN_TEXT_COLOR: Record<string, string> = {
+  people: "#946b36",    // darkened from #f7a600
+  strategy: "#008bd2",  // already passes (~3.5:1)
+  execution: "#946b36", // already the stripe color — passes
+  cash: "#6f9200",      // darkened from #95c11f
+};
+
 // ── Defensive view of the raw version `sections` JSON ──────────────────────
 // Sections are stored as a flat JSON array of { stableKey, name, domain? }.
 // Some shapes (and the report fixtures) additionally nest the section's
@@ -236,6 +246,27 @@ export function BrandedReport({ report, assessmentName, campaignLabel }: Branded
     (pq) => !assignedQuestionKeys.has(pq.stableKey),
   );
 
+  // ── Per-decision domain cards (only when the template defines domains) ────
+  // Esperto/4-Decisions anatomy: a colored card per decision with its average,
+  // a fill bar, and the total points. Domains roll up on a 0–10 item scale, so
+  // the bar width is avg/10 (clamped). Skipped entirely for non-domain
+  // templates (the neutral path renders no cards section).
+  const domainCards = (perDomain ?? []).map((d) => {
+    const color = domainColor(d.key);
+    const avg = typeof d.averagePoints === "number" ? d.averagePoints : null;
+    const pct = avg === null ? 0 : Math.max(0, Math.min(100, avg * 10));
+    // Total points for this domain = sum of its sections' totalPoints, matched
+    // by the section's parsed domain.
+    let points = 0;
+    for (const sc of sectionCards) {
+      if (sc.parsed?.domain && sc.parsed.domain.toLowerCase().trim() === d.key.toLowerCase().trim()) {
+        points += Number.isFinite(sc.ps.totalPoints) ? sc.ps.totalPoints : 0;
+      }
+    }
+    return { key: d.key, label: d.label || d.key, color, avg, pct, points };
+  });
+  const hasDomainCards = domainCards.length > 0;
+
   // ── Recommendations grouped by section (only non-empty) ──────────────────
   const recSections = sectionCards
     .map(({ ps, rows }) => ({
@@ -315,21 +346,46 @@ export function BrandedReport({ report, assessmentName, campaignLabel }: Branded
       {/* ── 2. Overall ──────────────────────────────────────────────────── */}
       <section className="su-report-overall" data-testid="report-overall">
         <div className="su-report-eyebrow">Overall result</div>
+        {/* sr-only: announce score + band to screen readers before the decorative ring */}
+        <span className="sr-only">
+          {neutral
+            ? "Submitted"
+            : `Overall score: ${headline.primary}${headline.label ? `, ${headline.label}` : ""}`}
+        </span>
         <div className="su-report-overall-main">
-          <div className="su-report-headline">{headline.primary}</div>
-          {neutral ? (
-            <div className="su-report-status">Submitted</div>
-          ) : (
-            headline.label && (
-              <div className="su-report-band" data-testid="overall-band">
-                {headline.label}
-              </div>
-            )
-          )}
+          {/* aria-hidden: the ring is decorative — the score is in the sr-only span above */}
+          <div className="su-report-ringwrap" aria-hidden="true">
+            {/* Split "58 / 100" → big number + small denominator to avoid crowding */}
+            {(() => {
+              const slashIdx = headline.primary.indexOf("/");
+              if (!neutral && slashIdx !== -1) {
+                const num = headline.primary.slice(0, slashIdx).trim();
+                const den = headline.primary.slice(slashIdx).trim();
+                return (
+                  <>
+                    <div className="su-report-headline su-report-headline-num">{num}</div>
+                    <div className="su-report-headline-den">{den}</div>
+                  </>
+                );
+              }
+              return <div className="su-report-headline">{headline.primary}</div>;
+            })()}
+          </div>
+          <div className="su-report-overall-text">
+            {neutral ? (
+              <div className="su-report-status">Submitted</div>
+            ) : (
+              headline.label && (
+                <div className="su-report-band" data-testid="overall-band">
+                  {headline.label}
+                </div>
+              )
+            )}
+            {!neutral && result.tier?.message && (
+              <p className="su-report-lede">{result.tier.message}</p>
+            )}
+          </div>
         </div>
-        {!neutral && result.tier?.message && (
-          <p className="su-report-lede">{result.tier.message}</p>
-        )}
         {/* small stats row */}
         <div className="su-report-stats">
           <div className="su-report-stat">
@@ -350,6 +406,42 @@ export function BrandedReport({ report, assessmentName, campaignLabel }: Branded
           </div>
         </div>
       </section>
+
+      {/* ── 2b. Per-decision cards (domain templates only) ──────────────── */}
+      {hasDomainCards && (
+        <section className="su-report-decisions" data-testid="report-decisions">
+          <div className="su-report-eyebrow">How you scored, by decision</div>
+          <h2 className="su-h2 su-report-sec-title">Your Four Decisions</h2>
+          <div className="su-report-card-grid">
+            {domainCards.map((d) => (
+              <div
+                className="su-report-decision-card"
+                key={d.key}
+                data-testid={`decision-card-${d.key}`}
+                style={{ borderLeftColor: d.color }}
+              >
+                <div className="su-report-decision-head">
+                  <span className="su-report-decision-name">{d.label}</span>
+                  <span
+                    className="su-report-decision-avg"
+                    style={{
+                      color: DOMAIN_TEXT_COLOR[d.key.toLowerCase()] ?? d.color,
+                    }}
+                  >
+                    {d.avg === null ? "—" : formatNumber(d.avg)}
+                  </span>
+                </div>
+                <div className="su-report-decision-bar">
+                  <i style={{ width: `${d.pct}%`, backgroundColor: d.color }} />
+                </div>
+                <div className="su-report-decision-sub">
+                  {formatNumber(d.points)} points
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
 
       {/* ── 3. Section breakdown ────────────────────────────────────────── */}
       <section className="su-report-sections" data-testid="report-sections">
@@ -570,9 +662,18 @@ export function BrandedReport({ report, assessmentName, campaignLabel }: Branded
           You&apos;ve completed your assessment. Turn these results into a
           90-day plan with your coach.
         </p>
-        <p className="su-report-cta-text">
+        {/* CTA: link to the referring coach via mailto, or fall back to the
+            Scaling Up coaches directory. Never crashes when coach is absent. */}
+        <a
+          className="su-report-cta"
+          href={
+            report.referringCoachEmail
+              ? `mailto:${report.referringCoachEmail}`
+              : "https://scalingup.com/coaches"
+          }
+        >
           Talk to your Scaling Up Certified Coach →
-        </p>
+        </a>
       </section>
 
       {/* ── 8. Footer ───────────────────────────────────────────────────── */}

--- a/src/src/components/assessments/public-quiz-client.tsx
+++ b/src/src/components/assessments/public-quiz-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useRef, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { SectionPager } from "./section-pager";
 import {
   buildSectionPages,
@@ -98,6 +99,17 @@ export function PublicQuizClient({
 }: PublicQuizClientProps) {
   const sections = useMemo(() => toSections(rawSections), [rawSections]);
   const questions = useMemo(() => toQuestions(rawQuestions), [rawQuestions]);
+
+  // §4 — Per-coach attribution. A `?coach=<ref>` query param (the coach's email
+  // for v1) is forwarded to the submit route as `referringCoachEmail`. The
+  // server's active-coach guard validates it; a blank/missing/inactive ref
+  // silently falls back to SU-team-only. We omit the field entirely when blank.
+  const searchParams = useSearchParams();
+  const referringCoachEmail = useMemo(() => {
+    const raw = searchParams?.get("coach") ?? "";
+    const trimmed = raw.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }, [searchParams]);
 
   const sortedQuestions = useMemo(
     () => [...questions].sort((a, b) => a.sortOrder - b.sortOrder),
@@ -209,9 +221,10 @@ export function PublicQuizClient({
               </button>
             </div>
             <p className="su-welcome-fine">
-              Free to take — you&apos;ll get your results on screen. Your
-              responses are also shared with the Scaling Up team and the
-              coach who referred you (if any).
+              Free to take — you&apos;ll get your results on screen and a copy
+              by email. Your responses are also shared with the Scaling Up team
+              and the coach who referred you (if any), who receives the full
+              report.
             </p>
           </section>
         </main>
@@ -247,9 +260,10 @@ export function PublicQuizClient({
               About you
             </h1>
             <p className="ty-sub">
-              We use your name and email to show you your results and, where
-              applicable, to share them with the Scaling Up team and the
-              coach who referred you.
+              We use your name and email to show you your results and email you
+              a copy, and, where applicable, to share them with the Scaling Up
+              team and the coach who referred you (who receives the full
+              report).
             </p>
             <div className="survey-question">
               <label className="wf-label" htmlFor="quiz-first-name-input">
@@ -402,6 +416,8 @@ export function PublicQuizClient({
             value,
           })),
           idempotencyKey: idemRef.current,
+          // §4 — include only when a non-blank ?coach= param was present.
+          ...(referringCoachEmail ? { referringCoachEmail } : {}),
         }),
       });
       const body = await res.json().catch(() => ({}));
@@ -465,8 +481,9 @@ export function PublicQuizClient({
             style={{ fontSize: "0.75rem", textAlign: "center", margin: "0.5rem 0 0" }}
             data-testid="quiz-consent"
           >
-            By submitting, you agree that your results will be shown to you and shared with
-            the Scaling Up team and the coach who referred you (if any).
+            By submitting, you agree that your results will be shown to you and
+            emailed to you, and shared with the Scaling Up team and the coach who
+            referred you (if any) — who receives the full report.
           </p>
 
           {!canSubmit && (

--- a/src/src/lib/assessments/report-email.ts
+++ b/src/src/lib/assessments/report-email.ts
@@ -1,0 +1,611 @@
+/**
+ * Spec 16 §2 — Email-safe report HTML builder.
+ *
+ * buildReportEmailHtml({ report, recipientRole }) renders a frozen
+ * RespondentReport into an inline-styled, **table-layout** HTML string that
+ * survives email clients (Outlook/Gmail strip <style>/<link>, drop flex/grid,
+ * and ignore many modern CSS features). The anatomy mirrors the approved
+ * mockup (/tmp/su-report-mockup/index.html): cover → overall → per-decision
+ * cards → score-summary table.
+ *
+ * Constraints:
+ *  - PURE: no DB, no network, no React. Props in → { subject, bodyHtml } out.
+ *  - EMAIL-SAFE: inline styles + <table> layout ONLY. No external CSS, no
+ *    @import, no display:flex / display:grid.
+ *  - SECURE: every interpolated value is HTML-escaped (escapeHtml).
+ *  - ADAPTIVE: reuses report-presentation.ts for band/headline/domain-color so
+ *    on-screen and email stay in lockstep. Degrades for neutral (no-domain)
+ *    templates — falls back to per-section rows.
+ *
+ * The Quick Assessment ("4 Decisions") is Scaling Up's OWN content, so quoting
+ * its statements/labels back to the taker is fine; we still escape every value
+ * because campaign labels / names are user-controlled.
+ */
+
+import { escapeHtml } from "@/lib/templates/interpolate-content-html";
+
+/** Strip control characters (C0 + C1) from a value that goes into a MIME subject
+ *  line. Prevents header injection. Do NOT use escapeHtml here — subjects are
+ *  plain-text MIME headers, not HTML. */
+function stripControlChars(value: string): string {
+  return value.replace(/[\x00-\x1f\x7f-\x9f]/g, "");
+}
+import type {
+  RespondentReport,
+} from "@/lib/assessments/respondent-report";
+import type {
+  ScoreResult,
+  PerSectionResult,
+  PerDomainResult,
+  PerQuestionResult,
+} from "@/lib/assessments/scoring";
+import {
+  isNeutralTier,
+  domainColor,
+  headlineForTierMetric,
+} from "@/lib/assessments/report-presentation";
+
+export type ReportEmailRecipientRole = "TAKER_COPY" | "REFERRING_COACH";
+
+export interface BuildReportEmailArgs {
+  report: RespondentReport;
+  recipientRole: ReportEmailRecipientRole;
+}
+
+export interface ReportEmail {
+  subject: string;
+  bodyHtml: string;
+}
+
+// ── Server-side RespondentReport assembly (Spec 16 §3) ──────────────────────
+//
+// The PUBLIC quiz submit route already holds everything a RespondentReport
+// needs (the frozen ScoreResult + the public taker + the published version's
+// sections/questions/scoringConfig + the template name). It has no DB-loaded
+// `respondent` relation (public takers are respondentId=null), so we build the
+// report shape directly rather than calling getRespondentReport.
+//
+// This mirrors the shape the on-screen public-quiz-client builds for
+// BrandedReport, so the email + on-screen views stay in lockstep.
+
+export interface BuildRespondentReportArgs {
+  result: ScoreResult;
+  publicTaker: { firstName: string; lastName: string; email: string };
+  assessmentName: string;
+  campaignLabel: string | null;
+  sections: unknown;
+  questions: unknown;
+  scoringConfig: unknown;
+  submittedAt: Date;
+  submissionId: string;
+  /** Optional: the coach who referred this taker. Wired into the CTA mailto link. */
+  referringCoachEmail?: string | null;
+}
+
+interface RawReportQuestion {
+  stableKey: string;
+  label: string;
+  type?: string;
+  sectionStableKey?: string;
+}
+
+function isRawReportQuestion(v: unknown): v is RawReportQuestion {
+  if (!v || typeof v !== "object") return false;
+  const r = v as Record<string, unknown>;
+  return typeof r.stableKey === "string" && typeof r.label === "string";
+}
+
+/**
+ * Builds a RespondentReport from the data the public-quiz submit route already
+ * has in hand — no DB round-trip. Pure. The result is shared by both report
+ * emails (TAKER_COPY + REFERRING_COACH) so they are byte-identical.
+ */
+export function buildRespondentReportFromSubmission(
+  args: BuildRespondentReportArgs,
+): RespondentReport {
+  const rawQuestions: unknown[] = Array.isArray(args.questions)
+    ? args.questions
+    : [];
+
+  const questionByKey: Record<string, string> = {};
+  const questionsByKey: Record<string, { type: string; label: string; sectionStableKey?: string }> = {};
+  const seen = new Set<string>();
+  for (const q of rawQuestions) {
+    if (!isRawReportQuestion(q)) continue;
+    if (seen.has(q.stableKey)) continue; // first-wins on duplicate
+    seen.add(q.stableKey);
+    questionByKey[q.stableKey] = q.label;
+    const meta: { type: string; label: string; sectionStableKey?: string } = {
+      type: typeof q.type === "string" ? q.type : "UNKNOWN",
+      label: q.label,
+    };
+    if (typeof q.sectionStableKey === "string") {
+      meta.sectionStableKey = q.sectionStableKey;
+    }
+    questionsByKey[q.stableKey] = meta;
+  }
+
+  const name = `${args.publicTaker.firstName.trim()} ${args.publicTaker.lastName.trim()}`.trim();
+
+  return {
+    respondentName: name,
+    jobTitle: null,
+    companyName: "",
+    assessmentName: args.assessmentName,
+    campaignLabel: args.campaignLabel,
+    submittedAt: args.submittedAt,
+    result: args.result,
+    sections: args.sections,
+    questionByKey,
+    questionsByKey,
+    rawAnswers: [],
+    scoringConfig: args.scoringConfig,
+    provenance: {
+      submissionId: args.submissionId,
+      versionId: "",
+      contentHash: "",
+      templateName: args.assessmentName,
+    },
+    degraded: false,
+    referringCoachEmail: args.referringCoachEmail ?? null,
+  };
+}
+
+// ── Brand palette (mirrors su-public-brand.css; literal for inline styles) ──
+const PURPLE = "#522583";
+const PURPLE_DEEP = "#3d1a63";
+const INK = "#2b2440";
+const MUTED = "#6b6480";
+const LINE = "#ece8f2";
+const SOFT = "#faf8fd";
+const PURPLE_TINT = "#f0e9fa";
+const FONT =
+  "'Helvetica Neue', Roboto, Arial, sans-serif";
+
+// Four-Decisions stripe colors (mockup .stripe).
+const D_PEOPLE = "#f7a600";
+const D_STRATEGY = "#008bd2";
+const D_EXECUTION = "#946b36";
+const D_CASH = "#95c11f";
+
+// WCAG-AA contrast-safe text overrides for the bright domain colors used as
+// large text (22px bold) on white. #f7a600 (People) = 2.02:1, #95c11f (Cash) =
+// 2.12:1 — both fail 3.0:1. Use darkened variants (same as approved mockup).
+const DOMAIN_TEXT_COLOR: Record<string, string> = {
+  people: "#946b36",    // darkened from #f7a600 — approved mockup color
+  strategy: "#008bd2",  // passes 3.5:1 on white — keep as-is
+  execution: "#946b36", // already the stripe color — passes
+  cash: "#6f9200",      // darkened from #95c11f — approved mockup color
+};
+
+// ── Defensive section parsing (mirrors BrandedReport.parseSections) ─────────
+
+interface ParsedSection {
+  stableKey: string;
+  name: string;
+  domain?: string;
+  questionKeys: string[];
+}
+
+function parseSections(raw: unknown): ParsedSection[] {
+  if (!Array.isArray(raw)) return [];
+  const out: ParsedSection[] = [];
+  for (const s of raw) {
+    if (!s || typeof s !== "object") continue;
+    const obj = s as Record<string, unknown>;
+    if (typeof obj.stableKey !== "string") continue;
+    // Question keys for the detailed-breakdown grouping (mirrors BrandedReport).
+    const questionKeys: string[] = [];
+    if (Array.isArray(obj.questions)) {
+      for (const q of obj.questions) {
+        if (q && typeof q === "object") {
+          const qk = (q as Record<string, unknown>).stableKey;
+          if (typeof qk === "string") questionKeys.push(qk);
+        } else if (typeof q === "string") {
+          questionKeys.push(q);
+        }
+      }
+    }
+    out.push({
+      stableKey: obj.stableKey,
+      name: typeof obj.name === "string" ? obj.name : obj.stableKey,
+      domain: typeof obj.domain === "string" ? obj.domain : undefined,
+      questionKeys,
+    });
+  }
+  return out;
+}
+
+// ── Number formatting (mirrors BrandedReport.formatNumber) ──────────────────
+
+function formatNumber(n: number): string {
+  if (!Number.isFinite(n)) return "0";
+  if (Number.isInteger(n)) return String(n);
+  return (Math.round(n * 100) / 100).toString();
+}
+
+function formatSubmittedAt(d: Date): string {
+  try {
+    return new Intl.DateTimeFormat("en-US", {
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+    }).format(d);
+  } catch {
+    return String(d);
+  }
+}
+
+function firstName(full: string): string {
+  const trimmed = full.trim();
+  if (trimmed === "") return "there";
+  return trimmed.split(/\s+/)[0];
+}
+
+// ── Builder ──────────────────────────────────────────────────────────────
+
+export function buildReportEmailHtml({
+  report,
+  recipientRole,
+}: BuildReportEmailArgs): ReportEmail {
+  const result: ScoreResult = report.result ?? ({} as ScoreResult);
+  const perSection: PerSectionResult[] = Array.isArray(result.perSection)
+    ? result.perSection
+    : [];
+  const perDomain: PerDomainResult[] | null = Array.isArray(result.perDomain)
+    ? result.perDomain
+    : null;
+  const perQuestion: PerQuestionResult[] = Array.isArray(result.perQuestion)
+    ? result.perQuestion
+    : [];
+
+  const sections = parseSections(report.sections);
+  const sectionByKey = new Map<string, ParsedSection>();
+  for (const s of sections) sectionByKey.set(s.stableKey, s);
+
+  const useDomainColors = !!perDomain;
+  const hasScaleUpScore = typeof result.scaleUpScore === "number";
+  const neutral = isNeutralTier(report.scoringConfig) && !hasScaleUpScore;
+  const headline = headlineForTierMetric(result, report.scoringConfig);
+
+  // ── Pre-escaped strings ──────────────────────────────────────────────────
+  const escName = escapeHtml(report.respondentName);
+  const escTitle = escapeHtml(report.assessmentName);
+  const escDate = escapeHtml(formatSubmittedAt(report.submittedAt));
+  const escFirst = escapeHtml(firstName(report.respondentName));
+  const escHeadlinePrimary = escapeHtml(headline.primary);
+  const escHeadlineLabel = escapeHtml(headline.label);
+  const escTierMessage =
+    !neutral && result.tier?.message ? escapeHtml(result.tier.message) : "";
+
+  // ── Subject — plain-text MIME header, NOT HTML ───────────────────────────
+  // Use stripControlChars (prevents header injection) but NOT escapeHtml.
+  // Subjects render as raw text in every email client; HTML entities would
+  // appear literally (e.g. "O&#x27;Brien completed…").
+  const safeName = stripControlChars(report.respondentName);
+  const subject =
+    recipientRole === "REFERRING_COACH"
+      ? `${safeName} completed the Scaling Up 4 Decisions Assessment`
+      : "Your Scaling Up 4 Decisions results";
+
+  // ── Cover ──────────────────────────────────────────────────────────────
+  const cover = `
+  <tr>
+    <td style="height:6px;padding:0;font-size:0;line-height:0;background:${D_PEOPLE};">&nbsp;</td>
+  </tr>
+  <tr>
+    <td style="padding:0;font-size:0;line-height:0;">
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+        <tr>
+          <td width="25%" style="height:4px;background:${D_PEOPLE};font-size:0;line-height:0;">&nbsp;</td>
+          <td width="25%" style="height:4px;background:${D_STRATEGY};font-size:0;line-height:0;">&nbsp;</td>
+          <td width="25%" style="height:4px;background:${D_EXECUTION};font-size:0;line-height:0;">&nbsp;</td>
+          <td width="25%" style="height:4px;background:${D_CASH};font-size:0;line-height:0;">&nbsp;</td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+  <tr>
+    <td style="background:${PURPLE};background-image:linear-gradient(135deg,${PURPLE},${PURPLE_DEEP});padding:28px 32px 26px;color:#ffffff;">
+      <div style="font-weight:800;letter-spacing:0.04em;font-size:14px;color:#ffffff;margin-bottom:14px;">SCALING UP</div>
+      <div style="font-size:21px;font-weight:800;color:#ffffff;line-height:1.2;margin-bottom:4px;">${escTitle}</div>
+      <div style="font-size:13px;color:#ffffff;opacity:0.85;">Report for ${escName} &middot; ${escDate}</div>
+    </td>
+  </tr>`;
+
+  // ── Overall ──────────────────────────────────────────────────────────────
+  const bandPill = neutral
+    ? `<span style="display:inline-block;background:${PURPLE_TINT};color:${PURPLE};font-weight:800;font-size:12px;letter-spacing:0.04em;text-transform:uppercase;padding:5px 12px;border-radius:999px;">Submitted</span>`
+    : escHeadlineLabel
+      ? `<span style="display:inline-block;background:${PURPLE_TINT};color:${PURPLE};font-weight:800;font-size:12px;letter-spacing:0.04em;text-transform:uppercase;padding:5px 12px;border-radius:999px;">${escHeadlineLabel}</span>`
+      : "";
+
+  const metaCells: string[] = [
+    `<td style="padding:0 14px 0 0;vertical-align:top;">
+       <div style="font-size:18px;font-weight:800;color:${PURPLE};line-height:1;">${escapeHtml(formatNumber(result.overallTotal ?? 0))}</div>
+       <div style="font-size:11px;letter-spacing:0.04em;text-transform:uppercase;color:${MUTED};margin-top:2px;">Total points</div>
+     </td>`,
+    `<td style="padding:0 14px;vertical-align:top;">
+       <div style="font-size:18px;font-weight:800;color:${PURPLE};line-height:1;">${escapeHtml(formatNumber(result.overallAverage ?? 0))}</div>
+       <div style="font-size:11px;letter-spacing:0.04em;text-transform:uppercase;color:${MUTED};margin-top:2px;">Avg / item</div>
+     </td>`,
+    `<td style="padding:0 0 0 14px;vertical-align:top;">
+       <div style="font-size:18px;font-weight:800;color:${PURPLE};line-height:1;">${perSection.length}</div>
+       <div style="font-size:11px;letter-spacing:0.04em;text-transform:uppercase;color:${MUTED};margin-top:2px;">Sections</div>
+     </td>`,
+  ];
+
+  const overall = `
+  <tr>
+    <td style="padding:26px 32px;border-bottom:1px solid ${LINE};">
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+        <tr>
+          <td width="120" valign="middle" style="padding:0 22px 0 0;">
+            <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="110" style="border:6px solid ${PURPLE_TINT};border-radius:55px;background:#ffffff;">
+              <tr>
+                <td align="center" valign="middle" style="height:98px;width:98px;">
+                  ${(() => {
+                    // Split "58 / 100" → big number + small denominator.
+                    // Neutral templates show "Submitted" (no slash) → single label.
+                    const slashIdx = headline.primary.indexOf("/");
+                    if (!neutral && slashIdx !== -1) {
+                      const num = escapeHtml(headline.primary.slice(0, slashIdx).trim());
+                      const den = escapeHtml(headline.primary.slice(slashIdx).trim());
+                      return `<div style="font-size:30px;font-weight:800;color:${PURPLE};line-height:1;">${num}</div>
+                  <div style="font-size:12px;color:#6b6480;line-height:1.4;">${den}</div>`;
+                    }
+                    return `<div style="font-size:22px;font-weight:800;color:${PURPLE};line-height:1;padding:0 4px;">${escHeadlinePrimary}</div>`;
+                  })()}
+                </td>
+              </tr>
+            </table>
+          </td>
+          <td valign="middle">
+            ${bandPill}
+            ${escTierMessage ? `<div style="font-size:14px;color:${INK};margin-top:8px;line-height:1.5;">${escTierMessage}</div>` : ""}
+            <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin-top:14px;"><tr>${metaCells.join("")}</tr></table>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>`;
+
+  // ── Per-decision cards (domains) ───────────────────────────────────────────
+  // Each domain row → a colored-left-border card with the domain average + a
+  // simple bar. Falls back to nothing when there are no domains.
+  let cardsBlock = "";
+  if (perDomain && perDomain.length > 0) {
+    const cardRows = perDomain
+      .map((d) => {
+        const color = useDomainColors ? domainColor(d.key) : PURPLE;
+        // Use a WCAG-AA contrast-safe text color for the avg numeral (bright
+        // domain colors like People #f7a600 / Cash #95c11f fail 3.0:1 on white).
+        // The left border and progress bar keep the full-brightness domain color.
+        const textColor = useDomainColors
+          ? (DOMAIN_TEXT_COLOR[d.key.toLowerCase()] ?? color)
+          : PURPLE;
+        const avg = typeof d.averagePoints === "number" ? d.averagePoints : 0;
+        // bar width as a percentage of a 0-10 scale, clamped.
+        const pct = Math.max(0, Math.min(100, avg * 10));
+        const escLabel = escapeHtml(d.label || d.key);
+        const escAvg = escapeHtml(formatNumber(avg));
+        return `
+        <tr>
+          <td style="padding:6px 0;">
+            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border:1px solid ${LINE};border-left:5px solid ${color};border-radius:13px;">
+              <tr>
+                <td style="padding:14px 15px;">
+                  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                    <tr>
+                      <td style="font-weight:800;font-size:15px;color:${INK};">${escLabel}</td>
+                      <td align="right" style="font-size:22px;font-weight:800;color:${textColor};">${escAvg}</td>
+                    </tr>
+                  </table>
+                  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:10px 0 0;background:#eeeeee;border-radius:4px;">
+                    <tr>
+                      <td width="${pct}%" style="height:7px;background:${color};border-radius:4px;font-size:0;line-height:0;">&nbsp;</td>
+                      <td style="font-size:0;line-height:0;">&nbsp;</td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>`;
+      })
+      .join("");
+    cardsBlock = `
+    <tr>
+      <td style="padding:24px 32px 6px;font-size:12px;letter-spacing:0.12em;text-transform:uppercase;color:${MUTED};font-weight:800;">How you scored, by decision</td>
+    </tr>
+    <tr>
+      <td style="padding:0 32px 6px;">
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">${cardRows}</table>
+      </td>
+    </tr>`;
+  }
+
+  // ── Score-summary table ────────────────────────────────────────────────────
+  const tableRows = perSection
+    .map((ps) => {
+      const parsed = sectionByKey.get(ps.stableKey);
+      const dotColor =
+        useDomainColors && parsed?.domain ? domainColor(parsed.domain) : null;
+      const dot = dotColor
+        ? `<span style="display:inline-block;width:9px;height:9px;border-radius:50%;background:${dotColor};margin-right:8px;">&nbsp;</span>`
+        : "";
+      const escSecName = escapeHtml(parsed?.name ?? ps.name ?? ps.stableKey);
+      return `
+      <tr>
+        <td style="text-align:left;padding:9px 10px;border-bottom:1px solid ${LINE};font-size:13px;color:${INK};">${dot}${escSecName}</td>
+        <td style="text-align:right;padding:9px 10px;border-bottom:1px solid ${LINE};font-size:13px;color:${PURPLE};font-weight:700;">${escapeHtml(formatNumber(ps.totalPoints))}</td>
+        <td style="text-align:right;padding:9px 10px;border-bottom:1px solid ${LINE};font-size:13px;color:${MUTED};">${escapeHtml(formatNumber(ps.averagePoints))}</td>
+      </tr>`;
+    })
+    .join("");
+
+  const scoresTable = `
+  <tr>
+    <td style="padding:24px 32px 6px;font-size:12px;letter-spacing:0.12em;text-transform:uppercase;color:${MUTED};font-weight:800;">Score summary</td>
+  </tr>
+  <tr>
+    <td style="padding:8px 32px 6px;">
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse;">
+        <tr>
+          <th style="text-align:left;padding:9px 10px;border-bottom:1px solid ${LINE};font-size:11px;letter-spacing:0.06em;text-transform:uppercase;color:${MUTED};">Decision</th>
+          <th style="text-align:right;padding:9px 10px;border-bottom:1px solid ${LINE};font-size:11px;letter-spacing:0.06em;text-transform:uppercase;color:${MUTED};">Score</th>
+          <th style="text-align:right;padding:9px 10px;border-bottom:1px solid ${LINE};font-size:11px;letter-spacing:0.06em;text-transform:uppercase;color:${MUTED};">Average</th>
+        </tr>
+        ${tableRows}
+        <tr>
+          <td style="text-align:left;padding:9px 10px;border-top:2px solid ${INK};font-weight:800;color:${PURPLE};font-size:13px;">Total</td>
+          <td style="text-align:right;padding:9px 10px;border-top:2px solid ${INK};font-weight:800;color:${PURPLE};font-size:13px;">${escapeHtml(formatNumber(result.overallTotal ?? 0))}</td>
+          <td style="text-align:right;padding:9px 10px;border-top:2px solid ${INK};font-weight:800;color:${PURPLE};font-size:13px;">${escapeHtml(formatNumber(result.overallAverage ?? 0))}</td>
+        </tr>
+      </table>
+    </td>
+  </tr>`;
+
+  // ── Detailed breakdown — per-section statement rows with score chips ───────
+  // Mirrors the on-screen "Detailed breakdown" section. Groups per-question
+  // rows under their section. Degrades gracefully when no per-question data.
+  let breakdownBlock = "";
+  if (perQuestion.length > 0 && perSection.length > 0) {
+    // Build sectionStableKey → perQuestion rows map using questionsByKey meta.
+    const pqByKey = new Map<string, PerQuestionResult>();
+    for (const pq of perQuestion) pqByKey.set(pq.stableKey, pq);
+
+    const sectionGroups = perSection
+      .map((ps) => {
+        const parsed = sectionByKey.get(ps.stableKey);
+        // Questions for this section from the parsed sections questionKeys.
+        const qKeys: string[] = parsed?.questionKeys ?? [];
+        // Fallback: find questions whose questionsByKey.sectionStableKey matches.
+        const rows: PerQuestionResult[] =
+          qKeys.length > 0
+            ? qKeys.map((k) => pqByKey.get(k)).filter((r): r is PerQuestionResult => !!r)
+            : perQuestion.filter((pq) => {
+                const meta = report.questionsByKey?.[pq.stableKey];
+                return meta?.sectionStableKey === ps.stableKey;
+              });
+        const dotColor =
+          useDomainColors && parsed?.domain ? domainColor(parsed.domain) : PURPLE;
+        const escSecName = escapeHtml(parsed?.name ?? ps.name ?? ps.stableKey);
+        return { ps, parsed, rows, dotColor, escSecName };
+      })
+      .filter((g) => g.rows.length > 0);
+
+    if (sectionGroups.length > 0) {
+      const groupHtml = sectionGroups
+        .map(({ rows, dotColor, escSecName }) => {
+          const rowHtml = rows
+            .map((r) => {
+              const lbl = report.questionByKey?.[r.stableKey] ?? r.stableKey;
+              const escLbl = escapeHtml(typeof lbl === "string" ? lbl : String(lbl));
+              const max = report.questionsByKey?.[r.stableKey]?.max;
+              const scoreText = max !== undefined
+                ? `${r.value} / ${max}`
+                : String(r.value);
+              return `
+              <tr>
+                <td style="padding:8px 0;border-bottom:1px solid ${LINE};font-size:13px;color:#3a3450;line-height:1.45;">${escLbl}</td>
+                <td align="right" style="padding:8px 0 8px 12px;border-bottom:1px solid ${LINE};white-space:nowrap;vertical-align:top;">
+                  <span style="display:inline-block;min-width:30px;text-align:center;font-weight:800;font-size:13px;color:${PURPLE};background:${PURPLE_TINT};border-radius:7px;padding:3px 8px;font-variant-numeric:tabular-nums;">${escapeHtml(scoreText)}</span>
+                </td>
+              </tr>`;
+            })
+            .join("");
+          const dot = `<span style="display:inline-block;width:9px;height:9px;border-radius:50%;background:${dotColor};margin-right:8px;vertical-align:middle;">&nbsp;</span>`;
+          return `
+          <tr>
+            <td colspan="2" style="padding:14px 0 4px;font-weight:800;font-size:13px;color:${INK};">${dot}${escSecName}</td>
+          </tr>
+          ${rowHtml}`;
+        })
+        .join("");
+
+      breakdownBlock = `
+      <tr>
+        <td style="padding:24px 32px 6px;font-size:12px;letter-spacing:0.12em;text-transform:uppercase;color:${MUTED};font-weight:800;">Detailed breakdown</td>
+      </tr>
+      <tr>
+        <td style="padding:4px 32px 12px;">
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+            ${groupHtml}
+          </table>
+        </td>
+      </tr>`;
+    }
+  }
+
+  // ── Conclusion + footer ────────────────────────────────────────────────────
+  const leadIn =
+    recipientRole === "REFERRING_COACH"
+      ? `<tr><td style="padding:18px 32px 0;font-size:14px;color:${INK};line-height:1.5;">Your client <strong>${escName}</strong> just completed the Scaling Up 4 Decisions Assessment. Their full results are below.</td></tr>`
+      : "";
+
+  const conclusionTitle =
+    recipientRole === "REFERRING_COACH"
+      ? `Follow up with ${escFirst}.`
+      : `Keep scaling, ${escFirst}.`;
+  const conclusionBody =
+    recipientRole === "REFERRING_COACH"
+      ? `Reach out to turn these results into a 90-day plan together.`
+      : `You&rsquo;ve completed your assessment. Turn these results into a 90-day plan with your Scaling Up Certified Coach.`;
+
+  // CTA href: if the report has a referring coach email, link to mailto; else
+  // fall back to the SU coaches directory.
+  const ctaHref = report.referringCoachEmail
+    ? `mailto:${encodeURIComponent(report.referringCoachEmail)}`
+    : "https://scalingup.com/coaches";
+  const ctaLabel = "Talk to your Scaling Up Certified Coach →";
+
+  const conclusion = `
+  <tr>
+    <td style="padding:22px 32px 0;">
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:${SOFT};border:1px solid ${LINE};border-radius:13px;">
+        <tr>
+          <td align="center" style="padding:20px;">
+            <div style="font-size:16px;font-weight:800;color:${INK};margin-bottom:6px;">${conclusionTitle}</div>
+            <div style="font-size:13px;color:${MUTED};line-height:1.5;margin-bottom:14px;">${conclusionBody}</div>
+            <a href="${ctaHref}" style="display:inline-block;background:${PURPLE};color:#ffffff;text-decoration:none;font-weight:700;padding:12px 22px;border-radius:11px;font-size:14px;">${ctaLabel}</a>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" style="padding:18px 32px 26px;font-size:11px;color:${MUTED};">Generated by the Scaling Up Assessment platform &middot; Confidential</td>
+  </tr>`;
+
+  // ── Assemble — single centered column, table layout, inline styles only ────
+  const bodyHtml = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>${escTitle}</title>
+</head>
+<body style="margin:0;padding:24px 12px;background:#eef0f4;font-family:${FONT};color:${INK};">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#eef0f4;">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="640" cellpadding="0" cellspacing="0" border="0" style="max-width:640px;width:100%;background:#ffffff;border-radius:16px;overflow:hidden;">
+          ${cover}
+          ${leadIn}
+          ${overall}
+          ${cardsBlock}
+          ${scoresTable}
+          ${breakdownBlock}
+          ${conclusion}
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+
+  return { subject, bodyHtml };
+}
+
+export default buildReportEmailHtml;

--- a/src/src/lib/assessments/respondent-report.ts
+++ b/src/src/lib/assessments/respondent-report.ts
@@ -116,6 +116,13 @@ export interface RespondentReport {
    * returned so the caller can render a degraded view.
    */
   degraded: boolean;
+  /**
+   * Optional: the email of the coach who referred this taker (from the ?coach=
+   * query param at submission time). Used to build a mailto: CTA in report
+   * emails. Absent on the admin/coach report view (where the coach is known
+   * from context) and on submissions with no ?coach= param.
+   */
+  referringCoachEmail?: string | null;
 }
 
 export type RespondentReportOutcome =

--- a/src/src/styles/su-report.css
+++ b/src/src/styles/su-report.css
@@ -27,8 +27,12 @@
  *   su-report-title, su-report-campaign-label,
  *   su-report-cover-meta, su-report-for, su-report-sub,
  *   su-report-overall, su-report-eyebrow, su-report-overall-main,
+ *   su-report-ringwrap, su-report-overall-text,
  *   su-report-headline, su-report-status, su-report-band,
  *   su-report-lede, su-report-stats, su-report-stat,
+ *   su-report-decisions, su-report-card-grid, su-report-decision-card,
+ *   su-report-decision-head, su-report-decision-name, su-report-decision-avg,
+ *   su-report-decision-bar, su-report-decision-sub,
  *   su-report-stat-v, su-report-stat-l,
  *   su-report-sections, su-report-sec-title, su-report-grid,
  *   su-report-card, su-report-card-head, su-report-card-title,
@@ -178,53 +182,109 @@
   margin-bottom: 4px;
 }
 
+/* Light overall card: a purple score "ring" on the left, band + message right.
+   (Mockup anatomy — replaces the old purple gradient banner.) */
 .su-public-brand .su-report-overall-main {
-  background: linear-gradient(120deg, #522583, #3f1c66);
-  color: #ffffff;
-  border-radius: 12px;
-  padding: 28px 32px;
+  background: #ffffff;
+  border: 1px solid #ece8f2;
+  color: #1a1322;
+  border-radius: 14px;
+  padding: 24px 28px;
   display: flex;
   align-items: center;
-  gap: 20px;
+  gap: 24px;
   flex-wrap: wrap;
   margin-top: 8px;
 }
 
+/* Score ring — conic-gradient donut with the headline metric in the center. */
+.su-public-brand .su-report-ringwrap {
+  flex: 0 0 128px;
+  width: 128px;
+  height: 128px;
+  border-radius: 50%;
+  background: conic-gradient(#522583 0 220deg, #eadff7 220deg 360deg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+
+.su-public-brand .su-report-ringwrap::after {
+  content: "";
+  position: absolute;
+  inset: 12px;
+  background: #ffffff;
+  border-radius: 50%;
+}
+
 .su-public-brand .su-report-headline {
+  position: relative;
+  z-index: 1;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-  font-weight: 700;
-  font-size: 34px;
+  font-weight: 800;
+  font-size: 26px;
   line-height: 1.05;
-  flex: 1 1 auto;
+  color: #522583;
+  text-align: center;
+  padding: 0 8px;
+}
+
+/* Split ring: big number + small denominator — mirrors approved mockup */
+.su-public-brand .su-report-headline-num {
+  font-size: 30px;
+  line-height: 1;
+}
+
+.su-public-brand .su-report-headline-den {
+  position: relative;
+  z-index: 1;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 1.4;
+  color: #6b6480;
+  text-align: center;
+}
+
+.su-public-brand .su-report-overall-text {
+  flex: 1 1 240px;
+  min-width: 200px;
 }
 
 .su-public-brand .su-report-band {
   display: inline-block;
-  background: rgba(255, 255, 255, 0.16);
-  border: 1px solid rgba(255, 255, 255, 0.3);
+  background: #f0e9fa;
+  color: #522583;
   border-radius: 999px;
-  padding: 6px 18px;
-  font-size: 14px;
-  font-weight: 700;
-  letter-spacing: 0.06em;
+  padding: 5px 14px;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
   white-space: nowrap;
-  flex-shrink: 0;
+  margin-bottom: 8px;
 }
 
 .su-public-brand .su-report-status {
-  font-size: 16px;
-  color: rgba(255, 255, 255, 0.82);
-  font-style: italic;
-  flex-shrink: 0;
+  display: inline-block;
+  background: #f0e9fa;
+  color: #522583;
+  border-radius: 999px;
+  padding: 5px 14px;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
 }
 
 .su-public-brand .su-report-lede {
-  font-size: 15px;
+  font-size: 14px;
   color: #3a3346;
-  margin: 14px 0 0;
-  max-width: 68ch;
-  line-height: 1.65;
+  margin: 6px 0 0;
+  max-width: 60ch;
+  line-height: 1.6;
 }
 
 /* Stats row */
@@ -261,6 +321,69 @@
   text-transform: uppercase;
   letter-spacing: 0.08em;
   margin-top: 6px;
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   2b. PER-DECISION CARDS  (domain templates only — 4 Decisions / SU Full)
+   ══════════════════════════════════════════════════════════════════════════ */
+.su-public-brand .su-report-decisions {
+  padding: 8px 60px 8px;
+}
+
+.su-public-brand .su-report-card-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+  margin-top: 10px;
+}
+
+.su-public-brand .su-report-decision-card {
+  border: 1px solid #ece8f2;
+  border-left: 5px solid #522583;
+  border-radius: 13px;
+  padding: 14px 16px;
+  background: #ffffff;
+}
+
+.su-public-brand .su-report-decision-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.su-public-brand .su-report-decision-name {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: 800;
+  font-size: 15px;
+  color: #1a1322;
+}
+
+.su-public-brand .su-report-decision-avg {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: 800;
+  font-size: 22px;
+  line-height: 1;
+}
+
+.su-public-brand .su-report-decision-bar {
+  height: 7px;
+  border-radius: 4px;
+  background: #eeeeee;
+  margin: 11px 0 7px;
+  overflow: hidden;
+}
+
+.su-public-brand .su-report-decision-bar i {
+  display: block;
+  height: 100%;
+  border-radius: 4px;
+  background: #522583;
+}
+
+.su-public-brand .su-report-decision-sub {
+  font-size: 12px;
+  color: #6b6480;
 }
 
 /* ══════════════════════════════════════════════════════════════════════════
@@ -339,11 +462,11 @@
 .su-public-brand .su-report-q {
   display: flex;
   align-items: flex-start;
-  gap: 9px;
+  gap: 12px;
   font-size: 13px;
   color: #3a3346;
-  padding: 5px 0;
-  border-bottom: 1px solid #f4f0fa;
+  padding: 8px 0;
+  border-bottom: 1px solid #faf8fd;
 }
 
 .su-public-brand .su-report-q:last-child {
@@ -385,14 +508,24 @@
   font-style: italic;
 }
 
+/* Right-aligned score CHIP — fixes the old "jammed digit" bug where the rating
+   number sat flush against the statement text. Now a self-contained pill,
+   visually separated from the label by the row gap. */
 .su-public-brand .su-report-q-rate {
   margin-left: auto;
-  flex-shrink: 0;
-  font-size: 11px;
-  color: #6b6480;
-  font-weight: 500;
+  flex: 0 0 auto;
+  align-self: flex-start;
+  min-width: 30px;
+  text-align: center;
+  font-size: 13px;
+  font-weight: 800;
+  color: #522583;
+  background: #f0e9fa;
+  border-radius: 7px;
+  padding: 3px 9px;
   white-space: nowrap;
-  padding-left: 8px;
+  font-variant-numeric: tabular-nums;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
 /* Orphan questions (not claimed by any section) */
@@ -576,6 +709,35 @@
   letter-spacing: 0.02em;
 }
 
+/* CTA link — styled as the purple button per mockup */
+.su-public-brand .su-report-cta {
+  display: inline-block;
+  margin-top: 16px;
+  background: #522583;
+  color: #ffffff;
+  text-decoration: none;
+  font-weight: 700;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 14px;
+  letter-spacing: 0.02em;
+  padding: 12px 22px;
+  border-radius: 11px;
+  transition: background 0.15s;
+}
+
+.su-public-brand .su-report-cta:hover {
+  background: #3d1a63;
+  color: #ffffff;
+}
+
+@media print {
+  .su-public-brand .su-report-cta {
+    color: #522583;
+    background: none;
+    border: 1px solid #522583;
+  }
+}
+
 /* ══════════════════════════════════════════════════════════════════════════
    8. FOOTER
    ══════════════════════════════════════════════════════════════════════════ */
@@ -614,8 +776,10 @@
   .su-public-brand .su-report-cover-inner { padding: 36px 24px 0; }
   .su-public-brand .su-report-title { font-size: 34px; }
   .su-public-brand .su-report-overall { padding: 28px 24px; }
-  .su-public-brand .su-report-overall-main { padding: 20px 22px; }
+  .su-public-brand .su-report-overall-main { padding: 20px 22px; justify-content: center; text-align: center; }
   .su-public-brand .su-report-headline { font-size: 24px; }
+  .su-public-brand .su-report-decisions { padding: 8px 24px; }
+  .su-public-brand .su-report-card-grid { grid-template-columns: 1fr; }
   .su-public-brand .su-report-sections { padding: 6px 24px 32px; }
   .su-public-brand .su-report-grid { grid-template-columns: 1fr; }
   .su-public-brand .su-report-scores { padding: 32px 24px; }
@@ -673,11 +837,13 @@
   }
 
   /* Prevent awkward mid-card / mid-section splits */
-  .su-public-brand .su-report-card {
+  .su-public-brand .su-report-card,
+  .su-public-brand .su-report-decision-card {
     break-inside: avoid;
   }
 
   .su-public-brand .su-report-overall,
+  .su-public-brand .su-report-decisions,
   .su-public-brand .su-report-sections,
   .su-public-brand .su-report-scores,
   .su-public-brand .su-report-recs,


### PR DESCRIPTION
Closes the gaps you found live-testing the Quick Assessment. Brainstorm → approved frontend-design mockup → Workflow build (report rendering + distribution) → 3-lens adversarial review → fixes. Spec [`16`](docs/specs/v7.6/16-quick-assessment-report-emails-and-coach-links.md).

**Report polish** — `BrandedReport` now renders the approved anatomy (cover → score ring → per-decision cards → score table → **aligned statement chips** → conclusion + coach CTA); the jammed per-statement digit is fixed. CSS scoped under `.su-public-brand .su-report` (ADR-0005, zero leak).

**Report emails** — new `report-email.ts` builds **email-safe inline HTML** (table layout, escaped body, plain-text subjects) of the same report. On submit (durable outbox, **additive — no migration**): the **taker** gets a copy, the **referring coach** gets the **full report** (was just a lead alert), the **SU team** keeps its lead-alert summary. All enqueued in the submission transaction; idempotent.

**Per-coach links** — the public client reads `?coach=…` → `referringCoachEmail`, validated by the existing active-coach open-relay guard (a bad/inactive ref → SU-team-only, never an arbitrary address). Plus a **"Copy my assessment link"** affordance in the coach portal.

**Consent** copy discloses the emailed copy.

**Review (3 lenses):** no critical, no leak, no open-relay. Fixes applied: plain-text email subjects (a subject isn't HTML); split score ring (no crowding); WCAG-safe card-average contrast; the overall score is announced to screen readers (ring stays decorative); real CTA link; heading-order consistency; the email now includes the detailed breakdown so it's a true copy. *(On-screen/email `scoringConfig` parity flagged as a benign multi-file follow-up.)*

114 tests / 8 suites green; `CI=true npx next build --turbopack` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)