### PR TITLE
fix(quiz): on-screen public report renders bare (missing su-report.css + scope wrapper)

### DIFF
--- a/src/src/__tests__/components/public-quiz-results.test.tsx
+++ b/src/src/__tests__/components/public-quiz-results.test.tsx
@@ -176,6 +176,12 @@ describe("PublicQuizClient — in-place results + consent + idempotency (Task 7)
       expect(screen.getByTestId("quiz-results")).toBeInTheDocument(),
     );
 
+    // The report MUST be wrapped in `.su-public-brand .su-report` so the scoped
+    // su-report.css applies on-screen (else it renders bare — the in-place CSS bug).
+    expect(
+      screen.getByTestId("quiz-results").querySelector(".su-public-brand.su-report"),
+    ).not.toBeNull();
+
     // BrandedReport renders the assessment name.
     expect(screen.getByText("Scaling Up Full")).toBeInTheDocument();
 

--- a/src/src/components/assessments/public-quiz-client.tsx
+++ b/src/src/components/assessments/public-quiz-client.tsx
@@ -18,6 +18,10 @@ import {
   deriveTimeEstimate,
 } from "@/components/assessments/assessment-welcome";
 import { BrandedReport } from "@/components/assessments/BrandedReport";
+// The detailed report styling lives in su-report.css (scoped to .su-public-brand
+// .su-report). The invited (report) route loads it via its layout; the public
+// in-place results must load it here too, else the report renders unstyled.
+import "@/styles/su-report.css";
 import type { RespondentReport, QuestionMeta } from "@/lib/assessments/respondent-report";
 import type { ScoreResult } from "@/lib/assessments/scoring";
 
@@ -367,11 +371,15 @@ export function PublicQuizClient({
     };
     return (
       <main className="survey-body" data-testid="quiz-results">
-        <BrandedReport
-          report={report}
-          assessmentName={templateName}
-          campaignLabel={campaignName}
-        />
+        {/* Scope wrapper so su-report.css applies (ADR-0005) — same wrapper the
+            invited (report) route layout provides. */}
+        <div className="su-public-brand su-report">
+          <BrandedReport
+            report={report}
+            assessmentName={templateName}
+            campaignLabel={campaignName}
+          />
+        </div>
       </main>
     );
   }


### PR DESCRIPTION
Live-testing caught it: after submitting the public Quick Assessment, the **on-screen** report rendered **bare** (plain text list) while the **emailed copy was correctly polished**.

**Cause:** the detailed report styling lives in `su-report.css`, scoped to `.su-public-brand .su-report`. Only the invited `(report)` route's layout imported it + provided the wrapper. The **public in-place results** (`public-quiz-client`) rendered `<BrandedReport>` with neither → unstyled. The email looked right because `buildReportEmailHtml` uses inline styles.

**Fix:** wrap the in-place report in `.su-public-brand .su-report` and `import "@/styles/su-report.css"` in the public client. Rules stay scoped (ADR-0005, no leak). Regression test asserts the wrapper is present in the results region.

13 tests green; build gate clean.