### PR TITLE
fix(workshops): Live Preview honors customHtml override (Wave B follow-up)

### DIFF
--- a/.claude/claudex/log
+++ b/.claude/claudex/log
@@ -1399,3 +1399,15 @@ The plan at `PLAN.md...
 [2026-06-13T05:13:24Z] Active loop: 20260613-040039-53aaa1
 [2026-06-13T05:13:24Z] State: mode=plan phase=done round=4/3 signal=max-reached
 [2026-06-13T05:13:24Z] APPROVE: plan loop already done
+[2026-06-14T13:59:29Z] Hook fired. Input bytes: 2172
+[2026-06-14T13:59:29Z] Active loop: 20260613-040039-53aaa1
+[2026-06-14T13:59:29Z] State: mode=plan phase=done round=4/3 signal=max-reached
+[2026-06-14T13:59:29Z] APPROVE: plan loop already done
+[2026-06-14T14:10:54Z] Hook fired. Input bytes: 3690
+[2026-06-14T14:10:54Z] Active loop: 20260613-040039-53aaa1
+[2026-06-14T14:10:54Z] State: mode=plan phase=done round=4/3 signal=max-reached
+[2026-06-14T14:10:54Z] APPROVE: plan loop already done
+[2026-06-14T14:17:45Z] Hook fired. Input bytes: 2156
+[2026-06-14T14:17:45Z] Active loop: 20260613-040039-53aaa1
+[2026-06-14T14:17:45Z] State: mode=plan phase=done round=4/3 signal=max-reached
+[2026-06-14T14:17:45Z] APPROVE: plan loop already done

--- a/src/.claude/claudex/log
+++ b/src/.claude/claudex/log
@@ -40,3 +40,7 @@
 [2026-06-05T18:27:18Z] ERR trap at line 67; failing open
 [2026-06-09T13:01:11Z] Hook fired. Input bytes: 3054
 [2026-06-09T13:01:11Z] ERR trap at line 67; failing open
+[2026-06-14T04:45:55Z] Hook fired. Input bytes: 2253
+[2026-06-14T04:45:55Z] ERR trap at line 67; failing open
+[2026-06-14T14:09:47Z] Hook fired. Input bytes: 1521
+[2026-06-14T14:09:47Z] ERR trap at line 67; failing open

--- a/src/src/__tests__/components/custom-html-panel.test.tsx
+++ b/src/src/__tests__/components/custom-html-panel.test.tsx
@@ -315,6 +315,44 @@ it("shows published notice when pageStatus is PUBLISHED", () => {
   expect(screen.queryByText(/won't be public/i)).toBeNull();
 });
 
+// ── 17b. onValueChange fires with initial value on mount ──
+it("onValueChange is called on mount with the initial textarea value", () => {
+  const onValueChange = jest.fn();
+  render(
+    <CustomHtmlPanel
+      {...BASE_PROPS}
+      initialCustomHtml="<p>initial</p>"
+      resolvedHtml=""
+      onValueChange={onValueChange}
+    />
+  );
+  // useEffect fires after mount — called at least once with the initial value
+  expect(onValueChange).toHaveBeenCalledWith("<p>initial</p>");
+});
+
+// ── 17c. onValueChange fires on every textarea keystroke ──
+it("onValueChange is called with updated value after typing in textarea", () => {
+  const onValueChange = jest.fn();
+  render(
+    <CustomHtmlPanel
+      {...BASE_PROPS}
+      initialCustomHtml=""
+      resolvedHtml=""
+      onValueChange={onValueChange}
+    />
+  );
+  onValueChange.mockClear();
+  fireEvent.change(getTextarea()!, { target: { value: "<p>typed</p>" } });
+  expect(onValueChange).toHaveBeenCalledWith("<p>typed</p>");
+});
+
+// ── 17d. onValueChange not required — panel works without it (no crash) ──
+it("panel renders without crash when onValueChange is not provided", () => {
+  expect(() =>
+    render(<CustomHtmlPanel {...BASE_PROPS} initialCustomHtml="<p>x</p>" resolvedHtml="" />)
+  ).not.toThrow();
+});
+
 // ── 17. Two consecutive saves send the correctly-updated expectedCustomHtml (CAS-baseline) ──
 it("two consecutive saves re-anchor expectedCustomHtml to the server-returned value after save 1", async () => {
   // Save 1: server echoes SERVER-A

--- a/src/src/app/(dashboard)/workshops/[id]/landing-pages/duo-landing/page.tsx
+++ b/src/src/app/(dashboard)/workshops/[id]/landing-pages/duo-landing/page.tsx
@@ -142,6 +142,8 @@ export default function DuoLandingEditor() {
   const [pageCustomHtml, setPageCustomHtml] = useState<string | null>(null);
   const [pageStatus, setPageStatus] = useState<string | null>(null);
   const [resolvedHtml, setResolvedHtml] = useState<string>("");
+  // Mirrors the live CustomHtmlPanel textarea value for the Live Preview pane.
+  const [livePreviewHtml, setLivePreviewHtml] = useState<string>("");
 
   useEffect(() => {
     async function loadData() {
@@ -223,7 +225,10 @@ export default function DuoLandingEditor() {
         // CustomHtmlPanel wiring — fail-closed: only activate when marker is true
         if (pageData.customHtmlEditor === true) {
           setCustomHtmlEditor(true);
-          setPageCustomHtml(pageData.data?.customHtml ?? null);
+          const storedHtml = pageData.data?.customHtml ?? null;
+          setPageCustomHtml(storedHtml);
+          // Seed Live Preview with the saved override so it reflects on first load.
+          setLivePreviewHtml(storedHtml ?? "");
           setPageStatus(pageData.data?.status ?? null);
           // Pre-fetch resolved HTML for the "Refresh" fallback (Q5b)
           try {
@@ -568,6 +573,7 @@ export default function DuoLandingEditor() {
               pageStatus={pageStatus}
               initialCustomHtml={pageCustomHtml}
               resolvedHtml={resolvedHtml}
+              onValueChange={setLivePreviewHtml}
             />
           )}
         </div>
@@ -579,13 +585,27 @@ export default function DuoLandingEditor() {
               <CardTitle className="text-sm font-medium">Live Preview</CardTitle>
             </CardHeader>
             <CardContent className="p-0">
-              <div className="max-h-[calc(100vh-200px)] overflow-y-auto">
-                <DuoLandingPageTemplate
-                  content={formData}
-                  workshop={SAMPLE_WORKSHOP_DUO}
-                  isPreview={true}
-                />
-              </div>
+              {customHtmlEditor && livePreviewHtml.trim() !== "" ? (
+                <div>
+                  <p className="px-3 py-1.5 text-xs text-muted-foreground border-b bg-muted/50">
+                    Preview shows your raw HTML. On the live page, tokens (e.g. {"{{"}<span>{"registration_url"}</span>{"}}"}) resolve and disallowed tags/scripts are stripped.
+                  </p>
+                  <iframe
+                    title="Custom HTML preview"
+                    srcDoc={livePreviewHtml}
+                    sandbox=""
+                    className="w-full h-[calc(100vh-240px)] border-0 bg-white"
+                  />
+                </div>
+              ) : (
+                <div className="max-h-[calc(100vh-200px)] overflow-y-auto">
+                  <DuoLandingPageTemplate
+                    content={formData}
+                    workshop={SAMPLE_WORKSHOP_DUO}
+                    isPreview={true}
+                  />
+                </div>
+              )}
             </CardContent>
           </Card>
         </div>

--- a/src/src/app/(dashboard)/workshops/[id]/landing-pages/solo-landing/page.tsx
+++ b/src/src/app/(dashboard)/workshops/[id]/landing-pages/solo-landing/page.tsx
@@ -77,6 +77,8 @@ export default function SoloLandingEditor() {
   const [pageCustomHtml, setPageCustomHtml] = useState<string | null>(null);
   const [pageStatus, setPageStatus] = useState<string | null>(null);
   const [resolvedHtml, setResolvedHtml] = useState<string>("");
+  // Mirrors the live CustomHtmlPanel textarea value for the Live Preview pane.
+  const [livePreviewHtml, setLivePreviewHtml] = useState<string>("");
 
   const [formData, setFormData] = useState<SoloLandingData>({
     coachPhoto: "",
@@ -135,7 +137,10 @@ export default function SoloLandingEditor() {
         // CustomHtmlPanel wiring — fail-closed: only activate when marker is true
         if (pageData.customHtmlEditor === true) {
           setCustomHtmlEditor(true);
-          setPageCustomHtml(pageData.data?.customHtml ?? null);
+          const storedHtml = pageData.data?.customHtml ?? null;
+          setPageCustomHtml(storedHtml);
+          // Seed Live Preview with the saved override so it reflects on first load.
+          setLivePreviewHtml(storedHtml ?? "");
           setPageStatus(pageData.data?.status ?? null);
           // Pre-fetch resolved HTML for the "Refresh" fallback (Q5b)
           try {
@@ -492,6 +497,7 @@ export default function SoloLandingEditor() {
               pageStatus={pageStatus}
               initialCustomHtml={pageCustomHtml}
               resolvedHtml={resolvedHtml}
+              onValueChange={setLivePreviewHtml}
             />
           )}
         </div>
@@ -504,13 +510,27 @@ export default function SoloLandingEditor() {
               <CardTitle className="text-sm font-medium">Live Preview</CardTitle>
             </CardHeader>
             <CardContent className="p-0">
-              <div className="max-h-[calc(100vh-200px)] overflow-y-auto">
-                <SoloLandingPageTemplate
-                  content={formData}
-                  workshop={SAMPLE_WORKSHOP_SOLO}
-                  isPreview={true}
-                />
-              </div>
+              {customHtmlEditor && livePreviewHtml.trim() !== "" ? (
+                <div>
+                  <p className="px-3 py-1.5 text-xs text-muted-foreground border-b bg-muted/50">
+                    Preview shows your raw HTML. On the live page, tokens (e.g. {"{{"}<span>{"registration_url"}</span>{"}}"}) resolve and disallowed tags/scripts are stripped.
+                  </p>
+                  <iframe
+                    title="Custom HTML preview"
+                    srcDoc={livePreviewHtml}
+                    sandbox=""
+                    className="w-full h-[calc(100vh-240px)] border-0 bg-white"
+                  />
+                </div>
+              ) : (
+                <div className="max-h-[calc(100vh-200px)] overflow-y-auto">
+                  <SoloLandingPageTemplate
+                    content={formData}
+                    workshop={SAMPLE_WORKSHOP_SOLO}
+                    isPreview={true}
+                  />
+                </div>
+              )}
             </CardContent>
           </Card>
         </div>

--- a/src/src/components/workshops/custom-html-panel.tsx
+++ b/src/src/components/workshops/custom-html-panel.tsx
@@ -9,7 +9,7 @@
  * surrounding editor's "Save Draft" / "Save & Publish" buttons.
  */
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ConfirmationModal } from "@/components/ui/confirmation-modal";
@@ -26,6 +26,12 @@ export interface CustomHtmlPanelProps {
    * Empty string means no active template / nothing to resolve.
    */
   resolvedHtml: string;
+  /**
+   * Optional callback fired whenever the live textarea value changes (including
+   * on mount and after programmatic Restore/Refresh). The parent editor uses
+   * this to mirror the live HTML into the Live Preview pane.
+   */
+  onValueChange?: (value: string) => void;
 }
 
 export function CustomHtmlPanel({
@@ -34,6 +40,7 @@ export function CustomHtmlPanel({
   pageStatus,
   initialCustomHtml,
   resolvedHtml,
+  onValueChange,
 }: CustomHtmlPanelProps) {
   // Q5b: non-empty stored value → else resolvedHtml → else ""
   const initialValue =
@@ -42,6 +49,12 @@ export function CustomHtmlPanel({
       : resolvedHtml;
 
   const [htmlValue, setHtmlValue] = useState<string>(initialValue);
+
+  // Report live value to parent (for Live Preview) — fires on mount + every change.
+  useEffect(() => {
+    onValueChange?.(htmlValue);
+  }, [htmlValue, onValueChange]);
+
   // CAS anchor: what was last loaded from the server
   const [loadedHtml, setLoadedHtml] = useState<string | null>(
     initialCustomHtml ?? null


### PR DESCRIPTION
The per-workshop landing-page editor's **Live Preview** pane always rendered the block-layout template and ignored a `customHtml` override — so the preview didn't match the live public page (which correctly shows the override). Reported during prod testing.

**Fix (UI-only, mirrors the public render precedence):** when the Custom HTML field has content, the Live Preview renders it in a **sandboxed iframe** (`sandbox=""` — no scripts, no CSS bleed), live as you type; when empty, it shows the block template as before. A caption notes the preview shows raw HTML (tokens resolve + scripts strip on the live page). Applied to solo + duo. Additive `onValueChange` read-out on `CustomHtmlPanel`; no change to save/restore/refresh/CAS/API/public-render.

Verified on a Vercel preview: the editor Live Preview now shows the custom Kajabi HTML (was the blue block layout). 20/20 panel tests, eslint 0/0, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)