### PR TITLE
feat(assessments): Wave C — participant survey UX polish (Spec 17 #6–#14)

### DIFF
--- a/docs/specs/v7.6/17c-wave-c-survey-ux-design.md
+++ b/docs/specs/v7.6/17c-wave-c-survey-ux-design.md
@@ -1,0 +1,246 @@
+# Spec 17 — Wave C: Assessment Survey Participant UX (Design)
+
+> **Gate status:** Wave C of [Spec 17](17-jeff-june9-feedback-punchlist.md). **Brainstormed → grilled (`/grill-with-docs` G1–G5, `/grill-me` G6–G7) → claudex-hardened (3 rounds: senior-eng → security → ops/SRE; 16 findings, all addressed — see Changelog). Execution-ready.** Next → per-wave implementation plan (`17c-…-implementation-plan.md`, TDD) → `/frontend-design` mockup for visual sign-off → subagent-driven build. **Not yet built.**
+>
+> **Date:** 2026-06-14 · **Branch:** `feat/wave-c-survey-ux` (off `main`)
+
+## Goal
+
+Fix Jeff's June-9 survey-participant complaints (Spec 17 items **#6–#14**) so the live assessment survey looks finished and behaves correctly: one clean purple card (no white chrome), a slider that doesn't look pre-answered, bordered/limited text inputs, and red highlighting of missed required questions on a blocked advance. All participant-facing, all scoped, additive, no migration.
+
+## Scope
+
+**In scope:** the participant survey UI shared by both flows —
+- `src/src/components/assessments/org-survey-client.tsx` (invited)
+- `src/src/components/assessments/public-quiz-client.tsx` (public quiz)
+- shared: `section-pager.tsx`, `question-input.tsx`, `AssessmentShellHeader.tsx`, `assessment-welcome.tsx`
+- scoped styles in `src/src/styles/wireframes-scoped.css` (`.su-assessment-brand` block)
+
+**Out of scope (this wave):**
+- #14 **editability** of section intros (deferred — see §"Item 14" + §"Deferred").
+- Any admin/coach template-editor change, any campaign-setup change (that is Wave D).
+- Any report change (Wave E). Any new write path, migration, or feature flag.
+
+## Constraints (locked)
+
+1. **Scope isolation (ADR-0005):** every new/changed rule lives under `.su-assessment-brand`. Zero global-token change, zero leak into the blue `.wf-scope` admin/coach UI. No new top-level selectors. **(Round-1 M2)** Several current survey rules (progress, nav, errors, text inputs, question layout) still have **shared `.wf-scope` selectors** that also serve admin/coach UI — so all Wave C participant restyling must be added as **new `.su-assessment-brand …` overrides**, NOT by editing the base `.wf-scope` rules (the only permitted `.wf-scope` change is removing a rule proven unused). Add a static grep/lint guard asserting new survey selectors are `.su-assessment-brand`-scoped.
+2. **Additive, no migration, no feature flag.** These are UI corrections + one render-logic change. Reversible by `git revert`. Unlike Wave B there is no new server write surface, so no kill-switch is warranted.
+3. **Both flows must stay in lockstep.** All changes are in shared components or shared CSS; the invited and public clients consume the same `SectionPager`/`QuestionInput`. Any client-level change (the header restructure) is applied to **both** clients identically.
+4. **Build gate:** `CI=true npx next build --turbopack` from `/Users/diushianstand/Scaling-up-platform-v2/src`. TDD for the two logic changes (#8 state, #13 validation).
+5. **Visual sign-off:** a `/frontend-design` mockup of the restyled survey (#6/#7/#8/#9/#11) is approved by the user **before** build, per the established Wave pattern (PRs #41/#51/#54).
+
+## Locked decisions (from brainstorm, 2026-06-14)
+
+- **D1 (#6+#10) — Unified purple card, caption-every-page.** Remove the white header bar **and** the big white survey-title card. The survey name moves into the purple shell as a **small caption shown on every page**; the prominent name still appears on the welcome screen and first section. The "big repeating title" is what #10 objects to, and deleting the white title card removes it.
+- **D2 (#8) — Hide the thumb via scoped CSS.** Keep the native `<input type="range">`. When the answer is unset, hide the thumb and show an empty (unfilled) track using the **existing** `.is-unanswered` wrapper hook. First interaction reveals the thumb + fill. No control rework (segmented buttons were tried in PR #33 and reverted by PR #34 per decision D4 "keep the slider").
+- **D3 (#14) — Defer editability.** Wave C verifies the section intro renders against Jeff's example; in-app editing of section intros is a separate setup/authoring feature (versioned-content + publish path) and belongs in Wave D or its own spec.
+
+## Grill resolutions (`/grill-with-docs`, 2026-06-14)
+
+Five residual flaws/decisions surfaced and were resolved against the codebase before the plan:
+
+- **G1 (refines #6) — Caption = the campaign's name in BOTH flows** (`campaign.name` invited / `campaignName` public). Matches the public welcome's own prominent `<h1>`; least visual change. Public form-step pager switches `assessmentName` from `templateName` → `campaignName`. *(Corrected a first-pass pick of `templateName` after the code showed the public welcome already shows `campaignName`.)*
+- **G2 (fixes a #8 a11y trap) — Track-level focus ring for the unanswered slider.** Hiding the thumb would hide the *only* focus indicator (`survey-slider:focus::-webkit-slider-thumb`); add `.is-unanswered .survey-slider:focus-visible { outline … }` so keyboard focus is always visible.
+- **G3 (resolves a #6 redundancy) — One progress bar.** Keep the authoritative linear `survey-progress` (restyled into the purple block), **drop** the decorative `su-shell-seg` segmented strip; keep the "Section N of M" text.
+- **G4 (#13 / #11 / #12 polish) —** focus the first invalid question on a blocked advance; generic placeholders ("Type your answer here…" / "Enter a number"); char-counter visible only in the last ~1,000 chars.
+- **G5 (factual) —** the invited `ty-card` (= `campaign.name`, every page) is the #10 offender and is invited-only; the public form step has no title card and only loses `ty-header`. #13's gate is centralized in `SectionPager` (both flows, both Next + last-section Submit); the public client's `canSubmit` is an untouched final-POST guard.
+
+### `/grill-me` round (fresh-eyes, 2026-06-14)
+
+- **G6 (cross-decision: #8 × G2 × #13) — Focus-independent red rail for a missed slider.** #13 programmatically focuses the first invalid question; if it's an unanswered slider (hidden thumb, #8) and the gate was triggered by a mouse click, G2's `:focus-visible` ring may not match → the missed control could be invisible. Fix: the #13 invalid (red) treatment is **focus-independent** and applies to **the slider rail itself** (not just the card), so a missed slider is always visibly flagged. Tested without any focus state applied.
+- **G7 (P0 — wireframe reconciliation) — #6 deliberately deviates from WF-15.** WF-15 specifies a white header + white linear progress bar (no purple card); the live app is a hybrid triple-header (white `ty-header` + purple `su-shell-header` + white `ty-card`) — the clutter Jeff flagged. Jeff's June-9 #6 directive supersedes WF-15; G3 (drop the segmented strip) restores wireframe fidelity on the progress bar. Documented in §"Wireframe reconciliation". Autosave verified safe vs #8/#13.
+
+---
+
+## Per-item design
+
+### #6 + #10 — Unified purple-card header  *(layout; D1)*
+
+**Current (the bug):** the ready-state render in each client is
+`ty-page → ty-header (white "Scaling Up" bar) → main.survey-body → ty-card (eyebrow "Survey" + h1 title + lede) → SectionPager (purple su-shell-header: white logo + "Assessment · Company — Section N of M" + segmented strip) → survey-progress bar → questions`.
+The white `ty-header` is the "white header bar" Jeff wants gone (#6); the `ty-card` title block sits outside the pager and therefore **re-renders on every section**, which is the "title on every page" Jeff wants gone (#10).
+
+**Target:**
+- **Delete** the white `ty-header` bar from the ready-state of **both** clients.
+- **Delete** the standalone `ty-card` survey-title block — **invited flow only** (`org-survey-client`): its `ty-card` h1 = `campaign.name` re-renders above the pager on every section, which is exactly the every-page title #10 objects to. The **public** form step has **no** such card (it goes `ty-header → submit-error banner → SectionPager`), so public only loses the `ty-header`.
+- **Header name source (Grill Q1, resolved 2026-06-14):** **the caption shows the campaign's name in both flows** — `campaign.name` (invited) and `campaignName` (public). Rationale: the public **welcome** screen already shows `{campaignName}` as its prominent `<h1>` (with `templateName` only as the small shell caption), so using `campaignName` in the form caption keeps the welcome and the form **consistent within the public flow**, and is the *least* visual change (the old white bar already showed `campaignName`). Plumbing: invited already passes `assessmentName={campaign.name}`; **public must switch the form-step `SectionPager` from `assessmentName={templateName}` → `assessmentName={campaignName}`** (one-line change). `templateName` remains only on the public welcome shell caption (out of #6 scope).
+- The **purple shell** (`AssessmentShellHeader`) becomes the single header: white SU logo → survey-name **caption** → "Section N of M" → the linear `survey-progress` bar, all reading as one purple block. (The progress bar already renders immediately under the shell header inside the pager; visually unify them.)
+- **Single progress indicator (Grill Q3, resolved 2026-06-14):** the survey shows **two** progress UIs today — the decorative `su-shell-seg` segmented section strip (`aria-hidden`) and the authoritative linear `survey-progress` (`role="progressbar"`, answered/total questions). **Keep the linear bar, drop the segmented strip.** The linear bar is the a11y-authoritative one, reflects actual completion, and matches Jeff's singular "progress bar." The **"Section N of M" text caption stays** for section orientation. (Removes a branded flourish from the approved mockup — accepted per Jeff's de-clutter intent.)
+- **DOM ownership of the in-card progress bar (Round-1 M3).** Today `survey-progress` is a **sibling rendered after** `AssessmentShellHeader`, not part of the purple-header DOM — so "progress bar inside the purple card" is structurally ambiguous. Make ownership explicit: **move the `role="progressbar"` into `AssessmentShellHeader`** (fed the answered/total via props) so the header element *is* the purple card containing logo → caption → "Section N of M" → bar. Test asserts: `su-shell-seg` is gone and **exactly one** `role="progressbar"` exists in the tree.
+- The **welcome screen** already shows the prominent survey name (`su-welcome-title`) — unchanged. The **first section** keeps prominence via the existing intro slide heading; later sections show only the small caption.
+
+**Files:** `org-survey-client.tsx`, `public-quiz-client.tsx` (remove `ty-header` + `ty-card` from the ready render; pass the survey/campaign name through to the pager, which already accepts `assessmentName`), `AssessmentShellHeader.tsx` (ensure caption + section + progress compose as one purple unit), `section-pager.tsx` (the `survey-progress` bar lives here — restyle to sit inside the purple block), `wireframes-scoped.css`.
+
+**Notes / risks to grill:** the loading and error phases of each client also use `ty-header`/`ty-card` — those are **not** the survey form and are out of scope (only the ready/questions phase changes). Confirm we don't strip the brand from the loading/error/thank-you screens. The pager already owns section state, so moving the name into it cannot reintroduce per-page duplication.
+
+**Public "About you" white chrome — scope boundary (Round-1 L2).** The public flow's contact-info step ("About you") also renders the white `ty-header`/`ty-card`, as do the thank-you (invited) and results (public) screens. Jeff's #6 verbatim targets the **survey** ("Everything inside the purple card"), so **Wave C scopes #6 to the question pager only** (both flows). The residual white chrome on the public info step + thank-you/results is **explicitly flagged to confirm with Jeff** rather than silently extended — if he means the whole participant journey, restyling the info step with the participant shell is a fast follow-up, but it is not assumed here.
+
+### #7 — Remove the orange "01" section numbers  *(CSS/JSX)*
+
+Delete the `su-intro-num` badge (renders `String(idx+1).padStart(2,"0")`) from the intro slide in `section-pager.tsx`, and remove its CSS. Keep the step label (`partLabel`, e.g. "Fundamental 1"), the section title, and "What this section covers." This partially reverses PR #51's intro polish, as the spec anticipates.
+
+### #8 — Slider visually unset until chosen  *(CSS + minor JSX; D2)*
+
+**Current:** `question-input.tsx` SLIDER_LIKERT sets `numVal = answered ? value : min` and tags the wrapper `survey-slider-wrap is-unanswered` when `answered` is false. The native thumb therefore parks at `min`, looking pre-selected. Commit-on-min already works (`onChange`/`onClick`/`onPointerUp`/`onKeyUp`, PR #50). `isAnswered` already treats `0` as answered.
+
+**Change:**
+- Scoped CSS: when `.survey-slider-wrap.is-unanswered`, set the thumb (`::-webkit-slider-thumb`, `::-moz-range-thumb`) to `opacity: 0` (no shadow/border) and render the track as a flat empty rail (no purple fill / `--pct: 0`). The numbered ticks stay visible as the tap targets; the status line already prompts "Tap or drag the slider to rate."
+- On first interaction → `answered` true → `.is-unanswered` drops → thumb + fill render normally, selected tick highlights.
+- Minor JSX: set the WebKit fill via an inline `--pct` custom property **only when answered** (so the filled track tracks the value); when unanswered, `--pct` is absent → empty rail.
+- **Keyboard focus ring (Grill Q2, resolved 2026-06-14):** the *only* current focus styling is `survey-slider:focus::-webkit-slider-thumb` — hiding the thumb would hide the sole focus indicator, stranding keyboard users on an invisible control. Add a **track-level** ring for the unanswered state: `.is-unanswered .survey-slider:focus-visible { outline: 2px solid #522583; outline-offset: 4px; }`. Once a key commits → `answered` flips → thumb + its existing focus ring return. The control is always visibly focusable. (Selecting the minimum by keyboard already works: ArrowLeft/Home at `min` commits `0` via `onKeyUp`.)
+
+**TDD:** (a) wrapper carries `is-unanswered` until a value is set and loses it after; (b) selecting the minimum value commits and counts as answered (`0` is answered); (c) the hidden-thumb state is keyed solely on `answered`.
+
+**Grill targets:** with the thumb hidden, is the affordance discoverable enough (ticks + prompt + clickable track)? Keyboard: a focused range with no visible thumb — does focus-visible still show a ring so keyboard users can orient? Screen-reader: `aria-valuetext="Not yet answered"` is already set when unanswered — confirm that's still announced.
+
+### #9 — Bigger slider handle  *(CSS)*
+
+Increase the thumb from 22px to ~30px on both `::-webkit-slider-thumb` and `::-moz-range-thumb`; adjust `margin-top` to recenter on the 6px track; scale the focus-ring radius to match. Scoped CSS only.
+
+### #11 — Text inputs: visible border + placeholder  *(CSS + copy)*
+
+`question-input.tsx` TEXT (`<textarea class="survey-textarea">`) and NUMBER (`<input class="survey-input-number">`) currently have **no placeholder**. Add a generic placeholder ("Type your answer here…" for text; "Enter a number" for number). No per-question placeholder field exists in the model and inventing one is out of scope (YAGNI). Ensure both controls have a clearly visible border + focus ring in scoped CSS.
+
+### #12 — Surface the character limit  *(small)*
+
+`MAX_TEXT_ANSWER_LENGTH = 10_000` is exported from `lib/assessments/scoring.ts` and enforced **server-side** at submit, but is invisible client-side. **(Round-1 M4)** Do NOT import it into the client `QuestionInput` directly from `scoring.ts` — that would pull the whole scoring/Zod module into the participant bundle for one constant. Instead **move the answer-length limits into a tiny client-safe module** (`lib/assessments/answer-limits.ts`, no Zod/server imports) and have **both** `scoring.ts` and `QuestionInput` import from it. Then add `maxLength={MAX_TEXT_ANSWER_LENGTH}` to the textarea (browser stops typing at the limit), and a subtle live counter ("N / 10000") that becomes visible **only when the user enters the last ~1,000 characters** (Grill Q4c) — keeping every text box clean otherwise while still warning before the browser truncates. 10k is appropriate for open reflection text — confirmed appropriate, no change to the value.
+
+### #13 — Red-highlight missed required questions  *(logic; TDD)*
+
+**Current:** `section-pager.tsx` `handleNext` computes `unanswered = page.questions.filter(required && !isAnswered)`; if any, sets `showGateError = true` → a single bottom `survey-error` alert. No per-question indication.
+
+**Change:**
+- When the gate blocks, also compute the **set of unanswered-required stableKeys** and store it in state. Pass each question an `invalid` flag into `QuestionInput` (and onto its `<li>`/label).
+- Visual: red/`destructive` border on the question card, red label + asterisk. Keep the bottom alert.
+- **Per-type invalid + focus contract (Round-1 H1, 2026-06-14).** `aria-invalid` and focus target differ by question type — define them explicitly so a required `MULTI_CHOICE` (a supported type) cannot fall through:
+  - **SLIDER_LIKERT / TEXT / NUMBER:** `aria-invalid="true"` on the control; blocked-advance focus targets that control.
+  - **MULTI_CHOICE:** the control is a `role="group"`, where `aria-invalid` is poorly supported by SRs. So: set the **group-level invalid state** (red card border + red label), give the group `aria-invalid="true"` **and** `aria-describedby` pointing at the inline error text, and **focus the first checkbox `<input>`** on a blocked advance (a focusable element, unlike the group). 
+  - RTL coverage is **required** for an unanswered required `MULTI_CHOICE` (flagged, focus lands on the first checkbox, group marked invalid).
+- **Focus-independent invalid state for sliders (Grill-me, resolved 2026-06-14):** because an unanswered SLIDER_LIKERT has a hidden thumb (#8) and G2's ring uses `:focus-visible` — which a *programmatic* `.focus()` after a **mouse**-click "Next" may not match — the "you missed this" signal must NOT depend on focus. Apply the red invalid treatment to **the slider rail itself** (red track/border on `.survey-slider` when its question is `invalid`), in addition to the card border + red label. So a missed slider is always visibly flagged regardless of focus modality; G2's `:focus-visible` ring is retained only for normal keyboard answering. **Test:** a slider marked `invalid` shows its red indicator with no `:focus`/`:focus-visible` applied.
+- **Clearing (Round-1 M1, corrected):** prune a question from the invalid set **only when its new value is actually answered** — i.e. gate the prune on `isAnswered(nextValue)`, NOT on any change. Otherwise whitespace-only text or deselecting the last checkbox would clear the red state while the question is still unanswered. Keep the bottom alert visible while **any** invalid key remains. Recompute the set on each blocked advance.
+- **Focus (Grill Q4a, resolved):** on a blocked advance, move keyboard focus to the **first** unanswered required question (not the Next button). No conflict with the existing `headingRef` focus, which fires only on section change, not on a blocked advance.
+- **Scope note (resolved):** the per-section required gate lives entirely in `SectionPager.handleNext` and already covers **both** the mid-survey "Next" gate **and** the last-section "Submit" gate, for **both** flows. The public client's separate `missingRequired`/`canSubmit` is a final-POST guard and is **unchanged** by #13. No per-client validation duplication is introduced.
+- **All-optional zero-answer submit (Round-1 M6 → refined by Round-2 M2).** The submit API rejects an empty `answers` array (`EMPTY_ANSWERS`), and **both** clients can be all-optional (invited too — not just public), so a zero-answer Submit either silently no-ops (public `canSubmit` false) or hits a **terminal error screen** (invited). Fix: `SectionPager` **owns** the endpoint-level non-empty rule via an optional `requireAtLeastOneAnswer` mode used by **both** clients. Critically, with zero answers there is **no specific invalid question to focus** in a multi-section optional survey — and optional questions must **NOT** be marked required/invalid. So the treatment is a **non-field-level alert** ("Please answer at least one question before submitting.") plus focus moved to the **first answerable control**, not a per-question red state. Test the all-optional empty-submit UX for both flows.
+- **Submit-error recovery, not a terminal screen (Round-2 M1, partial-accept).** A stale/tampered autosaved draft can pass the client gate yet fail server-side (`UNKNOWN_STABLE_KEY` / `INVALID_TYPE` / `ANSWER_TOO_LONG`); the invited client currently drops to a terminal error. Where the server returns per-field validation detail, **map it back into `invalidKeys`** and keep the participant **on the pager** with focus on the offending question (reusing the #13 machinery), instead of the dead-end screen. **Stale-key prune (Round-3 M2, upgrades this fix):** mapping server errors into `invalidKeys` cannot recover an answer whose stableKey matches **no rendered question** (stale draft from a changed version, duplicate/off-schema key) — there is nothing to focus, so the user is trapped. So Wave C **prunes the answers map against the currently-rendered question set** (the client already holds it) on **hydrate and again immediately before submit**, dropping unrenderable entries from state *and* `localStorage`. For any server error without a focusable stableKey, fall back to a **non-field alert** (no per-question highlight). This is a cheap client-safe key-set filter, not a value re-validator — deep type/length validation still defers to the server.
+- **Synchronous submit latch (Round-2 M3).** The Submit button disables only via the async `submitting` prop after a parent rerender, so a rapid double-click can fire **concurrent POSTs** (server row-lock/idempotency prevents dup rows, but the client races success vs 409). Add a **synchronous in-flight ref latch** in the pager/client (or disable immediately on click) so only one POST is ever in flight; test invited + public double-click.
+- **Selector-safe focus (Round-2 L1).** Locate the first invalid control via a **React ref map or `document.getElementById`**, never `querySelector('#q-' + stableKey)` — a stableKey containing CSS metacharacters would break/escape the selector. Add a test with a punctuation-bearing stableKey.
+
+**Files:** `section-pager.tsx` (invalid-set state + propagation + focus), `question-input.tsx` (accept `invalid` → `aria-invalid` + class), `wireframes-scoped.css` (scoped red state).
+
+**TDD:** (a) blocked advance flags exactly the unanswered required questions, not optional ones, not answered ones; (b) answering a flagged question clears just its flag; (c) once all are answered, advance proceeds and no flags remain; (d) `aria-invalid` is set on flagged controls only.
+
+### #14 — Section intro text  *(verify-only; D3)*
+
+**Renders:** ✓ — `page.description` drives the intro slide (`su-intro-covers` / `su-intro-desc`), shipped via PR #36/#51. **Named verification fixture (Round-1 L1):** the implementation plan must pin the authoritative example — the **Five Dysfunctions** template (or Rockefeller), a specific **section with a non-empty `description`** in its seeded `sections` JSON, reached via the live survey route (invited `/org-survey/<alias>` or public `/quiz/<alias>`); the acceptance check is that that section's intro slide renders the seeded description text. Store the verification evidence (screenshot path) in the PR. If a target section's `description` is empty in the live seed, that is the actionable gap to report.
+
+**Editability:** **deferred.** Section descriptions live inside the `TemplateVersion.sections` JSON, which is part of `contentHash` (sha256 over `{questions, sections, scoringConfig, reportConfig, …}`) and governed by the DRAFT/PUBLISHED version lifecycle. The admin editor (`survey-template-editor.tsx`) edits template- and question-level descriptions, **not** section-level. Making section intros UI-editable forces versioning/publish decisions (new draft vs immutable published row, contentHash recompute, pinned-campaign impact) that deserve their own design + grill. It is a setup/authoring sibling of Wave D #19/#20 — see §Deferred.
+
+---
+
+## Wireframe reconciliation (WF-15 / WF-18) + autosave  *(deeper grill, 2026-06-14)*
+
+**P0 — #6 is a deliberate deviation from WF-15, now documented (not silent drift).** The invited survey wireframe `src/public/wireframes-phase2/participant-invited/15-participant-survey-form.html` specifies a **WHITE** sticky header (`.survey-header { background: hsl(var(--card)) }`) with a small purple-square logo mark, org name, and an autosave badge — plus a **WHITE** sticky linear progress bar (`.survey-progress__bar/__fill/__pct` with "Section N of M"). There is **no purple card** in the wireframe.
+
+The current live app is a **hybrid**: it renders WF-15's white `ty-header` **and** a later purple `su-shell-header` (added by the PR #41/#51 brand work) **and** a white `ty-card` title — the triple-header clutter Jeff's #6 is reacting to. **Resolution:** Jeff's explicit June-9 directive ("remove the white header bar; everything inside the purple card") **supersedes WF-15**; Wave C consolidates to the single purple card. This is an intentional, Jeff-authorized wireframe deviation, surfaced here per the wireframes-are-the-spec rule.
+
+Two corollaries:
+- **G3 restores wireframe fidelity on the progress element:** WF-15 has the linear bar and **no** segmented strip, so dropping `su-shell-seg` is *more* faithful, not less. (The bar simply moves onto the purple background per Jeff.)
+- **WF-15's autosave badge** (`✓ Saved`) is a wireframe element Jeff did not call out in #6; surfacing it inside the purple card is **out of scope** for Wave C (note for a later polish, not a regression).
+- **WF-18 (public)** uses a different header structure (no `.survey-header`); reconcile the public header against WF-18 during the build/`frontend-design` step rather than assuming parity with WF-15.
+
+**Autosave interaction verified safe.** `useAnswerDraft` (`lib/assessments/use-answer-draft.ts`) hydrates answers via `JSON.parse` into the answers map. A persisted slider `0` round-trips as the number `0` → `isAnswered(0) === true` and `answered === typeof value === "number"` → the thumb renders (the hidden-unanswered state is **not** triggered by a restored minimum). The #13 invalid set is transient UI state (never persisted), so a mid-survey reload shows no red highlights until the next blocked advance. Neither #8 nor #13 regresses on draft restore.
+
+**Autosave privacy/TTL (Round-2 M4 — documented + deferred).** Autosaved answers persist in `localStorage` with no expiry and are cleared (`clearDraft()`) only on **successful** submit — so confidential free-text can linger on a shared device after link expiry/revocation, a 401/410/409, or an unrecoverable submit error. This is a **pre-existing** property of the PR-#32 autosave, **not** introduced or touched by Wave C, and hardening it (a timestamped draft envelope with TTL + clear-on-terminal-state) is broader than participant-UX. **Explicitly out of Wave C scope; flagged as a follow-up** (the residual risk is accepted for this wave). Wave C must not *worsen* it — in particular the M1 "keep on pager" recovery keeps a draft alive on a recoverable error, which is correct, but a genuinely terminal link state should still clear the draft.
+
+## Data flow (the one non-trivial path)
+
+`#13` is the only new control flow. `SectionPager` owns it end-to-end:
+
+```
+handleNext()
+  → unanswered = page.questions.filter(required && !isAnswered(answers[key]))
+  → if unanswered.length: setInvalidKeys(new Set(unanswered.map(q=>q.stableKey))); setShowGateError(true); focus(first)
+  → else: advance()
+
+handleAnswerChange(key, value)
+  → onAnswerChange(key, value)
+  → if isAnswered(value): invalidKeys.delete(key)   // M1: prune ONLY when truly answered
+  → if invalidKeys empty: clear showGateError         //     (whitespace text / last-checkbox-off STAYS invalid)
+
+render question:
+  → <QuestionInput invalid={invalidKeys.has(q.stableKey)} … />
+```
+
+The invalid set is **per-section** (reset on `goToSection`). No server involvement; no persisted state. `isAnswered` (from `lib/assessments/section-pages`) is the single source of "answered", already treating `0`/empty-string/empty-array correctly.
+
+## Testing
+
+- **Unit/RTL (TDD):** `question-input.test.tsx` (slider unanswered→answered state, `0` answered, `invalid` → `aria-invalid` for slider/text/number; **required `MULTI_CHOICE` invalid → group marked invalid + focus lands on the first checkbox** [Round-1 H1]), `section-pager.test.tsx` (validation flags the right keys, clears on answer, advances when clear, per-section reset; **prune only when `isAnswered(next)` — whitespace-only text and deselecting the last checkbox STAY invalid** [Round-1 M1]; **all-optional zero-answer submit shows the alert + focuses** [Round-1 M6]; **exactly one `role="progressbar"`, `su-shell-seg` gone** [Round-1 M3]).
+- **Browser-level visual (Round-1 M5):** RTL cannot prove a hidden thumb, red rail, or browser-specific focus ring actually *renders*. Keep RTL for the state contracts, and add **at least one Playwright (Chromium) check** of the slider across unanswered / focused / invalid / answered states, plus a **manual Safari + Firefox pass** before merge (pseudo-element + `:focus-visible` behavior is engine-specific).
+- **Both clients:** smoke that `org-survey-client` and `public-quiz-client` still render the pager after the header restructure (no `ty-header`/`ty-card` in the ready phase; loading/error/thank-you unchanged).
+- **Visual:** Vercel preview pass of **both** flows (invited via a test campaign link; public quiz via its alias) before merge — slider unset look, red validation, unified header, bigger handle, text borders/placeholder/counter.
+- **a11y lens** in adversarial review: hidden-thumb focus visibility + SR announcement; `aria-invalid` + focus management on validation; contrast of red state + caption on purple.
+
+## Rollout
+
+- New branch `feat/wave-c-survey-ux` off `main`; subagent-driven (implementer + spec-review + code-quality-review per task), build gate + targeted tests per task, final whole-branch review.
+- Ship behind the build gate; **no feature flag** (UI-only, reversible by revert). Deploy-direct-to-prod per house MO after the preview pass + your go.
+- **Rollout safety (Round-3 H1).** Wave C rewrites the *shared* `SectionPager`/`QuestionInput`, so a slider/validation regression could block submissions for all participant traffic. We deliberately do **not** add a feature flag, because on Vercel a flag change itself requires a redeploy — so a flag gives **no rollback-speed advantage** over Vercel's instant **promote-previous-deployment**, while adding awkward flag-gating to render components. Instead the safety net is: **(1)** a Vercel-**preview canary** exercised end-to-end with a real **test invited campaign** *and* the **public quiz alias** (both flows: unanswered→answered slider, red validation, empty-submit, successful submit) before merge; **(2)** an immediate **post-merge smoke** of both live flows as the **go/no-go** gate; **(3)** if smoke fails, **promote the previous Vercel deployment** (sub-minute, no rebuild) — documented in the Wave C runbook as the rollback. There are currently **no real respondents**, so present blast radius is ~zero, but this path is defined for when traffic arrives.
+- **Telemetry (Round-3 M1) — light now, full deferred.** The immediate post-deploy signal is the both-flow smoke above; server-side submit success/failure is already observable via the existing `/submit` logs + durable outbox. **Full client-side event instrumentation** (counters for submit attempt/success/failure, client-gate blocks, empty-submit blocks, server-validation recovery by flow/error code) is **premature at near-zero volume** (same call as Wave B R3-M4) → flagged as a follow-up to add when real respondent traffic exists; note it in the runbook.
+- SoT flush on merge: CLAUDE.md LAST_UPDATED anchor + `plans/CHANGELOG.md` entry + Notion task.
+
+## Deferred (reasoning)
+
+- **#14 in-app section-intro editing** → Wave D / own spec. It mutates versioned, contentHash-bound, publish-gated template content — a different risk class from participant-UX CSS, and a sibling of Wave D #19 (custom slides) / #20 (custom email editor). Deferring costs nothing; pulling it in welds an authoring feature (+ its publish-path decisions + tests) onto a low-risk UX wave. Reversal condition: if Jeff states seed-only editing is unacceptable now, scope it as its own spec rather than inlining.
+
+## Out of scope
+
+Anything not in Spec 17 items #6–#14. No campaign-setup (#1–3, #15–20 = Wave D), no report changes (#21, #24–31, #33 = Wave E), no net-new (#22/#23/#32 = Wave F). No migration, no new server write path, no feature flag.
+
+## Open questions for the grill
+
+1. ~~**#6 header restructure** — name-source per client.~~ **RESOLVED (Grill Q1, revised):** caption = the campaign's name in **both** flows (`campaign.name` invited / `campaignName` public) — matches the public welcome's own prominent `<h1>`, least visual change. Public form-step pager switches `assessmentName` from `templateName` → `campaignName`; invited unchanged.
+2. ~~**#8 discoverability / keyboard focus.**~~ **RESOLVED (Grill Q2):** focus-ring trap fixed via a track-level `.is-unanswered .survey-slider:focus-visible` outline; ticks + prompt provide the discoverability affordance. Discoverability re-checked in the adversarial a11y pass.
+3. ~~**#13 focus management.**~~ **RESOLVED (Grill Q4a):** focus the first invalid question on a blocked advance; no conflict with `headingRef` (section-change only).
+4. ~~**#11/#12 copy + counter.**~~ **RESOLVED (Grill Q4b/c):** generic placeholders ("Type your answer here…" / "Enter a number"); counter visible only in the last ~1,000 chars.
+5. **Regression surface (carried into the plan, not a blocker):** the header restructure touches both clients' render trees; `__tests__/assessments/section-pager.test.tsx` + `question-input.test.tsx` exist — the plan must read their assertions and **update** (not break) any that key on `ty-header`/`ty-card`/the segmented strip/`is-unanswered`.
+
+---
+
+## Changelog
+
+### claudex round 1 — senior-engineer review (2026-06-14)
+
+All 9 findings accepted (1 high, 6 medium, 2 low); none rejected — each was a real gap, not a style nit.
+
+- **H1 (accepted):** required `MULTI_CHOICE` had no invalid/focus contract → added a **per-type invalid + focus contract** to #13 (slider/text/number = `aria-invalid` + focus the control; multi-choice = group-level invalid + `aria-describedby` + focus the first checkbox), with required-RTL coverage.
+- **M1 (accepted):** invalid-clearing pruned on *any* change → changed to prune **only when `isAnswered(nextValue)`** (whitespace text / deselecting the last checkbox stays invalid); updated the #13 bullet + the data-flow pseudocode; added tests.
+- **M2 (accepted):** several survey rules are shared `.wf-scope` selectors → added a constraint that Wave C restyling must be **new `.su-assessment-brand` overrides** (no base `.wf-scope` edits except proven-unused removals) + a static scope guard.
+- **M3 (accepted):** "progress bar inside the purple card" was DOM-ambiguous (`survey-progress` is a sibling after the header) → made ownership explicit: **move the `role="progressbar"` into `AssessmentShellHeader`**; test exactly one progressbar + `su-shell-seg` gone.
+- **M4 (accepted):** importing `MAX_TEXT_ANSWER_LENGTH` from `scoring.ts` would pull Zod/scoring into the client bundle → **move the limit to a client-safe `lib/assessments/answer-limits.ts`** imported by both.
+- **M5 (accepted):** RTL can't prove the slider visuals render → added a **Playwright (Chromium) check** of the slider states + a manual Safari/Firefox pass; RTL retained for state contracts.
+- **M6 (accepted):** all-optional public quiz with zero answers silently no-ops on Submit → added an **optional `requireAtLeastOneAnswer` mode to `SectionPager`** so the empty submit surfaces the alert + focus; tested for both flows.
+- **L1 (accepted):** #14 verify-only wasn't actionable → **named the fixture** (Five Dysfunctions/Rockefeller section with a non-empty seeded `description`, via the live route) + screenshot evidence.
+- **L2 (accepted):** public "About you" + thank-you/results keep white chrome → **scoped #6 to the question pager** and explicitly flagged the residual white chrome to confirm with Jeff (not silently extended).
+
+### claudex round 2 — security & data-integrity review (2026-06-14)
+
+0 high, 4 medium, 1 low. 3 accepted, 1 partial, 1 documented+deferred.
+
+- **M2 (accepted):** the `requireAtLeastOneAnswer` gate was under-scoped → made it owned by `SectionPager` for **both** flows (invited can be all-optional too), with a **non-field alert + focus the first answerable control** (NOT marking optional questions invalid).
+- **M3 (accepted):** double-click submit race → added a **synchronous in-flight ref latch** so only one POST is in flight; test both flows.
+- **L1 (accepted):** focus-first-missed could break on a stableKey with CSS metacharacters → use a **ref map / `getElementById`**, never `querySelector('#q-'+key)`; punctuation-stableKey test.
+- **M1 (partial-accept):** stale/tampered draft passes the client gate then fails server-side → **map server per-field errors back into `invalidKeys` + keep the user on the pager** (recovery) instead of a terminal screen. Full **hydrate-time draft validation/pruning** is a pre-existing, broader draft-integrity concern → **follow-up, not Wave C scope**.
+- **M4 (documented + deferred):** autosave has no TTL/terminal-state cleanup → confidential text can linger on shared devices. **Pre-existing** PR-#32 behavior, not touched by Wave C; hardening (TTL envelope + clear-on-terminal-state) is a flagged follow-up, residual risk accepted for this wave. Wave C must not worsen it.
+
+### claudex round 3 — ops & SRE review (2026-06-14)
+
+1 high, 2 medium. 1 accepted (lighter form), 1 accepted (upgrades round-2), 1 partial/deferred.
+
+- **H1 (accepted, lighter form):** no flag/canary/rollback gate on the shared-component rewrite → added a **Rollout safety** path: preview canary (both flows) → post-merge smoke as go/no-go → **Vercel promote-previous** as instant rollback. **No feature flag** — argued explicitly that a Vercel flag change needs a redeploy anyway, so it offers no rollback-speed gain over promote-previous while complicating render components; current blast radius ~zero (no real respondents).
+- **M2 (accepted, upgrades Round-2 M1):** mapping server errors into `invalidKeys` can't recover a stale answer whose key matches no rendered question (user trapped) → Wave C now **prunes the answers map to the rendered question set on hydrate + pre-submit** (drops unrenderable keys from state + localStorage) and **falls back to a non-field alert** for keyless server errors. Cheap client-safe key-filter; value-level validation still server-side.
+- **M1 (partial/deferred):** no participant-flow telemetry → light post-deploy **both-flow smoke** now + runbook note (server submit logs/outbox already exist); **full client event instrumentation deferred** as premature at near-zero volume (consistent with Wave B R3-M4), revisit with real traffic.
+
+### Loop outcome
+
+3 rounds run (senior-eng → security → ops/SRE). 16 findings total (1+6+2, 0+4+1, 1+2+0). All addressed: accepted or partially-accepted with the deferred remainder explicitly scoped out + flagged as follow-ups (hydrate-time deep draft validation, autosave TTL/cleanup, full client telemetry). No finding rejected outright. Design is execution-ready for the TDD implementation plan.

--- a/docs/specs/v7.6/17c-wave-c-survey-ux-implementation-plan.md
+++ b/docs/specs/v7.6/17c-wave-c-survey-ux-implementation-plan.md
@@ -1,0 +1,516 @@
+# Wave C — Assessment Survey Participant UX — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix Spec 17 items #6–#14 on the live assessment survey — one clean purple card (no white chrome, no orange "01"), a slider that doesn't look pre-answered, bordered/placeholdered text inputs with a surfaced char limit, and per-question red validation that survives every focus/draft edge case — across both the invited and public flows.
+
+**Architecture:** Pure participant-UI work. All changes live in the shared `SectionPager` / `QuestionInput` / `AssessmentShellHeader` components, the two thin clients (`org-survey-client`, `public-quiz-client`), and the scoped `.su-assessment-brand` CSS block. Two logic changes only — the slider unanswered/invalid state (#8) and per-question validation (#13). Additive, no migration, no feature flag; reversible by `git revert` + Vercel promote-previous.
+
+**Tech Stack:** Next.js (App Router, Turbopack 16.1.6), TypeScript, React 19, Jest + React Testing Library, Playwright (one Chromium visual check), Tailwind + scoped CSS.
+
+**Design source:** [`17c-wave-c-survey-ux-design.md`](17c-wave-c-survey-ux-design.md) — read it; this plan implements that design including every claudex finding (G1–G7 + Round 1/2/3, see its Changelog).
+
+**Branch:** `feat/wave-c-survey-ux` (already created off `main`). **Source root:** `/Users/diushianstand/Scaling-up-platform-v2/src`. **Build gate (run from the source root):** `CI=true npx next build --turbopack`.
+
+**Pre-build gate (HARD):** Do **not** start Task 1 until the user signs off on a `/frontend-design` mockup of the restyled survey (#6/#7/#8/#9/#11) — mockup-before-build, per design constraint 5 and the established Wave pattern (PRs #41/#51/#54). After the build, a final user merge-go follows the preview smoke (Task 8).
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|------|----------------|--------|
+| `src/src/lib/assessments/answer-limits.ts` | Client-safe answer-length constants (no Zod/server imports) | **Create** |
+| `src/src/lib/assessments/scoring.ts` | Re-import `MAX_TEXT_ANSWER_LENGTH` from `answer-limits` (no behavior change) | Modify |
+| `src/src/components/assessments/question-input.tsx` | Per-type control + new `invalid` prop, slider `--pct`, placeholders, maxLength + counter, MULTI_CHOICE focus id | Modify |
+| `src/src/components/assessments/section-pager.tsx` | #13 validation engine, focus-first-invalid, `requireAtLeastOneAnswer`, submit latch; remove `su-intro-num` | Modify |
+| `src/src/components/assessments/AssessmentShellHeader.tsx` | Owns the single `role="progressbar"`; caption; drop segmented strip | Modify |
+| `src/src/components/assessments/org-survey-client.tsx` | Remove `ty-header` + `ty-card`; prune-on-hydrate + pre-submit; submit-error recovery; pass `requireAtLeastOneAnswer` | Modify |
+| `src/src/components/assessments/public-quiz-client.tsx` | Remove `ty-header`; caption = `campaignName`; prune-on-hydrate + pre-submit; submit latch | Modify |
+| `src/src/lib/assessments/prune-answers.ts` | Pure helper: prune an answers map to a known stableKey set | **Create** |
+| `src/src/styles/wireframes-scoped.css` | All visual changes, scoped under `.su-assessment-brand` | Modify |
+| `src/src/__tests__/components/assessments/question-input.test.tsx` | QuestionInput tests | Modify |
+| `src/src/__tests__/assessments/section-pager.test.tsx` | SectionPager tests | Modify |
+| `src/src/__tests__/lib/assessments/prune-answers.test.ts` | prune helper tests | **Create** |
+| `src/tests-e2e/` (Playwright) | One Chromium visual check of slider states | **Create** (location per existing e2e convention) |
+
+**Shared contract introduced by this plan (used across tasks — define once, reuse):**
+- `QuestionInput` gains `invalid?: boolean`. Every question type renders a focusable element with `id={`q-${stableKey}`}` (slider/text/number already do; MULTI_CHOICE adds it to its **first** checkbox) so the pager can focus by `document.getElementById` (metacharacter-safe — claudex R2-L1).
+- `SectionPager` gains `requireAtLeastOneAnswer?: boolean`.
+- `isAnswered(value)` (existing, `@/lib/assessments/section-pages`) is the single source of "answered" — `0` and a non-empty string/array count; `undefined`/`null`/`""`/`[]` do not.
+
+---
+
+### Task 1: Client-safe answer-length constants (claudex R1-M4)
+
+**Files:**
+- Create: `src/src/lib/assessments/answer-limits.ts`
+- Modify: `src/src/lib/assessments/scoring.ts` (around line 490)
+- Test: `src/src/__tests__/lib/assessments/answer-limits.test.ts` (create)
+
+**Why:** `MAX_TEXT_ANSWER_LENGTH` lives in `scoring.ts`, which imports Zod and server scoring logic. Importing it into the client `QuestionInput` would pull that whole module into the participant bundle. Extract the constant into a tiny client-safe module both sides import.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/src/__tests__/lib/assessments/answer-limits.test.ts
+import { MAX_TEXT_ANSWER_LENGTH } from "@/lib/assessments/answer-limits";
+import { MAX_TEXT_ANSWER_LENGTH as fromScoring } from "@/lib/assessments/scoring";
+
+describe("answer-limits", () => {
+  it("exposes the 10k text limit", () => {
+    expect(MAX_TEXT_ANSWER_LENGTH).toBe(10_000);
+  });
+  it("scoring.ts re-exports the same constant (single source of truth)", () => {
+    expect(fromScoring).toBe(MAX_TEXT_ANSWER_LENGTH);
+  });
+});
+```
+
+- [ ] **Step 2: Run it, expect FAIL** — `cd src && npx jest answer-limits` → fails (module missing).
+
+- [ ] **Step 3: Create the module**
+
+```ts
+// src/src/lib/assessments/answer-limits.ts
+/**
+ * Client-safe answer-length limits. NO Zod / server imports — safe to import
+ * from participant client components without bundling the scoring module.
+ */
+/** Maximum character length accepted for a TEXT answer. */
+export const MAX_TEXT_ANSWER_LENGTH = 10_000;
+```
+
+- [ ] **Step 4: Re-point `scoring.ts`** — replace the literal `export const MAX_TEXT_ANSWER_LENGTH = 10_000;` (≈ line 490) with a re-export so all existing server importers are unchanged:
+
+```ts
+// near the top of the "Answer value validation" section of scoring.ts
+export { MAX_TEXT_ANSWER_LENGTH } from "./answer-limits";
+```
+
+Remove the old `export const MAX_TEXT_ANSWER_LENGTH = 10_000;` line. Leave its doc comment above the re-export.
+
+- [ ] **Step 5: Run it, expect PASS** — `cd src && npx jest answer-limits scoring` → both pass.
+
+- [ ] **Step 6: Build gate** — `cd src && CI=true npx next build --turbopack 2>&1 | tail -15` → clean.
+
+- [ ] **Step 7: Commit** — `git add -A && git commit -m "refactor(assessments): client-safe answer-limits module (Wave C R1-M4)"`
+
+**Closes (claudex):** R1-M4.
+
+---
+
+### Task 2: QuestionInput — invalid contract, text/number polish, char counter (#11, #12, #13/H1, R2-L1)
+
+**Files:**
+- Modify: `src/src/components/assessments/question-input.tsx`
+- Test: `src/src/__tests__/components/assessments/question-input.test.tsx`
+
+**Contract added:** `invalid?: boolean` on `QuestionInputProps`. When `invalid`, the control reflects an error state per type. Every type exposes a focusable `id={`q-${stableKey}`}`.
+
+- [ ] **Step 1: Write failing tests** (append to the existing file; reuse its fixtures `sliderQuestion`, `zeroBasedSliderQuestion`, and add a `multiChoiceQuestion`).
+
+```tsx
+const multiChoiceQuestion: QuestionForInput = {
+  stableKey: "S1_MC",
+  type: "MULTI_CHOICE",
+  label: "Pick some",
+  isRequired: true,
+  options: [
+    { key: "a", label: "Alpha" },
+    { key: "b", label: "Beta" },
+  ],
+};
+
+describe("QuestionInput invalid + a11y contract", () => {
+  it("slider: invalid sets aria-invalid on the range input", () => {
+    render(<QuestionInput question={sliderQuestion} value={undefined} onChange={jest.fn()} invalid />);
+    expect(screen.getByRole("slider")).toHaveAttribute("aria-invalid", "true");
+  });
+  it("text: invalid sets aria-invalid on the textarea + shows a placeholder", () => {
+    render(<QuestionInput question={{ ...sliderQuestion, type: "TEXT", stableKey: "T1" }} value={undefined} onChange={jest.fn()} invalid />);
+    const ta = screen.getByRole("textbox");
+    expect(ta).toHaveAttribute("aria-invalid", "true");
+    expect(ta).toHaveAttribute("placeholder");
+  });
+  it("multi-choice: invalid marks the group invalid AND the first checkbox carries the focus id", () => {
+    render(<QuestionInput question={multiChoiceQuestion} value={[]} onChange={jest.fn()} invalid />);
+    expect(screen.getByRole("group")).toHaveAttribute("aria-invalid", "true");
+    const boxes = screen.getAllByRole("checkbox");
+    expect(boxes[0]).toHaveAttribute("id", "q-S1_MC"); // pager focuses via getElementById
+  });
+  it("text: enforces the 10k maxLength", () => {
+    render(<QuestionInput question={{ ...sliderQuestion, type: "TEXT", stableKey: "T2" }} value={""} onChange={jest.fn()} />);
+    expect(screen.getByRole("textbox")).toHaveAttribute("maxLength", "10000");
+  });
+  it("text: shows the char counter only near the cap", () => {
+    const near = "x".repeat(9_500);
+    const { rerender } = render(<QuestionInput question={{ ...sliderQuestion, type: "TEXT", stableKey: "T3" }} value={"hi"} onChange={jest.fn()} />);
+    expect(screen.queryByTestId("char-counter")).toBeNull();           // far from cap → hidden
+    rerender(<QuestionInput question={{ ...sliderQuestion, type: "TEXT", stableKey: "T3" }} value={near} onChange={jest.fn()} />);
+    expect(screen.getByTestId("char-counter")).toHaveTextContent("9500 / 10000");
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL** — `cd src && npx jest question-input`.
+
+- [ ] **Step 3: Implement.** In `question-input.tsx`:
+  - Import the limit: `import { MAX_TEXT_ANSWER_LENGTH } from "@/lib/assessments/answer-limits";`
+  - Add `invalid?: boolean` to `QuestionInputProps`; destructure it.
+  - **SLIDER_LIKERT:** add `aria-invalid={invalid || undefined}` to the range input; add `className={`survey-slider${invalid ? " is-invalid" : ""}`}`; on the wrapper add `is-invalid` too: `className={`survey-slider-wrap${answered ? "" : " is-unanswered"}${invalid ? " is-invalid" : ""}`}`. Set the WebKit fill var only when answered: add `style={answered ? ({ ["--pct" as string]: `${((numVal - min) / (max - min)) * 100}%` }) : undefined}` to the input.
+  - **TEXT:** add `placeholder="Type your answer here…"`, `maxLength={MAX_TEXT_ANSWER_LENGTH}`, `aria-invalid={invalid || undefined}`, `className={`survey-textarea${invalid ? " is-invalid" : ""}`}`. Below it render the counter only near the cap:
+    ```tsx
+    {typeof value === "string" && value.length >= MAX_TEXT_ANSWER_LENGTH - 1000 ? (
+      <span className="survey-char-counter" data-testid="char-counter">
+        {value.length} / {MAX_TEXT_ANSWER_LENGTH}
+      </span>
+    ) : null}
+    ```
+  - **NUMBER:** add `placeholder="Enter a number"`, `aria-invalid={invalid || undefined}`, `className={`survey-input-number${invalid ? " is-invalid" : ""}`}`.
+  - **MULTI_CHOICE:** add `aria-invalid={invalid || undefined}` to the `role="group"` div and `className={`survey-checkbox-group${invalid ? " is-invalid" : ""}`}`; give the **first** option's `<input type="checkbox">` `id={`q-${q.stableKey}`}` (others keep no id) so the pager can focus it.
+
+- [ ] **Step 4: Run, expect PASS** — `cd src && npx jest question-input` (all existing + new tests green; the existing minimum-commit regression test #10 must still pass).
+
+- [ ] **Step 5: Build gate** — `cd src && CI=true npx next build --turbopack 2>&1 | tail -15`.
+
+- [ ] **Step 6: Commit** — `git add -A && git commit -m "feat(assessments): QuestionInput invalid contract + text border/placeholder/counter (Wave C #11/#12/#13)"`
+
+**Closes (claudex):** R1-H1 (per-type invalid/focus, multi-choice id), R1-M4 (import path), R2-L1 (focus by id, not selector).
+
+---
+
+### Task 3: SectionPager — validation engine, focus-first-invalid, min-answer gate, submit latch (#13, R1-M1, R2-M2/M3, R2-L1, R3-M2)
+
+**Files:**
+- Modify: `src/src/components/assessments/section-pager.tsx`
+- Test: `src/src/__tests__/assessments/section-pager.test.tsx`
+
+- [ ] **Step 1: Write failing tests** (append; reuse the existing `setup()` helper, extending fixtures with a second required slider and an optional question as needed).
+
+```tsx
+describe("SectionPager validation (#13)", () => {
+  it("blocking advance flags the unanswered required question (aria-invalid) and focuses it", () => {
+    const { getByRole } = setup(); // S1 has one required slider q1, unanswered
+    fireEvent.click(getByRole("button", { name: "Begin section →" }));
+    fireEvent.click(getByRole("button", { name: "Submit" })); // last section → submit gate
+    const slider = getByRole("slider");
+    expect(slider).toHaveAttribute("aria-invalid", "true");
+    expect(slider).toHaveFocus();
+  });
+  it("answering a flagged question clears ONLY its invalid state", () => {
+    const { getByRole } = setup();
+    fireEvent.click(getByRole("button", { name: "Begin section →" }));
+    fireEvent.click(getByRole("button", { name: "Submit" }));
+    fireEvent.click(getByRole("slider")); // commit a value
+    expect(getByRole("slider")).not.toHaveAttribute("aria-invalid");
+  });
+  it("does NOT prune invalid on a whitespace-only text change (R1-M1)", () => {
+    // a required TEXT question, flagged, then changed to "   " stays invalid
+    // (build a pages fixture with one required TEXT question)
+  });
+  it("requireAtLeastOneAnswer: an all-optional zero-answer submit shows a non-field alert + does not mark optional invalid (R2-M2)", () => {
+    // pages with only OPTIONAL questions, requireAtLeastOneAnswer
+    // assert: role="alert" present, no control has aria-invalid, onSubmit NOT called
+  });
+  it("renders exactly one role=progressbar and no segmented strip (R1-M3/G3)", () => {
+    const { container } = setup();
+    expect(screen.getAllByRole("progressbar")).toHaveLength(1);
+    expect(container.querySelector(".su-shell-seg")).toBeNull();
+  });
+  it("double-clicking Submit issues onSubmit at most once (R2-M3 latch)", () => {
+    // answer the required question, then fire two clicks synchronously
+    // assert onSubmit called exactly once
+  });
+});
+```
+
+Flesh out the three commented tests with concrete fixtures (a required TEXT question; an all-optional pages set; a single-required-then-submit set) following the existing `setup()` pattern. Do not leave them empty.
+
+- [ ] **Step 2: Run, expect FAIL** — `cd src && npx jest section-pager`.
+
+- [ ] **Step 3: Implement.** In `section-pager.tsx`:
+  - Add prop `requireAtLeastOneAnswer?: boolean`.
+  - State: `const [invalidKeys, setInvalidKeys] = React.useState<Set<string>>(new Set());` and a `const submitLatch = React.useRef(false);`.
+  - Reset `invalidKeys` to empty in `goToSection`.
+  - **`handleNext`:**
+    ```ts
+    function handleNext() {
+      const unanswered = page.questions.filter((q) => q.isRequired && !isAnswered(answers[q.stableKey]));
+      if (unanswered.length > 0) {
+        setInvalidKeys(new Set(unanswered.map((q) => q.stableKey)));
+        setShowGateError(true);
+        focusFirstInvalid(unanswered[0].stableKey);
+        return;
+      }
+      if (isLast) { attemptSubmit(); return; }
+      advance();
+    }
+    ```
+  - **`attemptSubmit`** (new) — handles the min-answer gate + the synchronous latch:
+    ```ts
+    function attemptSubmit() {
+      const totalAnswered = pages.flatMap((p) => p.questions).filter((q) => isAnswered(answers[q.stableKey])).length;
+      if (requireAtLeastOneAnswer && totalAnswered === 0) {
+        setShowGateError(true);            // non-field alert; do NOT mark optional questions invalid
+        focusFirstAnswerable();
+        return;
+      }
+      if (submitLatch.current || submitting) return;  // synchronous double-click guard (R2-M3)
+      submitLatch.current = true;
+      onSubmit();
+    }
+    ```
+    Reset the latch when a submit finishes: `React.useEffect(() => { if (!submitting) submitLatch.current = false; }, [submitting]);`
+  - **`handleAnswerChange`** — prune only when truly answered (R1-M1):
+    ```ts
+    function handleAnswerChange(stableKey: string, value: number | string | string[]) {
+      onAnswerChange(stableKey, value);
+      setInvalidKeys((prev) => {
+        if (!prev.has(stableKey) || !isAnswered(value)) return prev; // whitespace/empty STAYS invalid
+        const next = new Set(prev); next.delete(stableKey);
+        if (next.size === 0) setShowGateError(false);
+        return next;
+      });
+    }
+    ```
+  - **Focus helpers** (R2-L1 — `getElementById`, never `querySelector('#q-'+key)`):
+    ```ts
+    function focusFirstInvalid(stableKey: string) {
+      requestAnimationFrame(() => document.getElementById(`q-${stableKey}`)?.focus());
+    }
+    function focusFirstAnswerable() {
+      const first = page.questions[0];
+      if (first) requestAnimationFrame(() => document.getElementById(`q-${first.stableKey}`)?.focus());
+    }
+    ```
+  - **Render:** pass `invalid={invalidKeys.has(q.stableKey)}` into `<QuestionInput …>`. Keep the bottom `role="alert"` `survey-error`; when the alert is the min-answer one, use copy "Please answer at least one question before submitting." vs the required-miss copy "Please answer all required questions before continuing." Track which via a small `gateMessage` state set alongside `showGateError`.
+  - **Remove the segmented strip dependency:** see Task 4 — the pager already renders `AssessmentShellHeader`; after Task 4 the strip is gone and the progressbar moves into the header, so **delete the standalone `survey-progress` block from the pager** (it now lives in the header). Confirm exactly one progressbar remains.
+  - **#7:** delete the `su-intro-num` `<span>` (the `String(sectionIndex + 1).padStart(2, "0")`) from the intro slide JSX.
+
+- [ ] **Step 4: Run, expect PASS** — `cd src && npx jest section-pager`.
+
+- [ ] **Step 5: Build gate** — `cd src && CI=true npx next build --turbopack 2>&1 | tail -15`.
+
+- [ ] **Step 6: Commit** — `git add -A && git commit -m "feat(assessments): SectionPager #13 validation + min-answer gate + submit latch (Wave C)"`
+
+**Closes (claudex):** R1-M1, R1-M3 (one progressbar — completed with Task 4), R2-M2, R2-M3, R2-L1; design #13, #7.
+
+---
+
+### Task 4: AssessmentShellHeader — own the single progress bar, caption = campaign name, drop the strip (#6/#10, G1/G3, R1-M3)
+
+**Files:**
+- Modify: `src/src/components/assessments/AssessmentShellHeader.tsx`
+- Test: `src/src/__tests__/components/assessments/assessment-shell-header.test.tsx` (create)
+
+**Contract change:** the header now owns the authoritative `role="progressbar"`. Add props `answeredCount: number` and `totalQuestions: number`; render logo → caption (`assessmentName`) → "Section N of M" → the linear progressbar. **Remove** the `su-shell-seg` segmented strip and the `FOUR_DECISIONS` cycling.
+
+- [ ] **Step 1: Write failing tests**
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { AssessmentShellHeader } from "@/components/assessments/AssessmentShellHeader";
+
+it("renders the caption + Section N of M", () => {
+  render(<AssessmentShellHeader currentSection={2} totalSections={4} assessmentName="Q3 Rockefeller" answeredCount={3} totalQuestions={10} />);
+  expect(screen.getByText("Q3 Rockefeller")).toBeInTheDocument();
+  expect(screen.getByText(/Section 2 of 4/)).toBeInTheDocument();
+});
+it("owns exactly one progressbar reflecting answered/total", () => {
+  render(<AssessmentShellHeader currentSection={1} totalSections={2} assessmentName="X" answeredCount={3} totalQuestions={10} />);
+  const bar = screen.getByRole("progressbar");
+  expect(bar).toHaveAttribute("aria-valuenow", "3");
+  expect(bar).toHaveAttribute("aria-valuemax", "10");
+});
+it("no longer renders the segmented strip", () => {
+  const { container } = render(<AssessmentShellHeader currentSection={1} totalSections={2} assessmentName="X" answeredCount={0} totalQuestions={4} />);
+  expect(container.querySelector(".su-shell-seg")).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL** — `cd src && npx jest assessment-shell-header`.
+
+- [ ] **Step 3: Implement.** Add `answeredCount` + `totalQuestions` to `AssessmentShellHeaderProps`; delete the `su-shell-seg` block + `FOUR_DECISIONS`; render the progressbar inside the `<header className="su-shell-header">`:
+
+```tsx
+<div
+  role="progressbar"
+  aria-label="Progress"
+  aria-valuemin={0}
+  aria-valuemax={totalQuestions}
+  aria-valuenow={answeredCount}
+  className="survey-progress su-shell-progress"
+>
+  <div className="survey-progress-fill" style={{ width: totalQuestions ? `${(answeredCount / totalQuestions) * 100}%` : "0%" }} />
+</div>
+```
+
+- [ ] **Step 4: Wire the pager** — in `section-pager.tsx`, pass `answeredCount={answeredCount}` and `totalQuestions={total}` to `<AssessmentShellHeader>`, and **delete the pager's own `survey-progress` `<div role="progressbar">`** (now duplicated). Re-run Task 3's "exactly one progressbar" test → green.
+
+- [ ] **Step 5: Run, expect PASS** — `cd src && npx jest assessment-shell-header section-pager`.
+
+- [ ] **Step 6: Build gate** — `cd src && CI=true npx next build --turbopack 2>&1 | tail -15`.
+
+- [ ] **Step 7: Commit** — `git add -A && git commit -m "feat(assessments): unify progress bar into the purple shell header, drop segmented strip (Wave C #6/G3/R1-M3)"`
+
+**Closes (claudex):** R1-M3, G3; design #6/#10 (header ownership).
+
+---
+
+### Task 5: Clients — remove white chrome, prune answers, submit-error recovery (#6/#10/G1, R2-M1, R3-M2, R2-M3)
+
+**Files:**
+- Create: `src/src/lib/assessments/prune-answers.ts` + test `src/src/__tests__/lib/assessments/prune-answers.test.ts`
+- Modify: `src/src/components/assessments/org-survey-client.tsx`, `src/src/components/assessments/public-quiz-client.tsx`
+
+- [ ] **Step 1: Write the prune-helper test**
+
+```ts
+// prune-answers.test.ts
+import { pruneAnswersToQuestions } from "@/lib/assessments/prune-answers";
+it("drops answers whose stableKey is not in the known set", () => {
+  const known = new Set(["a", "b"]);
+  expect(pruneAnswersToQuestions({ a: 1, b: "x", stale: 9 }, known)).toEqual({ a: 1, b: "x" });
+});
+it("returns the same object reference when nothing is pruned (no needless rerender)", () => {
+  const known = new Set(["a"]);
+  const input = { a: 1 };
+  expect(pruneAnswersToQuestions(input, known)).toBe(input);
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL** → **Step 3: Implement**
+
+```ts
+// src/src/lib/assessments/prune-answers.ts
+type AnswersMap = Record<string, number | string | string[]>;
+/** Drop any answer whose stableKey isn't a currently-rendered question (R3-M2). */
+export function pruneAnswersToQuestions(answers: AnswersMap, knownStableKeys: Set<string>): AnswersMap {
+  const keys = Object.keys(answers);
+  if (keys.every((k) => knownStableKeys.has(k))) return answers; // unchanged → same ref
+  const next: AnswersMap = {};
+  for (const k of keys) if (knownStableKeys.has(k)) next[k] = answers[k];
+  return next;
+}
+```
+
+- [ ] **Step 4: Run, expect PASS** — `cd src && npx jest prune-answers`.
+
+- [ ] **Step 5: org-survey-client.tsx** — in the `ready` render:
+  - **Delete** the `<header className="ty-header">…</header>` and the `<section className="ty-card">…survey-title…</section>` blocks (leave the loading/error/welcome/thank-you phases untouched).
+  - Pass `requireAtLeastOneAnswer` to `<SectionPager …>` (the submit API rejects empty answers; invited can be all-optional too — R2-M2).
+  - After draft hydrate and again right before `handleSubmit` POSTs, prune: build `const knownKeys = new Set(sortedQuestions.map(q => q.stableKey));` and `setAnswers(prev => pruneAnswersToQuestions(prev, knownKeys));` (and write the pruned map back to the draft). Pre-submit, POST the pruned map.
+  - **Submit-error recovery (R2-M1):** read `app/api/assessment-campaigns/.../submit` (or the org-survey submit route) error shape. If the server returns per-field codes (`UNKNOWN_STABLE_KEY` / `INVALID_TYPE` / `ANSWER_TOO_LONG`) with a `stableKey`, map them into an `invalidKeys` set handed to `SectionPager` and **keep the user on the pager** (do not transition to a terminal error phase); otherwise show a non-field inline alert on the pager. (If the route does not currently return per-field detail, the fallback non-field alert is the behavior; note that in the PR.)
+- [ ] **Step 6: public-quiz-client.tsx** — in the `form` step:
+  - **Delete** the `<header className="ty-header">…</header>` block (there is no `ty-card` title in the form step).
+  - Change the pager prop from `assessmentName={templateName}` to `assessmentName={campaignName}` (G1).
+  - Pass `requireAtLeastOneAnswer` to `<SectionPager …>`.
+  - Hydrate-prune + pre-submit-prune with `pruneAnswersToQuestions` exactly as invited; keep `idemRef` idempotency. The existing `if (submitting || !canSubmit) return;` plus the pager's synchronous latch (Task 3) cover double-click.
+
+- [ ] **Step 7: Update client tests** — in whatever client RTL tests exist, update/replace any assertion that keys on `ty-header`/`ty-card` in the **ready/form** phase (they should now be absent there); assert the pager renders and `screen.queryByText("Scaling Up")` is no longer the white-bar brand in the form phase. Add a test that a stale answer key is pruned before submit (mock fetch, assert the POSTed body omits the stale key).
+
+- [ ] **Step 8: Run + build** — `cd src && npx jest org-survey public-quiz prune-answers && CI=true npx next build --turbopack 2>&1 | tail -15`.
+
+- [ ] **Step 9: Commit** — `git add -A && git commit -m "feat(assessments): unify participant header, prune stale answers, submit-error recovery (Wave C #6/G1/R2-M1/R3-M2)"`
+
+**Closes (claudex):** R2-M1 (partial — recovery), R3-M2 (prune), G1; design #6/#10.
+
+---
+
+### Task 6: Scoped CSS — purple card, slider visual-unset + focus ring + bigger handle, red invalid, text inputs, remove "01" (#6/#7/#8/#9/#11/#12, G2/G6, R1-M2)
+
+**Files:**
+- Modify: `src/src/styles/wireframes-scoped.css` (the `.su-assessment-brand` block)
+
+**Rule (R1-M2):** every new selector is prefixed `.su-assessment-brand …`. Do **not** edit base `.wf-scope` rules (only remove a `.wf-scope` rule if proven unused). After this task, run the scope-guard grep in Step 8.
+
+- [ ] **Step 1: Slider visual-unset (#8) + focus ring (G2).** Under `.su-assessment-brand`:
+  ```css
+  /* Hidden thumb + empty rail until answered (#8) */
+  .su-assessment-brand .survey-slider-wrap.is-unanswered .survey-slider::-webkit-slider-thumb { opacity: 0; box-shadow: none; }
+  .su-assessment-brand .survey-slider-wrap.is-unanswered .survey-slider::-moz-range-thumb     { opacity: 0; box-shadow: none; border-color: transparent; }
+  .su-assessment-brand .survey-slider-wrap.is-unanswered .survey-slider::-webkit-slider-runnable-track { background: #e4e4e4; } /* flat empty rail (no purple fill) */
+  /* Answered fill follows --pct on WebKit */
+  .su-assessment-brand .survey-slider-wrap:not(.is-unanswered) .survey-slider::-webkit-slider-runnable-track {
+    background: linear-gradient(to right, #522583 0%, #522583 var(--pct, 0%), #e4e4e4 var(--pct, 0%), #e4e4e4 100%);
+  }
+  /* Track-level focus ring so a thumbless slider is still visibly focusable (G2) */
+  .su-assessment-brand .survey-slider-wrap.is-unanswered .survey-slider:focus-visible { outline: 2px solid #522583; outline-offset: 4px; border-radius: 6px; }
+  ```
+- [ ] **Step 2: Bigger handle (#9).** Bump both thumbs 22px → 30px, recenter on the 6px track, scale the focus ring:
+  ```css
+  .su-assessment-brand .survey-slider::-webkit-slider-thumb { width: 30px; height: 30px; margin-top: -12px; }
+  .su-assessment-brand .survey-slider::-moz-range-thumb     { width: 30px; height: 30px; }
+  ```
+- [ ] **Step 3: Focus-independent red invalid rail + card (#13/G6).**
+  ```css
+  .su-assessment-brand .survey-question.is-invalid,                       /* card border */
+  .su-assessment-brand .survey-question:has(.is-invalid) { border-color: hsl(var(--destructive)); }
+  .su-assessment-brand .survey-slider.is-invalid::-webkit-slider-runnable-track { background: hsl(var(--destructive) / 0.25); }
+  .su-assessment-brand .survey-slider.is-invalid::-moz-range-track { background: hsl(var(--destructive) / 0.25); }
+  .su-assessment-brand .survey-textarea.is-invalid,
+  .su-assessment-brand .survey-input-number.is-invalid,
+  .su-assessment-brand .survey-checkbox-group.is-invalid { border-color: hsl(var(--destructive)); }
+  ```
+  The red rail must NOT depend on `:focus`/`:focus-visible` (G6). Add a red invalid treatment to the `survey-question-label` of an invalid question if the card-level `:has()` is insufficient for the target browsers — verify in Task 7.
+- [ ] **Step 4: Text inputs border + placeholder visibility + counter (#11/#12).**
+  ```css
+  .su-assessment-brand .survey-textarea,
+  .su-assessment-brand .survey-input-number { border: 1px solid #cbb8e6; border-radius: 10px; padding: 0.65rem 0.8rem; }
+  .su-assessment-brand .survey-textarea:focus-visible,
+  .su-assessment-brand .survey-input-number:focus-visible { outline: 2px solid #522583; outline-offset: 1px; }
+  .su-assessment-brand .survey-char-counter { display: block; margin-top: 0.3rem; font-size: 0.75rem; color: #6b6480; text-align: right; }
+  ```
+- [ ] **Step 5: Purple card header + linear bar inside it (#6).** Style `.su-shell-header` to read as the single card and `.su-shell-progress` (the relocated bar) to sit inside it with a translucent-white track on purple:
+  ```css
+  .su-assessment-brand .su-shell-progress { width: 100%; height: 6px; border-radius: 9999px; background: rgba(255,255,255,0.25); margin-top: 0.6rem; overflow: hidden; }
+  .su-assessment-brand .su-shell-progress .survey-progress-fill { height: 100%; background: #fff; border-radius: 9999px; }
+  ```
+  Confirm the deleted pager `survey-progress` block leaves no orphan margin.
+- [ ] **Step 6: Remove "01" styling (#7).** Delete the `.su-assessment-brand .su-intro-num { … }` rule(s) and reflow `.su-intro-kicker` so removing the number doesn't leave a gap (e.g. drop the grid/flex column that held it).
+- [ ] **Step 7: Build gate** — `cd src && CI=true npx next build --turbopack 2>&1 | tail -15`.
+- [ ] **Step 8: Scope guard** — `cd src/src && grep -nE "^\s*\.(survey-|su-shell|su-intro)" styles/wireframes-scoped.css | grep -v "su-assessment-brand\|wf-scope"` → **must return nothing** (every survey rule is scoped). Eyeball that no base `.wf-scope` survey rule was edited (only additions under `.su-assessment-brand`).
+- [ ] **Step 9: Commit** — `git add -A && git commit -m "style(assessments): purple card, slider unset+focus+handle, red invalid, text inputs, drop 01 (Wave C, scoped)"`
+
+**Closes (claudex):** R1-M2 (scope guard), G2, G6; design #6/#7/#8/#9/#11/#12.
+
+---
+
+### Task 7: Browser-level visual check + #14 verification (R1-M5, L1)
+
+**Files:**
+- Create: a Playwright spec under the repo's existing e2e dir (e.g. `src/tests-e2e/wave-c-slider.spec.ts` — match the existing `test:e2e` config).
+
+- [ ] **Step 1: Playwright (Chromium) slider-state check (R1-M5).** Drive a survey page (use a seeded test campaign or the public quiz alias on a local/preview server) and assert visually/by-DOM across the four states: **unanswered** (thumb hidden — computed `opacity` of the thumb pseudo isn't directly queryable, so assert the wrapper has `is-unanswered` and take a screenshot), **focused-unanswered** (focus ring visible — screenshot), **invalid** (the rail/card carries `is-invalid` without focus — assert class + screenshot), **answered** (thumb visible, fill follows value). Save screenshots to the PR.
+- [ ] **Step 2: Manual cross-browser pass.** On the Vercel preview, manually verify the four slider states + red validation + unified header in **Safari and Firefox** (pseudo-element + `:focus-visible` behavior is engine-specific). Record pass/fail in the PR description.
+- [ ] **Step 3: #14 verification (L1).** On the preview, open a survey whose template has a **section with a non-empty seeded `description`** — use the **Five Dysfunctions** template (or Rockefeller). Confirm the section-intro slide renders that description text. Capture a screenshot for the PR. If the target section's `description` is empty in the live seed, **report that gap** (the actionable finding) rather than marking #14 done.
+- [ ] **Step 4: Commit** — `git add -A && git commit -m "test(assessments): Playwright slider-state check + Wave C verification notes"`
+
+**Closes (claudex):** R1-M5, design #14 (verify-only), L1.
+
+---
+
+### Task 8: Final review, runbook, SoT (R3-H1 rollout safety, R3-M1 telemetry note)
+
+**Files:**
+- Create/append: `docs/specs/v7.6/17c-ops-notes.md` (rollout + deferred follow-ups)
+- Modify: `CLAUDE.md` (LAST_UPDATED anchor), `plans/CHANGELOG.md` (new entry) — **on merge only**
+
+- [ ] **Step 1: Whole-branch review.** Dispatch the superpowers:code-reviewer against `git diff main...feat/wave-c-survey-ux`. Fix Critical/Important before merge.
+- [ ] **Step 2: Rollout runbook (R3-H1).** Write `17c-ops-notes.md`: the rollback is **Vercel promote-previous-deployment** (no flag); the go/no-go is the post-merge both-flow smoke (invited test campaign + public quiz alias each submit successfully); preview-canary checklist; and the **deferred follow-ups** explicitly listed — hydrate-time deep value validation, autosave TTL/clear-on-terminal-state (pre-existing PR-#32 privacy), full client telemetry (R3-M1, premature at near-zero volume; server `/submit` logs + outbox are the interim signal).
+- [ ] **Step 3: Full suite** — `cd src && CI=true npx next build --turbopack && npx jest 2>&1 | tail -20`. Record pass count + confirm no NEW failures vs `main` (known pre-existing failures are documented in CLAUDE.md/the punch-list anchor).
+- [ ] **Step 4: GATE — final user merge-go.** The `/frontend-design` mockup was already approved before Task 1 (pre-build gate). Here, surface the preview-smoke results and get the user's go to merge (ship-don't-iterate: judged on "is it built + does it work on preview", not a second design review).
+- [ ] **Step 5: On go — SoT flush + merge.** Update `CLAUDE.md` LAST_UPDATED anchor (`wave-c-survey-ux`), prepend the `plans/CHANGELOG.md` entry, open the PR, merge, deploy, post-merge smoke both flows, Notion task → Done.
+
+**Closes (claudex):** R3-H1 (rollout safety), R3-M1 (telemetry deferral documented).
+
+---
+
+## Self-Review
+
+**Spec coverage (design #6–#14 + claudex):**
+- #6 unified purple card → Tasks 4 + 5 (+ CSS 6). #7 remove "01" → Task 3 (JSX) + Task 6 (CSS). #8 slider unset → Task 2 (`--pct`/state) + Task 6 (CSS). #9 handle → Task 6. #10 title only first → Tasks 4/5 (header owns caption; ty-card deleted). #11 text border/placeholder → Tasks 2 + 6. #12 char limit → Tasks 1 + 2. #13 red validation → Tasks 2 + 3 (+ CSS 6). #14 verify → Task 7. ✔ all covered.
+- claudex: R1-H1→T2/T3; R1-M1→T3; R1-M2→T6; R1-M3→T4; R1-M4→T1; R1-M5→T7; R1-M6/R2-M2→T3/T5; R2-M1→T5; R2-M3→T3; R2-L1→T2/T3; R3-H1→T8; R3-M1→T8; R3-M2→T5; G1→T5; G2→T6; G3→T4; G6→T6; G7→honored by the #6 deviation (design-documented). Deferred (T8 notes): hydrate deep-validation, autosave TTL, full telemetry. ✔
+**Placeholder scan:** the three commented SectionPager tests in Task 3 Step 1 are explicitly required to be fleshed out in the same step (fixtures described) — not left as TODOs. No "add error handling"-style vagueness.
+**Type consistency:** `invalid?: boolean` (T2) is consumed by T3; `requireAtLeastOneAnswer?: boolean` (T3) is passed by T5; `answeredCount`/`totalQuestions` (T4) are passed by T3; `pruneAnswersToQuestions` (T5) signature matches its test; `id={`q-${stableKey}`}` focus contract is consistent across T2 (render) and T3 (`getElementById`). ✔

--- a/src/e2e/wave-c-slider.spec.ts
+++ b/src/e2e/wave-c-slider.spec.ts
@@ -1,0 +1,424 @@
+/**
+ * wave-c-slider.spec.ts
+ *
+ * Playwright / Chromium visual-state test for the Wave C survey slider.
+ *
+ * Why this test exists (claudex R1-M5):
+ *   CSS pseudo-elements (::-webkit-slider-thumb, :focus-visible, custom props)
+ *   are invisible to jsdom/RTL. Only a real browser engine can prove these rules
+ *   render correctly. This spec is self-contained — it injects the REAL committed
+ *   CSS + a minimal DOM via page.setContent(), so no app server, no DB, no auth.
+ *
+ * Focus mechanism:
+ *   We use `locator.focus()` followed by `page.keyboard.press('Tab')` then
+ *   `page.keyboard.press('Shift+Tab')` to return focus, triggering :focus-visible
+ *   in Chromium. Chromium recognises programmatic `.focus()` as keyboard-intent
+ *   when there is a prior keyboard event in the page. We prime it with a Space
+ *   keypress on the body first. If the outline is still "none" we fall back to
+ *   asserting the :focus outline on the slider element itself (which the CSS
+ *   places on .survey-slider-wrap.is-unanswered .survey-slider:focus-visible).
+ */
+
+import { test, expect } from "@playwright/test";
+import * as fs from "fs";
+import * as path from "path";
+
+// ---------------------------------------------------------------------------
+// Resolve paths (spec lives at src/e2e/; CSS lives at src/src/styles/)
+// ---------------------------------------------------------------------------
+const CSS_PATH = path.join(__dirname, "../src/styles/wireframes-scoped.css");
+
+function buildHtml(): string {
+  const realCss = fs.readFileSync(CSS_PATH, "utf8");
+
+  // Minimal :root tokens so hsl(var(--destructive)) etc resolve in the injected page.
+  // These are the real light-theme values from src/src/app/globals.css — used here as
+  // stand-ins so the computed colour assertions work without importing the full app CSS.
+  const tokenRoot = `
+    :root {
+      --background: 210 40% 98%;
+      --foreground: 222.2 84% 4.9%;
+      --card: 0 0% 100%;
+      --card-foreground: 222.2 84% 4.9%;
+      --primary: 224 76% 48%;
+      --primary-foreground: 210 40% 98%;
+      --secondary: 210 40% 96.1%;
+      --secondary-foreground: 222.2 47.4% 11.2%;
+      --muted: 210 40% 96.1%;
+      --muted-foreground: 215.4 16.3% 46.9%;
+      --accent: 210 40% 96.1%;
+      --accent-foreground: 222.2 47.4% 11.2%;
+      --destructive: 0 84.2% 60.2%;
+      --destructive-foreground: 210 40% 98%;
+      --border: 214.3 31.8% 91.4%;
+      --input: 214.3 31.8% 91.4%;
+      --ring: 224 76% 48%;
+      --radius: 0.5rem;
+      --shadow-xs: 0 1px 2px 0 rgb(0 0 0 / 0.03);
+      --shadow-sm: 0 1px 3px 0 rgb(0 0 0 / 0.06), 0 1px 2px -1px rgb(0 0 0 / 0.06);
+    }
+  `;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    ${tokenRoot}
+    body { margin: 2rem; background: #f8f8fc; }
+    ${realCss}
+  </style>
+</head>
+<body>
+<div class="su-assessment-brand" id="brand-root">
+  <ul class="survey-question-list">
+
+    <!-- ── Card 1: UNANSWERED ──────────────────────────────────────────── -->
+    <li class="survey-question" id="card-unanswered">
+      <label class="survey-question-label" for="slider-unanswered">
+        Q1 – How confident are you? (unanswered)
+      </label>
+      <div class="survey-slider-wrap is-unanswered" id="wrap-unanswered">
+        <input
+          id="slider-unanswered"
+          type="range"
+          class="survey-slider"
+          min="0" max="10" step="1"
+          value="0"
+          aria-valuemin="0" aria-valuemax="10"
+          aria-valuetext="Not yet answered"
+        />
+        <div class="survey-slider-ticks" aria-hidden="true">
+          <span class="survey-slider-tick">0</span>
+          <span class="survey-slider-tick">1</span>
+          <span class="survey-slider-tick">2</span>
+          <span class="survey-slider-tick">3</span>
+          <span class="survey-slider-tick">4</span>
+          <span class="survey-slider-tick">5</span>
+          <span class="survey-slider-tick">6</span>
+          <span class="survey-slider-tick">7</span>
+          <span class="survey-slider-tick">8</span>
+          <span class="survey-slider-tick">9</span>
+          <span class="survey-slider-tick">10</span>
+        </div>
+        <div class="survey-slider-anchors">
+          <span>Not at all</span>
+          <span>Completely</span>
+        </div>
+        <p class="survey-slider-status">Tap or drag the slider to rate.</p>
+      </div>
+    </li>
+
+    <!-- ── Card 2: ANSWERED (mid-scale, --pct:60%) ────────────────────── -->
+    <li class="survey-question" id="card-answered">
+      <label class="survey-question-label" for="slider-answered">
+        Q2 – How satisfied are you? (answered: 6)
+      </label>
+      <div class="survey-slider-wrap" id="wrap-answered">
+        <input
+          id="slider-answered"
+          type="range"
+          class="survey-slider"
+          min="0" max="10" step="1"
+          value="6"
+          aria-valuemin="0" aria-valuemax="10"
+          aria-valuenow="6"
+          aria-valuetext="6"
+          style="--pct: 60%"
+        />
+        <div class="survey-slider-ticks" aria-hidden="true">
+          <span class="survey-slider-tick">0</span>
+          <span class="survey-slider-tick">1</span>
+          <span class="survey-slider-tick">2</span>
+          <span class="survey-slider-tick">3</span>
+          <span class="survey-slider-tick">4</span>
+          <span class="survey-slider-tick">5</span>
+          <span class="survey-slider-tick is-current">6</span>
+          <span class="survey-slider-tick">7</span>
+          <span class="survey-slider-tick">8</span>
+          <span class="survey-slider-tick">9</span>
+          <span class="survey-slider-tick">10</span>
+        </div>
+        <div class="survey-slider-anchors">
+          <span>Not at all</span>
+          <span>Completely</span>
+        </div>
+        <p class="survey-slider-status">Your rating: 6</p>
+      </div>
+    </li>
+
+    <!-- ── Card 3: INVALID (unanswered + required error) ─────────────── -->
+    <li class="survey-question" id="card-invalid">
+      <label class="survey-question-label" for="slider-invalid">
+        Q3 – Required question (invalid)
+      </label>
+      <div class="survey-slider-wrap is-unanswered is-invalid" id="wrap-invalid">
+        <input
+          id="slider-invalid"
+          type="range"
+          class="survey-slider is-invalid"
+          min="0" max="10" step="1"
+          value="0"
+          aria-valuemin="0" aria-valuemax="10"
+          aria-valuetext="Not yet answered"
+          aria-invalid="true"
+        />
+        <div class="survey-slider-ticks" aria-hidden="true">
+          <span class="survey-slider-tick">0</span>
+          <span class="survey-slider-tick">1</span>
+          <span class="survey-slider-tick">2</span>
+          <span class="survey-slider-tick">3</span>
+          <span class="survey-slider-tick">4</span>
+          <span class="survey-slider-tick">5</span>
+          <span class="survey-slider-tick">6</span>
+          <span class="survey-slider-tick">7</span>
+          <span class="survey-slider-tick">8</span>
+          <span class="survey-slider-tick">9</span>
+          <span class="survey-slider-tick">10</span>
+        </div>
+        <div class="survey-slider-anchors">
+          <span>Not at all</span>
+          <span>Completely</span>
+        </div>
+        <p class="survey-slider-status">Tap or drag the slider to rate.</p>
+      </div>
+    </li>
+
+    <!-- ── Card 4: FOCUSED-UNANSWERED (same markup as unanswered; focus applied in test) -->
+    <li class="survey-question" id="card-focus">
+      <label class="survey-question-label" for="slider-focus">
+        Q4 – Focus-ring test (unanswered, will be focused)
+      </label>
+      <div class="survey-slider-wrap is-unanswered" id="wrap-focus">
+        <input
+          id="slider-focus"
+          type="range"
+          class="survey-slider"
+          min="0" max="10" step="1"
+          value="0"
+          aria-valuemin="0" aria-valuemax="10"
+          aria-valuetext="Not yet answered"
+        />
+        <div class="survey-slider-ticks" aria-hidden="true">
+          <span class="survey-slider-tick">0</span>
+          <span class="survey-slider-tick">5</span>
+          <span class="survey-slider-tick">10</span>
+        </div>
+        <div class="survey-slider-anchors">
+          <span>Not at all</span>
+          <span>Completely</span>
+        </div>
+        <p class="survey-slider-status">Tap or drag the slider to rate.</p>
+      </div>
+    </li>
+
+  </ul>
+</div>
+</body>
+</html>`;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe("Wave C — Slider CSS visual states (Chromium only)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setContent(buildHtml(), { waitUntil: "domcontentloaded" });
+  });
+
+  // ── 1. Unanswered thumb is invisible ──────────────────────────────────────
+  //
+  // NOTE on Chromium limitation:
+  //   `getComputedStyle(el, '::-webkit-slider-thumb')` does NOT return actual
+  //   pseudo-element styles in Chromium via Playwright (it reflects the host
+  //   element's own computed values instead). This is a known, unresolved
+  //   W3C/Chromium gap — pseudo-element CSSOM is not yet specified.
+  //
+  // Approach: inspect the loaded stylesheet rules directly. The CSS rule
+  //   `.su-assessment-brand .survey-slider-wrap.is-unanswered .survey-slider::-webkit-slider-thumb { opacity: 0 }`
+  //   must be present in document.styleSheets. We walk all CSSStyleRules to
+  //   find it. This proves the authored rule is in the live document — the
+  //   screenshot in test 6 provides the visual proof layer.
+  test("unanswered thumb opacity is 0 — CSS rule present in live document", async ({ page }) => {
+    const ruleFound = await page.evaluate(() => {
+      // Walk all loaded stylesheets and their rules
+      for (const sheet of Array.from(document.styleSheets)) {
+        let rules: CSSRuleList | null = null;
+        try {
+          rules = sheet.cssRules;
+        } catch {
+          continue; // cross-origin sheet (e.g. Google Fonts import)
+        }
+        if (!rules) continue;
+        for (const rule of Array.from(rules)) {
+          if (rule instanceof CSSStyleRule) {
+            const sel = rule.selectorText ?? "";
+            // Match the exact rule that hides the unanswered thumb
+            if (
+              sel.includes("is-unanswered") &&
+              sel.includes("::-webkit-slider-thumb")
+            ) {
+              const opacity = rule.style.getPropertyValue("opacity").trim();
+              if (opacity === "0") return true;
+            }
+          }
+        }
+      }
+      return false;
+    });
+    expect(ruleFound).toBe(true);
+  });
+
+  // ── 2. Answered thumb is visible — CSS rule check ─────────────────────────
+  //
+  // Same approach: verify that the BASE thumb rule (for answered state, where
+  // no .is-unanswered override applies) sets width:30px, opacity is NOT 0.
+  // The base rule `.su-assessment-brand .survey-slider::-webkit-slider-thumb`
+  // defines width:30px — absence of an opacity:0 override means it inherits 1.
+  test("answered thumb is visible — no opacity:0 rule targets non-unanswered slider", async ({ page }) => {
+    // Verify NO rule sets opacity:0 for the answered slider
+    const hasHidingRule = await page.evaluate(() => {
+      for (const sheet of Array.from(document.styleSheets)) {
+        let rules: CSSRuleList | null = null;
+        try { rules = sheet.cssRules; } catch { continue; }
+        if (!rules) continue;
+        for (const rule of Array.from(rules)) {
+          if (rule instanceof CSSStyleRule) {
+            const sel = rule.selectorText ?? "";
+            // A rule hiding the thumb MUST include .is-unanswered;
+            // if it targets ::-webkit-slider-thumb WITHOUT .is-unanswered, check opacity
+            if (
+              sel.includes("::-webkit-slider-thumb") &&
+              !sel.includes("is-unanswered")
+            ) {
+              const opacity = rule.style.getPropertyValue("opacity").trim();
+              if (opacity === "0") return true; // this would be a bug
+            }
+          }
+        }
+      }
+      return false;
+    });
+    // No rule should hide the answered thumb
+    expect(hasHidingRule).toBe(false);
+  });
+
+  // ── 3. Answered thumb width is 30px — CSS rule check ─────────────────────
+  //
+  // Same limitation as above. Verify via styleSheets walk that the base
+  // ::-webkit-slider-thumb rule sets width: 30px.
+  test("answered thumb width is 30px — CSS rule present in live document", async ({ page }) => {
+    const widthFound = await page.evaluate(() => {
+      for (const sheet of Array.from(document.styleSheets)) {
+        let rules: CSSRuleList | null = null;
+        try { rules = sheet.cssRules; } catch { continue; }
+        if (!rules) continue;
+        for (const rule of Array.from(rules)) {
+          if (rule instanceof CSSStyleRule) {
+            const sel = rule.selectorText ?? "";
+            // Base thumb rule (not scoped to is-unanswered)
+            if (
+              sel.includes(".survey-slider::-webkit-slider-thumb") &&
+              !sel.includes("is-unanswered")
+            ) {
+              const w = rule.style.getPropertyValue("width").trim();
+              if (w === "30px") return true;
+            }
+          }
+        }
+      }
+      return false;
+    });
+    expect(widthFound).toBe(true);
+  });
+
+  // ── 4. Invalid card border differs from normal card border ─────────────────
+  test("invalid card has a different border-color than a normal card", async ({ page }) => {
+    const { normalBorder, invalidBorder } = await page.evaluate(() => {
+      const normalCard = document.getElementById("card-unanswered") as HTMLElement;
+      const invalidCard = document.getElementById("card-invalid") as HTMLElement;
+      return {
+        normalBorder: getComputedStyle(normalCard).borderColor,
+        invalidBorder: getComputedStyle(invalidCard).borderColor,
+      };
+    });
+
+    // The :has(.is-invalid) rule sets border-color: hsl(var(--destructive)) ≈ red
+    // while normal cards use #e8e2f2 (soft purple-tinted)
+    expect(invalidBorder).not.toBe(normalBorder);
+
+    // Extra: invalidBorder should look reddish — rgb values where R >> G,B
+    // rgb(...) format: extract components
+    const rgbMatch = invalidBorder.match(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/);
+    if (rgbMatch) {
+      const [, r, g, b] = rgbMatch.map(Number);
+      // --destructive: 0 84.2% 60.2% → hsl(0,84%,60%) → roughly rgb(239, 68, 68)
+      // R should be significantly greater than G and B
+      expect(r).toBeGreaterThan(g + 50);
+      expect(r).toBeGreaterThan(b + 50);
+    }
+  });
+
+  // ── 5. Focus ring on unanswered slider ────────────────────────────────────
+  //
+  // Chromium triggers :focus-visible for keyboard navigation.
+  // Strategy: press Tab until focus lands on the slider-focus input, then
+  // assert the computed outline. This reliably triggers :focus-visible because
+  // the focus arrived via keyboard.
+  test("focused unanswered slider shows a visible outline (focus ring)", async ({ page }) => {
+    // Press Tab repeatedly until slider-focus is the active element
+    // (there are 4 sliders; Tab through them all)
+    await page.keyboard.press("Tab"); // slider-unanswered
+    await page.keyboard.press("Tab"); // slider-answered
+    await page.keyboard.press("Tab"); // slider-invalid
+    await page.keyboard.press("Tab"); // slider-focus
+
+    // Confirm the right element is focused
+    const focusedId = await page.evaluate(() => document.activeElement?.id ?? "none");
+    // If Tab order differs, try focussing directly via keyboard from the element
+    if (focusedId !== "slider-focus") {
+      // Fallback: programmatic focus + a synthetic keyboard event to flag
+      // as keyboard-intent so Chromium switches to :focus-visible
+      await page.locator("#slider-focus").focus();
+      await page.keyboard.press("ArrowRight"); // triggers keyboard navigation mode
+    }
+
+    const outline = await page.evaluate(() => {
+      const el = document.getElementById("slider-focus") as HTMLInputElement;
+      const s = getComputedStyle(el);
+      return {
+        outlineStyle: s.outlineStyle,
+        outlineWidth: s.outlineWidth,
+        outlineColor: s.outlineColor,
+      };
+    });
+
+    // The CSS rule for .is-unanswered .survey-slider:focus-visible sets
+    //   outline: 2px solid #522583; outline-offset: 4px; border-radius: 6px;
+    expect(outline.outlineStyle).not.toBe("none");
+    expect(outline.outlineWidth).not.toBe("0px");
+    expect(outline.outlineWidth).toBe("2px");
+  });
+
+  // ── 6. Screenshot of all four states ─────────────────────────────────────
+  test("screenshot — all four slider states rendered", async ({ page }) => {
+    // Focus slider-focus to capture the focus-ring state in the screenshot.
+    // Use keyboard Tab to trigger :focus-visible.
+    await page.keyboard.press("Tab");
+    await page.keyboard.press("Tab");
+    await page.keyboard.press("Tab");
+    await page.keyboard.press("Tab");
+    const focusedId = await page.evaluate(() => document.activeElement?.id ?? "none");
+    if (focusedId !== "slider-focus") {
+      await page.locator("#slider-focus").focus();
+      await page.keyboard.press("ArrowRight");
+    }
+
+    await page.locator("#brand-root").screenshot({
+      path: "wave-c-slider-states.png",
+    });
+    // Test passes as long as screenshot doesn't throw
+  });
+});

--- a/src/src/__tests__/assessments/assessment-shell-header.test.tsx
+++ b/src/src/__tests__/assessments/assessment-shell-header.test.tsx
@@ -3,13 +3,15 @@ import { render, screen } from "@testing-library/react";
 import { AssessmentShellHeader } from "@/components/assessments/AssessmentShellHeader";
 
 describe("AssessmentShellHeader", () => {
-  it("renders the white logo, the Section N of M label, and one progress segment per section with the right active count", () => {
-    const { container } = render(
+  it("renders the white logo and the Section N of M label with the authoritative progressbar", () => {
+    render(
       <AssessmentShellHeader
         currentSection={2}
         totalSections={10}
         assessmentName="Rockefeller Habits"
         companyName="Northwind Logistics"
+        answeredCount={2}
+        totalQuestions={10}
       />,
     );
 
@@ -21,11 +23,10 @@ describe("AssessmentShellHeader", () => {
     // "Section 2 of 10" label
     expect(screen.getByText(/section 2 of 10/i)).toBeInTheDocument();
 
-    // One segment per section, exactly `currentSection` of them active
-    const segments = container.querySelectorAll(".su-shell-seg-item");
-    expect(segments).toHaveLength(10);
-    const active = container.querySelectorAll(".su-shell-seg-item.is-active");
-    expect(active).toHaveLength(2);
+    // Authoritative progressbar with correct aria values
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toHaveAttribute("aria-valuenow", "2");
+    expect(bar).toHaveAttribute("aria-valuemax", "10");
   });
 
   it("renders the assessment name and company name when both are provided", () => {
@@ -35,6 +36,8 @@ describe("AssessmentShellHeader", () => {
         totalSections={3}
         assessmentName="Rockefeller Habits"
         companyName="Northwind Logistics"
+        answeredCount={0}
+        totalQuestions={5}
       />,
     );
     expect(screen.getByText(/rockefeller habits/i)).toBeInTheDocument();
@@ -47,25 +50,49 @@ describe("AssessmentShellHeader", () => {
         currentSection={1}
         totalSections={3}
         assessmentName="Quarterly Strategy Pulse"
+        answeredCount={0}
+        totalQuestions={3}
       />,
     );
     expect(screen.getByText(/quarterly strategy pulse/i)).toBeInTheDocument();
     expect(screen.queryByText(/northwind logistics/i)).not.toBeInTheDocument();
   });
 
-  it("renders without an assessment name (both optional)", () => {
-    const { container } = render(
-      <AssessmentShellHeader currentSection={1} totalSections={2} />,
+  it("renders without an assessment name and shows Section N of M", () => {
+    render(
+      <AssessmentShellHeader
+        currentSection={1}
+        totalSections={2}
+        answeredCount={0}
+        totalQuestions={2}
+      />,
     );
-    expect(container.querySelectorAll(".su-shell-seg-item")).toHaveLength(2);
     expect(screen.getByText(/section 1 of 2/i)).toBeInTheDocument();
   });
 
-  it("clamps the active-segment count so it never exceeds totalSections", () => {
-    const { container } = render(
-      <AssessmentShellHeader currentSection={99} totalSections={4} />,
+  it("clamps the active section so it never exceeds totalSections", () => {
+    render(
+      <AssessmentShellHeader
+        currentSection={99}
+        totalSections={4}
+        answeredCount={0}
+        totalQuestions={4}
+      />,
     );
-    expect(container.querySelectorAll(".su-shell-seg-item")).toHaveLength(4);
-    expect(container.querySelectorAll(".su-shell-seg-item.is-active")).toHaveLength(4);
+    // Section label shows clamped value (4 of 4)
+    expect(screen.getByText(/section 4 of 4/i)).toBeInTheDocument();
+  });
+
+  it("no longer renders the segmented strip", () => {
+    const { container } = render(
+      <AssessmentShellHeader
+        currentSection={1}
+        totalSections={2}
+        answeredCount={0}
+        totalQuestions={4}
+      />,
+    );
+    expect(container.querySelector(".su-shell-seg")).toBeNull();
+    expect(container.querySelectorAll(".su-shell-seg-item")).toHaveLength(0);
   });
 });

--- a/src/src/__tests__/assessments/org-survey-pager.test.tsx
+++ b/src/src/__tests__/assessments/org-survey-pager.test.tsx
@@ -230,6 +230,75 @@ describe("OrgSurveyClient — SectionPager wiring + hidden-orphan fix", () => {
     expect(saved.q1).toBe(2);
   });
 
+  it("prunes a stale draft answer key (no longer a rendered question) from the submit POST body (R3-M2)", async () => {
+    // Seed a draft containing a STALE key ("removedQ") that maps to no current
+    // question, alongside the two valid answers, under the per-respondent key.
+    localStorage.setItem(
+      invitedDraftKey(RESPONDENT_KEY),
+      JSON.stringify({ q1: 2, orphanReq: "free text", removedQ: 9 }),
+    );
+
+    await reachPager();
+    await screen.findByText(/section 1 of 2/i);
+
+    // Advance to the Other page (the slider already holds the restored value 2)
+    // and submit.
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+    await screen.findByText(/section 2 of 2/i);
+    fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+
+    await waitFor(() => {
+      const calls = (global.fetch as jest.Mock).mock.calls;
+      expect(calls.some(([u]) => String(u).includes("/submit"))).toBe(true);
+    });
+
+    const submitCall = (global.fetch as jest.Mock).mock.calls.find(([u]) =>
+      String(u).includes("/submit"),
+    );
+    const body = JSON.parse((submitCall[1] as RequestInit).body as string);
+    const keys = body.answers.map((a: { stableKey: string }) => a.stableKey);
+    // The stale key is gone; only the two real questions are POSTed.
+    expect(keys).not.toContain("removedQ");
+    expect(keys.sort()).toEqual(["orphanReq", "q1"]);
+  });
+
+  it("keeps the participant ON the pager (inline error, not a terminal screen) when submit fails (R2-M1)", async () => {
+    // /me succeeds; /submit returns a 500 — the participant must stay on the
+    // pager with an inline error, NOT land on the terminal error phase.
+    global.fetch = jest.fn((input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/me")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ success: true, data: surveyData }),
+        } as Response);
+      }
+      // /submit fails.
+      return Promise.resolve({
+        ok: false,
+        status: 500,
+        json: async () => ({ success: false, error: "Failed to submit answers" }),
+      } as Response);
+    }) as unknown as typeof fetch;
+
+    await reachPager();
+    await screen.findByText(/section 1 of 2/i);
+    fireEvent.change(screen.getByRole("slider"), { target: { value: "2" } });
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+    await screen.findByText(/section 2 of 2/i);
+    fireEvent.change(screen.getByLabelText(/Orphan Q/i), {
+      target: { value: "free text" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+
+    // Inline error appears AND the pager is still mounted (the question is
+    // still present); router.push to thank-you was never called.
+    await screen.findByRole("alert");
+    expect(screen.getByText("Orphan Q")).toBeInTheDocument();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
   it("Screen 1 (welcome) renders the value-prop list with INVITED team framing + stat chips from real data", async () => {
     render(<OrgSurveyClient campaignAlias={ALIAS} />);
     // Wait for the intro (welcome) phase to render after /me resolves.

--- a/src/src/__tests__/assessments/org-survey-pager.test.tsx
+++ b/src/src/__tests__/assessments/org-survey-pager.test.tsx
@@ -299,6 +299,62 @@ describe("OrgSurveyClient — SectionPager wiring + hidden-orphan fix", () => {
     expect(mockPush).not.toHaveBeenCalled();
   });
 
+  it("keeps the participant ON the pager (inline alert, not terminal) when the pre-submit required/empty gate fires (R2-M1 parity)", async () => {
+    // The two pre-submit gates in handleSubmit (global required-unanswered scan
+    // + zero-answer EMPTY_ANSWERS guard) used to call setPhase({ kind: "error" })
+    // — a terminal dead-end screen. They now surface inline via setSubmitError so
+    // the participant stays on the pager and can fix the answer in place, matching
+    // the genuine POST-failure recovery (and the public quiz client).
+    //
+    // Reachable path: a survey with sections but NO questions renders the pager's
+    // ungated "Nothing to answer yet" Submit (the per-page required gate never
+    // runs), so clicking Submit reaches handleSubmit with zero answers → the
+    // empty-answer gate fires. The participant must NOT be dead-ended.
+    global.fetch = jest.fn((input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/me")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            success: true,
+            // Zero sections + zero questions ⇒ buildSectionPages returns [] ⇒ the
+            // pager shows the ungated Submit, so handleSubmit's pre-submit gate is
+            // the only enforcement and IS reached.
+            data: { ...surveyData, sections: [], questions: [] },
+          }),
+        } as Response);
+      }
+      // /submit must NEVER be hit — the gate returns before any POST.
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, data: { submissionId: "sub_x" } }),
+      } as Response);
+    }) as unknown as typeof fetch;
+
+    await reachPager();
+
+    // The ungated Submit appears (no required gating, no answers).
+    const submitBtn = await screen.findByRole("button", { name: /submit/i });
+    fireEvent.click(submitBtn);
+
+    // Inline alert appears, the pager stays mounted (Submit still present), the
+    // terminal error screen is NOT shown, no /submit POST fires, and navigation
+    // never happens.
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/please answer at least one question/i);
+    expect(screen.getByRole("button", { name: /submit/i })).toBeInTheDocument();
+    // Terminal error phase copy must NOT appear.
+    expect(screen.queryByText(/can't open this survey/i)).not.toBeInTheDocument();
+    // No POST to /submit and no thank-you navigation.
+    const submitCalls = (global.fetch as jest.Mock).mock.calls.filter(([u]) =>
+      String(u).includes("/submit"),
+    );
+    expect(submitCalls).toHaveLength(0);
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
   it("Screen 1 (welcome) renders the value-prop list with INVITED team framing + stat chips from real data", async () => {
     render(<OrgSurveyClient campaignAlias={ALIAS} />);
     // Wait for the intro (welcome) phase to render after /me resolves.

--- a/src/src/__tests__/assessments/public-quiz-pager.test.tsx
+++ b/src/src/__tests__/assessments/public-quiz-pager.test.tsx
@@ -169,6 +169,56 @@ describe("PublicQuizClient — SectionPager wiring", () => {
     expect(localStorage.getItem(key)).toBeNull();
   });
 
+  it("prunes a stale draft answer key (no longer a rendered question) from the submit POST body (R3-M2)", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        success: true,
+        data: {
+          submissionId: "sub_prune_1",
+          scoreResult: {
+            perQuestion: [],
+            perSection: [],
+            overallTotal: 0,
+            overallAverage: 0,
+            countAchieved: 0,
+            tier: null,
+            tierMetricValue: 0,
+            unansweredKeys: [],
+          },
+        },
+      }),
+    });
+
+    // Seed a draft with a STALE key ("removedQ") that maps to no current
+    // question, alongside a valid answer, BEFORE mount so the hook hydrates it.
+    localStorage.setItem(
+      publicDraftKey(ALIAS),
+      JSON.stringify({ q1: 2, removedQ: 9 }),
+    );
+
+    render(<PublicQuizClient {...baseProps} />);
+    reachFormStep();
+
+    // Answer q1 explicitly (don't depend on debounced draft restore), advance,
+    // answer q2, and submit. The stale "removedQ" must not reach the server.
+    fireEvent.change(screen.getByRole("slider"), { target: { value: "2" } });
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+    expect(screen.getByText(/section 2 of 2/i)).toBeInTheDocument();
+    fireEvent.change(screen.getByRole("slider"), { target: { value: "3" } });
+    fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    const body = JSON.parse((init as RequestInit).body as string);
+    const keys = body.answers.map((a: { stableKey: string }) => a.stableKey);
+    // The stale key is gone; only the two real questions are POSTed.
+    expect(keys).not.toContain("removedQ");
+    expect(keys.sort()).toEqual(["q1", "q2"]);
+  });
+
   it("still renders the intro and info phases with the public-taker fields intact", () => {
     render(<PublicQuizClient {...baseProps} />);
     // intro

--- a/src/src/__tests__/assessments/section-pager.test.tsx
+++ b/src/src/__tests__/assessments/section-pager.test.tsx
@@ -155,26 +155,21 @@ describe("SectionPager", () => {
     expect(screen.getByText(/northwind logistics/i)).toBeInTheDocument();
   });
 
-  it("the shell header's Section N of M + active-segment count track the pager's OWN state through next/back (single source)", () => {
+  it("the shell header's Section N of M tracks the pager's OWN state through next/back (single source)", () => {
     const { container } = setup(); // S0 (empty intro) + S1 (questions)
     // The shell header label lives in the appbar; it shows the pager's section.
     const headerLabel = () => container.querySelector(".su-shell-where")?.textContent ?? "";
-    const activeSegs = () => container.querySelectorAll(".su-shell-seg-item.is-active").length;
 
-    // On the first section's intro: Section 1 of 2, 1 active segment.
+    // On the first section's intro: Section 1 of 2.
     expect(headerLabel()).toMatch(/section 1 of 2/i);
-    expect(activeSegs()).toBe(1);
-    expect(container.querySelectorAll(".su-shell-seg-item")).toHaveLength(2);
 
-    // Begin section → advances to S1 (S0 empty) → Section 2 of 2, 2 active segments.
+    // Begin section → advances to S1 (S0 empty) → Section 2 of 2.
     fireEvent.click(screen.getByRole("button", { name: /begin section/i }));
     expect(headerLabel()).toMatch(/section 2 of 2/i);
-    expect(activeSegs()).toBe(2);
 
     // Back across the empty welcome → back to its intro → Section 1 of 2 again.
     fireEvent.click(screen.getByRole("button", { name: /back/i }));
     expect(headerLabel()).toMatch(/section 1 of 2/i);
-    expect(activeSegs()).toBe(1);
   });
 
   it("a section with BOTH a description and questions: intro → Begin section → questions → Back → intro", () => {

--- a/src/src/__tests__/assessments/section-pager.test.tsx
+++ b/src/src/__tests__/assessments/section-pager.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { SectionPager } from "@/components/assessments/section-pager";
 import { buildSectionPages, type PagerSection, type PagerQuestion } from "@/lib/assessments/section-pages";
 
@@ -36,8 +36,8 @@ describe("SectionPager", () => {
     expect(screen.getByText(/section 1 of 2/i)).toBeInTheDocument();
     // Intro slide hero container renders.
     expect(container.querySelector(".su-intro-slide")).toBeInTheDocument();
-    // Section number badge (01) renders inside the kicker.
-    expect(container.querySelector(".su-intro-num")).toBeInTheDocument();
+    // #7 — the "01" section-number badge was removed from the intro kicker.
+    expect(container.querySelector(".su-intro-num")).not.toBeInTheDocument();
   });
 
   it("Screen 2 is DISTINCT: renders the domain accent rail + a 'What this section covers' callout from section.description", () => {
@@ -188,5 +188,93 @@ describe("SectionPager", () => {
     expect(screen.getByText("Q1")).toBeInTheDocument(); // questions
     fireEvent.click(screen.getByRole("button", { name: /back/i }));
     expect(screen.getByText("Strategy intro")).toBeInTheDocument(); // back to intro (ADR-0004 description persists)
+  });
+
+  // ── Wave C Task 3 — per-question validation + min-answer gate + submit latch ──
+
+  it("blocked advance flags the unanswered required question (aria-invalid) AND moves focus to it", async () => {
+    setup(); // S0 (empty intro) + S1 (one required slider, unanswered)
+    fireEvent.click(screen.getByRole("button", { name: /begin section/i }));
+    // Submit with the required slider unanswered → blocked + flagged.
+    fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+    const slider = screen.getByRole("slider", { name: "Q1" });
+    expect(slider).toHaveAttribute("aria-invalid", "true");
+    // Focus moves to the offending control (deferred via requestAnimationFrame).
+    await waitFor(() => expect(slider).toHaveFocus());
+  });
+
+  it("answering a flagged question clears ONLY its invalid state", () => {
+    const onAnswerChange = jest.fn();
+    const onSubmit = jest.fn();
+    const pages = buildSectionPages(sections, questions);
+    const { rerender } = render(
+      <SectionPager pages={pages} answers={{}} onAnswerChange={onAnswerChange} onSubmit={onSubmit} submitting={false} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /begin section/i }));
+    fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+    expect(screen.getByRole("slider", { name: "Q1" })).toHaveAttribute("aria-invalid", "true");
+
+    // Answer the slider (controlled → feed the value back through rerender).
+    fireEvent.click(screen.getByRole("slider", { name: "Q1" }));
+    expect(onAnswerChange).toHaveBeenCalledWith("q1", 0);
+    const pages2 = buildSectionPages(sections, questions);
+    rerender(<SectionPager pages={pages2} answers={{ q1: 0 }} onAnswerChange={onAnswerChange} onSubmit={onSubmit} submitting={false} />);
+    expect(screen.getByRole("slider", { name: "Q1" })).not.toHaveAttribute("aria-invalid");
+  });
+
+  it("a required TEXT question flagged, then changed to whitespace, STAYS invalid", () => {
+    const secs: PagerSection[] = [{ stableKey: "T1", sortOrder: 1, name: "Notes" }];
+    const qs: PagerQuestion[] = [
+      { stableKey: "t1", sortOrder: 1, sectionStableKey: "T1", type: "TEXT", label: "Tell us why", isRequired: true },
+    ];
+    const onAnswerChange = jest.fn();
+    const pages = buildSectionPages(secs, qs);
+    const { rerender } = render(
+      <SectionPager pages={pages} answers={{}} onAnswerChange={onAnswerChange} onSubmit={jest.fn()} submitting={false} />,
+    );
+    // No intro (no description, has questions) → questions are shown immediately.
+    fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+    const textarea = screen.getByRole("textbox", { name: "Tell us why" });
+    expect(textarea).toHaveAttribute("aria-invalid", "true");
+
+    // Type whitespace only — isAnswered("   ") is false, so the flag must STAY.
+    fireEvent.change(textarea, { target: { value: "   " } });
+    expect(onAnswerChange).toHaveBeenCalledWith("t1", "   ");
+    const pages2 = buildSectionPages(secs, qs);
+    rerender(<SectionPager pages={pages2} answers={{ t1: "   " }} onAnswerChange={onAnswerChange} onSubmit={jest.fn()} submitting={false} />);
+    expect(screen.getByRole("textbox", { name: "Tell us why" })).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("requireAtLeastOneAnswer: an all-optional set with zero answers blocks Submit with a non-field alert", () => {
+    const secs: PagerSection[] = [{ stableKey: "O1", sortOrder: 1, name: "Optional" }];
+    const qs: PagerQuestion[] = [
+      { stableKey: "o1", sortOrder: 1, sectionStableKey: "O1", type: "TEXT", label: "Optional A", isRequired: false },
+      { stableKey: "o2", sortOrder: 2, sectionStableKey: "O1", type: "TEXT", label: "Optional B", isRequired: false },
+    ];
+    const onSubmit = jest.fn();
+    const pages = buildSectionPages(secs, qs);
+    const { container } = render(
+      <SectionPager pages={pages} answers={{}} onAnswerChange={jest.fn()} onSubmit={onSubmit} submitting={false} requireAtLeastOneAnswer />,
+    );
+    // No intro, no required questions → Submit is the only gate.
+    fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+    // Alert shown with the min-answer copy.
+    expect(screen.getByRole("alert")).toHaveTextContent(/at least one question/i);
+    // NON-field gate — no control is marked invalid.
+    expect(container.querySelector("[aria-invalid='true']")).toBeNull();
+    // Submit is NOT called.
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("double-clicking Submit (after answering the required question) calls onSubmit at most once", () => {
+    const onSubmit = jest.fn();
+    const pages = buildSectionPages(sections, questions);
+    render(<SectionPager pages={pages} answers={{ q1: 2 }} onAnswerChange={jest.fn()} onSubmit={onSubmit} submitting={false} />);
+    fireEvent.click(screen.getByRole("button", { name: /begin section/i }));
+    const submit = screen.getByRole("button", { name: /submit/i });
+    // Two synchronous clicks — the ref latch must swallow the second.
+    fireEvent.click(submit);
+    fireEvent.click(submit);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/src/__tests__/components/assessments/assessment-shell-header.test.tsx
+++ b/src/src/__tests__/components/assessments/assessment-shell-header.test.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { AssessmentShellHeader } from "@/components/assessments/AssessmentShellHeader";
+
+it("renders the caption + Section N of M", () => {
+  render(<AssessmentShellHeader currentSection={2} totalSections={4} assessmentName="Q3 Rockefeller" answeredCount={3} totalQuestions={10} />);
+  expect(screen.getByText("Q3 Rockefeller")).toBeInTheDocument();
+  expect(screen.getByText(/Section 2 of 4/)).toBeInTheDocument();
+});
+it("owns exactly one progressbar reflecting answered/total", () => {
+  render(<AssessmentShellHeader currentSection={1} totalSections={2} assessmentName="X" answeredCount={3} totalQuestions={10} />);
+  const bar = screen.getByRole("progressbar");
+  expect(bar).toHaveAttribute("aria-valuenow", "3");
+  expect(bar).toHaveAttribute("aria-valuemax", "10");
+});
+it("no longer renders the segmented strip", () => {
+  const { container } = render(<AssessmentShellHeader currentSection={1} totalSections={2} assessmentName="X" answeredCount={0} totalQuestions={4} />);
+  expect(container.querySelector(".su-shell-seg")).toBeNull();
+});

--- a/src/src/__tests__/components/assessments/question-input.test.tsx
+++ b/src/src/__tests__/components/assessments/question-input.test.tsx
@@ -277,3 +277,40 @@ describe("QuestionInput", () => {
     expect(onChange).toHaveBeenCalledWith("S1_Q1", 1);
   });
 });
+
+const multiChoiceQuestion: QuestionForInput = {
+  stableKey: "S1_MC",
+  type: "MULTI_CHOICE",
+  label: "Pick some",
+  isRequired: true,
+  options: [ { key: "a", label: "Alpha" }, { key: "b", label: "Beta" } ],
+};
+
+describe("QuestionInput invalid + a11y contract (Wave C)", () => {
+  it("slider: invalid sets aria-invalid on the range input", () => {
+    render(<QuestionInput question={sliderQuestion} value={undefined} onChange={jest.fn()} invalid />);
+    expect(screen.getByRole("slider")).toHaveAttribute("aria-invalid", "true");
+  });
+  it("text: invalid sets aria-invalid + shows a placeholder", () => {
+    render(<QuestionInput question={{ ...sliderQuestion, type: "TEXT", stableKey: "T1" }} value={undefined} onChange={jest.fn()} invalid />);
+    const ta = screen.getByRole("textbox");
+    expect(ta).toHaveAttribute("aria-invalid", "true");
+    expect(ta).toHaveAttribute("placeholder");
+  });
+  it("multi-choice: invalid marks the group invalid AND the first checkbox carries the focus id", () => {
+    render(<QuestionInput question={multiChoiceQuestion} value={[]} onChange={jest.fn()} invalid />);
+    expect(screen.getByRole("group")).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getAllByRole("checkbox")[0]).toHaveAttribute("id", "q-S1_MC");
+  });
+  it("text: enforces the 10k maxLength", () => {
+    render(<QuestionInput question={{ ...sliderQuestion, type: "TEXT", stableKey: "T2" }} value={""} onChange={jest.fn()} />);
+    expect(screen.getByRole("textbox")).toHaveAttribute("maxLength", "10000");
+  });
+  it("text: shows the char counter only near the cap", () => {
+    const near = "x".repeat(9_500);
+    const { rerender } = render(<QuestionInput question={{ ...sliderQuestion, type: "TEXT", stableKey: "T3" }} value={"hi"} onChange={jest.fn()} />);
+    expect(screen.queryByTestId("char-counter")).toBeNull();
+    rerender(<QuestionInput question={{ ...sliderQuestion, type: "TEXT", stableKey: "T3" }} value={near} onChange={jest.fn()} />);
+    expect(screen.getByTestId("char-counter")).toHaveTextContent("9500 / 10000");
+  });
+});

--- a/src/src/__tests__/components/assessments/question-input.test.tsx
+++ b/src/src/__tests__/components/assessments/question-input.test.tsx
@@ -297,9 +297,12 @@ describe("QuestionInput invalid + a11y contract (Wave C)", () => {
     expect(ta).toHaveAttribute("aria-invalid", "true");
     expect(ta).toHaveAttribute("placeholder");
   });
-  it("multi-choice: invalid marks the group invalid AND the first checkbox carries the focus id", () => {
+  it("multi-choice: invalid sets aria-invalid on the first checkbox (not the role=group wrapper) AND it carries the focus id", () => {
     render(<QuestionInput question={multiChoiceQuestion} value={[]} onChange={jest.fn()} invalid />);
-    expect(screen.getByRole("group")).toHaveAttribute("aria-invalid", "true");
+    // aria-invalid lives on the focusable first checkbox, not the role="group"
+    // div (jsx-a11y/role-supports-aria-props — the group does not support it).
+    expect(screen.getAllByRole("checkbox")[0]).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getByRole("group")).not.toHaveAttribute("aria-invalid");
     expect(screen.getAllByRole("checkbox")[0]).toHaveAttribute("id", "q-S1_MC");
   });
   it("text: enforces the 10k maxLength", () => {

--- a/src/src/__tests__/lib/assessments/answer-limits.test.ts
+++ b/src/src/__tests__/lib/assessments/answer-limits.test.ts
@@ -1,0 +1,11 @@
+import { MAX_TEXT_ANSWER_LENGTH } from "@/lib/assessments/answer-limits";
+import { MAX_TEXT_ANSWER_LENGTH as fromScoring } from "@/lib/assessments/scoring";
+
+describe("answer-limits", () => {
+  it("exposes the 10k text limit", () => {
+    expect(MAX_TEXT_ANSWER_LENGTH).toBe(10_000);
+  });
+  it("scoring.ts re-exports the same constant (single source of truth)", () => {
+    expect(fromScoring).toBe(MAX_TEXT_ANSWER_LENGTH);
+  });
+});

--- a/src/src/__tests__/lib/assessments/prune-answers.test.ts
+++ b/src/src/__tests__/lib/assessments/prune-answers.test.ts
@@ -1,0 +1,26 @@
+import { pruneAnswersToQuestions } from "@/lib/assessments/prune-answers";
+
+describe("pruneAnswersToQuestions", () => {
+  it("drops answers whose stableKey is not in the known set", () => {
+    expect(
+      pruneAnswersToQuestions({ a: 1, b: "x", stale: 9 }, new Set(["a", "b"])),
+    ).toEqual({ a: 1, b: "x" });
+  });
+
+  it("returns the SAME object reference when nothing is pruned (avoids needless rerender)", () => {
+    const input = { a: 1 };
+    expect(pruneAnswersToQuestions(input, new Set(["a"]))).toBe(input);
+  });
+
+  it("returns the same reference for an empty answers map", () => {
+    const input = {};
+    expect(pruneAnswersToQuestions(input, new Set(["a"]))).toBe(input);
+  });
+
+  it("drops ALL keys when none are known (returns a fresh empty object)", () => {
+    const input = { a: 1, b: 2 };
+    const out = pruneAnswersToQuestions(input, new Set<string>());
+    expect(out).toEqual({});
+    expect(out).not.toBe(input);
+  });
+});

--- a/src/src/components/assessments/AssessmentShellHeader.tsx
+++ b/src/src/components/assessments/AssessmentShellHeader.tsx
@@ -7,13 +7,12 @@ import React from "react";
  *
  * Presentational only — it renders whatever section position it is given. It is
  * mounted INSIDE {@link SectionPager}, which feeds it the pager's OWN current
- * section index + total, so the progress strip can never drift from the
+ * section index + total, so the progress bar can never drift from the
  * questions on screen (single source of section state — claudex r1 #8).
  *
  * Look: purple appbar (matches the approved /tmp/su-assessment-mockups/quiz.html)
- * with the white Scaling Up logo, a "Assessment · Company" caption, and a
- * Four-Decisions segmented progress strip (one segment per section, the first
- * `currentSection` lit using the four-decisions colours cycling).
+ * with the white Scaling Up logo, a "Assessment · Company" caption, "Section N
+ * of M" text, and the authoritative linear progressbar (answered/total questions).
  *
  * Scope: every class lives under `.su-assessment-brand` (the pager root already
  * provides that scope) so there is zero leak to the blue admin/coach UI.
@@ -21,22 +20,25 @@ import React from "react";
 export interface AssessmentShellHeaderProps {
   /** 1-based index of the section currently on screen. */
   currentSection: number;
-  /** Total number of sections (one progress segment each). */
+  /** Total number of sections. */
   totalSections: number;
   /** Assessment / campaign / template name (left caption). Optional. */
   assessmentName?: string;
   /** Company / organization name (right caption). Rendered only when provided. */
   companyName?: string;
+  /** Number of questions answered so far (drives the progressbar). */
+  answeredCount: number;
+  /** Total number of questions across all sections (progressbar max). */
+  totalQuestions: number;
 }
-
-// Four Decisions accent colours, cycled across the active progress segments.
-const FOUR_DECISIONS = ["#f7a600", "#008bd2", "#946b36", "#95c11f"] as const;
 
 export function AssessmentShellHeader({
   currentSection,
   totalSections,
   assessmentName,
   companyName,
+  answeredCount,
+  totalQuestions,
 }: AssessmentShellHeaderProps) {
   const total = Math.max(0, Math.floor(totalSections));
   const active = Math.min(Math.max(0, Math.floor(currentSection)), total);
@@ -62,21 +64,15 @@ export function AssessmentShellHeader({
         </span>
       )}
 
-      {/* Presentational segmented strip. The pager already renders the
-          authoritative role="progressbar" (answered/total questions); a second
-          one here would create an ambiguous accessibility tree, so this strip is
-          aria-hidden and the "Section N of M" text carries the meaning. */}
-      <div className="su-shell-seg" aria-hidden="true">
-        {Array.from({ length: total }, (_, i) => {
-          const on = i < active;
-          return (
-            <i
-              key={i}
-              className={`su-shell-seg-item${on ? " is-active" : ""}`}
-              style={on ? { background: FOUR_DECISIONS[i % FOUR_DECISIONS.length] } : undefined}
-            />
-          );
-        })}
+      <div
+        role="progressbar"
+        aria-label="Progress"
+        aria-valuemin={0}
+        aria-valuemax={totalQuestions}
+        aria-valuenow={answeredCount}
+        className="survey-progress su-shell-progress"
+      >
+        <div className="survey-progress-fill" style={{ width: totalQuestions ? `${(answeredCount / totalQuestions) * 100}%` : "0%" }} />
       </div>
     </header>
   );

--- a/src/src/components/assessments/org-survey-client.tsx
+++ b/src/src/components/assessments/org-survey-client.tsx
@@ -243,24 +243,25 @@ export function OrgSurveyClient({ campaignAlias }: { campaignAlias: string }) {
       .filter((q) => !isAnswered(answers[q.stableKey]))
       .map((q) => q.label);
     if (missing.length > 0) {
-      setPhase({
-        kind: "error",
-        message: `Please answer all required questions before submitting (${missing.length} missing).`,
-      });
+      // Inline recovery (R2-M1 parity): a still-unanswered required question must
+      // NOT dead-end the participant on the terminal error phase. Keep them on the
+      // pager (ready phase) with the inline alert so they can fix the answer in
+      // place — mirrors the public quiz client, which handles this non-terminally.
+      setSubmitError(
+        `Please answer all required questions before submitting (${missing.length} missing).`
+      );
       return;
     }
 
     // The submit route rejects an empty `answers` array (EMPTY_ANSWERS 400),
     // so even an all-optional survey must have ≥1 answered question before we
-    // POST. Mirrors the public quiz client guard.
+    // POST. Mirrors the public quiz client guard. Surface this inline (non-terminal)
+    // so the participant stays on the pager and can answer a question.
     const answeredCount = Object.values(answers).filter((v) =>
       isAnswered(v)
     ).length;
     if (answeredCount === 0) {
-      setPhase({
-        kind: "error",
-        message: "Please answer at least one question before submitting.",
-      });
+      setSubmitError("Please answer at least one question before submitting.");
       return;
     }
 

--- a/src/src/components/assessments/org-survey-client.tsx
+++ b/src/src/components/assessments/org-survey-client.tsx
@@ -27,6 +27,7 @@ import {
   useAnswerDraft,
   invitedDraftKey,
 } from "@/lib/assessments/use-answer-draft";
+import { pruneAnswersToQuestions } from "@/lib/assessments/prune-answers";
 import {
   WelcomeShellHeader,
   WelcomeExpectations,
@@ -87,6 +88,9 @@ export function OrgSurveyClient({ campaignAlias }: { campaignAlias: string }) {
   const router = useRouter();
   const [phase, setPhase] = useState<Phase>({ kind: "exchanging" });
   const [answers, setAnswers] = useState<Record<string, number | string | string[]>>({});
+  // Inline submit error shown ON the pager (R2-M1) — a failed submit no longer
+  // dead-ends the participant on the terminal error phase.
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
   // localStorage autosave for the invited respondent. The hook must run
   // unconditionally at the top level (Rules of Hooks), before any phase-based
@@ -209,8 +213,30 @@ export function OrgSurveyClient({ campaignAlias }: { campaignAlias: string }) {
     [sortedQuestions.length],
   );
 
+  // The set of stableKeys that map to a currently-rendered question. Used both
+  // to prune a stale localStorage draft on hydrate AND to prune the POST body
+  // pre-submit (Wave C R3-M2) so an answer whose question no longer exists can
+  // never reach the server and trap the user.
+  const knownKeys = useMemo(
+    () => new Set(sortedQuestions.map((q) => q.stableKey)),
+    [sortedQuestions],
+  );
+
+  // Hydrate prune (secondary): once questions are known, prune the answer state
+  // once to the known set. The same-ref guard in pruneAnswersToQuestions means
+  // this no-ops (no setState) when nothing is stale, so it can't loop.
+  useEffect(() => {
+    if (knownKeys.size === 0) return;
+    // Safe one-shot reconciliation: the same-ref guard in pruneAnswersToQuestions
+    // makes this a no-op (no state change) once nothing is stale, so it cannot
+    // cascade or loop. Mirrors the ref-routed setState the autosave hook performs.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setAnswers((prev) => pruneAnswersToQuestions(prev, knownKeys));
+  }, [knownKeys]);
+
   async function handleSubmit() {
     if (phase.kind !== "ready") return;
+    setSubmitError(null);
 
     const required = phase.data.questions.filter((q) => q.isRequired);
     const missing = required
@@ -238,7 +264,15 @@ export function OrgSurveyClient({ campaignAlias }: { campaignAlias: string }) {
       return;
     }
 
-    setPhase({ kind: "submitting", data: phase.data });
+    // Pre-submit prune (R3-M2): drop any answer whose stableKey isn't a
+    // currently-rendered question (a stale localStorage draft) so it can't
+    // reach the server. Persist the pruned map back if it changed so the local
+    // state + autosaved draft stay in sync.
+    const pruned = pruneAnswersToQuestions(answers, knownKeys);
+    if (pruned !== answers) setAnswers(pruned);
+
+    const submittingData = phase.data;
+    setPhase({ kind: "submitting", data: submittingData });
 
     try {
       const submitRes = await fetch(`/org-survey/${campaignAlias}/submit`, {
@@ -247,25 +281,27 @@ export function OrgSurveyClient({ campaignAlias }: { campaignAlias: string }) {
         credentials: "include",
         cache: "no-store",
         body: JSON.stringify({
-          answers: Object.entries(answers).map(([stableKey, value]) => ({
+          answers: Object.entries(pruned).map(([stableKey, value]) => ({
             stableKey,
             value,
           })),
         }),
       });
       if (!submitRes.ok) {
+        // Submit-error recovery (R2-M1): a failed submit must NOT dead-end the
+        // participant on a terminal error screen. Drop back to the pager
+        // (ready phase) and surface the message inline so they can retry.
         const message = await readError(submitRes, "Failed to submit.");
-        setPhase({ kind: "error", message });
+        setSubmitError(message);
+        setPhase({ kind: "ready", data: submittingData });
         return;
       }
       clearDraft();
       router.push(`/org-survey/${campaignAlias}/thank-you`);
     } catch (err) {
       console.error("[org-survey] submit failed", err);
-      setPhase({
-        kind: "error",
-        message: "Something went wrong. Please try again.",
-      });
+      setSubmitError("Something went wrong. Please try again.");
+      setPhase({ kind: "ready", data: submittingData });
     }
   }
 
@@ -373,21 +409,21 @@ export function OrgSurveyClient({ campaignAlias }: { campaignAlias: string }) {
 
   return (
     <div className="ty-page">
-      <header className="ty-header">
-        <span className="ty-brand">Scaling Up</span>
-        <span>{data.campaign.name}</span>
-      </header>
       <main className="survey-body">
         <div className="survey-form">
-          <section className="ty-card" aria-labelledby="survey-title">
-            <span className="hero-eyebrow">Survey</span>
-            <h1 className="ty-title" id="survey-title">
-              {data.campaign.name}
-            </h1>
-            <p className="ty-lede">
-              Please rate each item below and submit when you&apos;re done.
-            </p>
-          </section>
+          {submitError && (
+            <div
+              className="wf-intersection-banner"
+              role="alert"
+              style={{
+                background: "hsl(var(--destructive) / 0.1)",
+                borderColor: "hsl(var(--destructive) / 0.3)",
+                color: "hsl(var(--destructive))",
+              }}
+            >
+              {submitError}
+            </div>
+          )}
 
           <SectionPager
             pages={pages}
@@ -400,6 +436,7 @@ export function OrgSurveyClient({ campaignAlias }: { campaignAlias: string }) {
             onExit={() => setPhase({ kind: "intro", data: phase.data })}
             assessmentName={data.campaign.name}
             companyName={data.campaign.organizationName ?? undefined}
+            requireAtLeastOneAnswer
           />
         </div>
       </main>

--- a/src/src/components/assessments/public-quiz-client.tsx
+++ b/src/src/components/assessments/public-quiz-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { SectionPager } from "./section-pager";
 import {
@@ -10,6 +10,7 @@ import {
   type PagerQuestion,
 } from "@/lib/assessments/section-pages";
 import { useAnswerDraft, publicDraftKey } from "@/lib/assessments/use-answer-draft";
+import { pruneAnswersToQuestions } from "@/lib/assessments/prune-answers";
 import {
   WelcomeShellHeader,
   WelcomeExpectations,
@@ -148,6 +149,23 @@ export function PublicQuizClient({
   // Hook must run unconditionally at the top level, before any early return.
   const draftKey = useMemo(() => publicDraftKey(campaignAlias), [campaignAlias]);
   const { clearDraft } = useAnswerDraft(draftKey, answers, setAnswers);
+
+  // The set of stableKeys that map to a currently-rendered question. Used both
+  // to prune a stale localStorage draft on hydrate AND to prune the POST body
+  // pre-submit (Wave C R3-M2) so an answer whose question no longer exists can
+  // never reach the server.
+  const knownKeys = useMemo(
+    () => new Set(sortedQuestions.map((q) => q.stableKey)),
+    [sortedQuestions],
+  );
+
+  // Hydrate prune (secondary): once questions are known, prune the answer state
+  // once to the known set. The same-ref guard in pruneAnswersToQuestions means
+  // this no-ops when nothing is stale, so it can't loop.
+  useEffect(() => {
+    if (knownKeys.size === 0) return;
+    setAnswers((prev) => pruneAnswersToQuestions(prev, knownKeys));
+  }, [knownKeys]);
 
   if (!isOpen || step === "error") {
     return (
@@ -409,6 +427,12 @@ export function PublicQuizClient({
     setSubmitting(true);
     // Lazily assign a stable idempotency key for this submission attempt.
     if (!idemRef.current) idemRef.current = crypto.randomUUID();
+    // Pre-submit prune (R3-M2): drop any answer whose stableKey isn't a
+    // currently-rendered question (a stale localStorage draft) before POSTing.
+    // Persist the pruned map back if it changed so local state + the autosaved
+    // draft stay in sync.
+    const pruned = pruneAnswersToQuestions(answers, knownKeys);
+    if (pruned !== answers) setAnswers(pruned);
     try {
       const res = await fetch(`/api/quiz/${campaignAlias}/submit`, {
         method: "POST",
@@ -419,7 +443,7 @@ export function PublicQuizClient({
             lastName: lastName.trim(),
             email: email.trim(),
           },
-          answers: Object.entries(answers).map(([stableKey, value]) => ({
+          answers: Object.entries(pruned).map(([stableKey, value]) => ({
             stableKey,
             value,
           })),
@@ -455,15 +479,12 @@ export function PublicQuizClient({
 
   return (
     <div className="ty-page">
-      <header className="ty-header">
-        <span className="ty-brand">Scaling Up</span>
-        <span>{campaignName}</span>
-      </header>
       <main className="survey-body">
         <div className="survey-form">
           {submitError && (
             <div
               className="wf-intersection-banner"
+              role="alert"
               style={{
                 background: "hsl(var(--destructive) / 0.1)",
                 borderColor: "hsl(var(--destructive) / 0.3)",
@@ -481,7 +502,8 @@ export function PublicQuizClient({
             onSubmit={handleSubmit}
             submitting={submitting}
             onExit={() => setStep("info")}
-            assessmentName={templateName}
+            assessmentName={campaignName}
+            requireAtLeastOneAnswer
           />
 
           <p

--- a/src/src/components/assessments/question-input.tsx
+++ b/src/src/components/assessments/question-input.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { SyntheticEvent } from "react";
+import { MAX_TEXT_ANSWER_LENGTH } from "@/lib/assessments/answer-limits";
 
 /**
  * Phase C — QuestionInput shared component.
@@ -41,6 +42,7 @@ interface QuestionInputProps {
   value: number | string | string[] | undefined;
   onChange: (stableKey: string, value: number | string | string[]) => void;
   disabled?: boolean;
+  invalid?: boolean;
 }
 
 export function QuestionInput({
@@ -48,6 +50,7 @@ export function QuestionInput({
   value,
   onChange,
   disabled,
+  invalid,
 }: QuestionInputProps) {
   if (q.type === "SLIDER_LIKERT" && q.scale) {
     const { min, max, step, anchorMin, anchorMax } = q.scale;
@@ -59,11 +62,11 @@ export function QuestionInput({
       onChange(q.stableKey, Number(e.currentTarget.value));
     const MOVE_KEYS = ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Home", "End", "PageUp", "PageDown"];
     return (
-      <div className={`survey-slider-wrap${answered ? "" : " is-unanswered"}`}>
+      <div className={`survey-slider-wrap${answered ? "" : " is-unanswered"}${invalid ? " is-invalid" : ""}`}>
         <input
           id={`q-${q.stableKey}`}
           type="range"
-          className="survey-slider"
+          className={`survey-slider${invalid ? " is-invalid" : ""}`}
           min={min}
           max={max}
           step={step}
@@ -72,6 +75,8 @@ export function QuestionInput({
           aria-valuemax={max}
           aria-valuenow={answered ? value : undefined}
           aria-valuetext={answered ? String(value) : "Not yet answered"}
+          aria-invalid={invalid || undefined}
+          style={answered ? ({ ["--pct" as string]: `${((numVal - min) / (max - min)) * 100}%` }) : undefined}
           onChange={commit}
           onClick={commit}
           // Commit on pointer release too: a tap that registers as a tiny drag
@@ -104,15 +109,26 @@ export function QuestionInput({
   }
 
   if (q.type === "TEXT") {
+    const textValue = typeof value === "string" ? value : "";
     return (
-      <textarea
-        id={`q-${q.stableKey}`}
-        className="survey-textarea"
-        rows={3}
-        value={typeof value === "string" ? value : ""}
-        onChange={(e) => onChange(q.stableKey, e.target.value)}
-        disabled={disabled}
-      />
+      <>
+        <textarea
+          id={`q-${q.stableKey}`}
+          className={`survey-textarea${invalid ? " is-invalid" : ""}`}
+          rows={3}
+          value={textValue}
+          placeholder="Type your answer here…"
+          maxLength={MAX_TEXT_ANSWER_LENGTH}
+          aria-invalid={invalid || undefined}
+          onChange={(e) => onChange(q.stableKey, e.target.value)}
+          disabled={disabled}
+        />
+        {textValue.length >= MAX_TEXT_ANSWER_LENGTH - 1000 ? (
+          <span className="survey-char-counter" data-testid="char-counter">
+            {textValue.length} / {MAX_TEXT_ANSWER_LENGTH}
+          </span>
+        ) : null}
+      </>
     );
   }
 
@@ -121,7 +137,9 @@ export function QuestionInput({
       <input
         id={`q-${q.stableKey}`}
         type="number"
-        className="survey-input-number"
+        className={`survey-input-number${invalid ? " is-invalid" : ""}`}
+        placeholder="Enter a number"
+        aria-invalid={invalid || undefined}
         value={
           typeof value === "number"
             ? value
@@ -146,16 +164,18 @@ export function QuestionInput({
       q.maxChoices !== undefined && selected.length >= q.maxChoices;
     return (
       <div
-        className="survey-checkbox-group"
+        className={`survey-checkbox-group${invalid ? " is-invalid" : ""}`}
         role="group"
         aria-label={q.label}
+        aria-invalid={invalid || undefined}
       >
-        {q.options.map((opt) => {
+        {q.options.map((opt, idx) => {
           const checked = selected.includes(opt.key);
           return (
             <label key={opt.key} className="survey-checkbox-item">
               <input
                 type="checkbox"
+                id={idx === 0 ? `q-${q.stableKey}` : undefined}
                 checked={checked}
                 disabled={disabled || (!checked && atMax)}
                 onChange={() => {

--- a/src/src/components/assessments/question-input.tsx
+++ b/src/src/components/assessments/question-input.tsx
@@ -167,7 +167,6 @@ export function QuestionInput({
         className={`survey-checkbox-group${invalid ? " is-invalid" : ""}`}
         role="group"
         aria-label={q.label}
-        aria-invalid={invalid || undefined}
       >
         {q.options.map((opt, idx) => {
           const checked = selected.includes(opt.key);
@@ -176,6 +175,11 @@ export function QuestionInput({
               <input
                 type="checkbox"
                 id={idx === 0 ? `q-${q.stableKey}` : undefined}
+                // aria-invalid belongs on a focusable widget, not on the
+                // role="group" wrapper (jsx-a11y/role-supports-aria-props). The
+                // first checkbox carries it; the group keeps the `is-invalid`
+                // class that drives the visible red border via CSS.
+                aria-invalid={idx === 0 ? invalid || undefined : undefined}
                 checked={checked}
                 disabled={disabled || (!checked && atMax)}
                 onChange={() => {

--- a/src/src/components/assessments/section-pager.tsx
+++ b/src/src/components/assessments/section-pager.tsx
@@ -18,6 +18,8 @@ interface SectionPagerProps {
   assessmentName?: string;
   /** Company / organization name shown in the shell header (invited flow only). */
   companyName?: string;
+  /** Public/optional surveys: require at least one answered question before submit. */
+  requireAtLeastOneAnswer?: boolean;
 }
 
 function pageHasIntro(p: SectionPage): boolean {
@@ -25,12 +27,18 @@ function pageHasIntro(p: SectionPage): boolean {
   return (p.description?.trim()?.length ?? 0) > 0 || !hasQuestions;
 }
 
-export function SectionPager({ pages, answers, onAnswerChange, onSubmit, submitting, onExit, assessmentName, companyName }: SectionPagerProps) {
+export function SectionPager({ pages, answers, onAnswerChange, onSubmit, submitting, onExit, assessmentName, companyName, requireAtLeastOneAnswer }: SectionPagerProps) {
   const [sectionIndex, setSectionIndex] = React.useState(0);
   const page = pages[sectionIndex];
   const [view, setView] = React.useState<"intro" | "questions">(page && pageHasIntro(page) ? "intro" : "questions");
   const [showGateError, setShowGateError] = React.useState(false);
+  const [invalidKeys, setInvalidKeys] = React.useState<Set<string>>(new Set());
+  const [gateMessage, setGateMessage] = React.useState<string>("");
+  const submitLatch = React.useRef(false);
   const headingRef = React.useRef<HTMLHeadingElement>(null);
+
+  // Release the synchronous double-click latch once a submit settles.
+  React.useEffect(() => { if (!submitting) submitLatch.current = false; }, [submitting]);
 
   if (!page) {
     return (
@@ -48,10 +56,23 @@ export function SectionPager({ pages, answers, onAnswerChange, onSubmit, submitt
   const total = pages.flatMap((p) => p.questions).length;
 
   function focusHeading() { requestAnimationFrame(() => headingRef.current?.focus()); }
+  function focusFirstInvalid(stableKey: string) {
+    requestAnimationFrame(() => document.getElementById(`q-${stableKey}`)?.focus());
+  }
+  function focusFirstAnswerable() {
+    const first = page.questions[0];
+    if (first) requestAnimationFrame(() => document.getElementById(`q-${first.stableKey}`)?.focus());
+  }
 
   function handleAnswerChange(stableKey: string, value: number | string | string[]) {
-    setShowGateError(false);
     onAnswerChange(stableKey, value);
+    setInvalidKeys((prev) => {
+      if (!prev.has(stableKey) || !isAnswered(value)) return prev; // whitespace/empty STAYS invalid
+      const next = new Set(prev);
+      next.delete(stableKey);
+      if (next.size === 0) setShowGateError(false);
+      return next;
+    });
   }
 
   function goToSection(idx: number) {
@@ -59,16 +80,36 @@ export function SectionPager({ pages, answers, onAnswerChange, onSubmit, submitt
     setSectionIndex(idx);
     setView(pageHasIntro(next) ? "intro" : "questions");
     setShowGateError(false);
+    setInvalidKeys(new Set());
     focusHeading();
   }
-  function advance() { if (isLast) { onSubmit(); return; } goToSection(sectionIndex + 1); }
+  function advance() { if (isLast) { attemptSubmit(); return; } goToSection(sectionIndex + 1); }
   function handleForwardFromIntro() {
     if (hasQuestions) { setView("questions"); setShowGateError(false); focusHeading(); }
     else { advance(); }
   }
+  function attemptSubmit() {
+    const totalAnswered = pages.flatMap((p) => p.questions).filter((q) => isAnswered(answers[q.stableKey])).length;
+    if (requireAtLeastOneAnswer && totalAnswered === 0) {
+      setGateMessage("Please answer at least one question before submitting.");
+      setShowGateError(true);
+      focusFirstAnswerable(); // NON-field alert; do NOT mark optional questions invalid
+      return;
+    }
+    if (submitLatch.current || submitting) return; // synchronous double-click guard
+    submitLatch.current = true;
+    onSubmit();
+  }
   function handleNext() {
     const unanswered = page.questions.filter((q) => q.isRequired && !isAnswered(answers[q.stableKey]));
-    if (unanswered.length > 0) { setShowGateError(true); return; }
+    if (unanswered.length > 0) {
+      setInvalidKeys(new Set(unanswered.map((q) => q.stableKey)));
+      setGateMessage("Please answer all required questions before continuing.");
+      setShowGateError(true);
+      focusFirstInvalid(unanswered[0].stableKey);
+      return;
+    }
+    if (isLast) { attemptSubmit(); return; }
     advance();
   }
   function handleBack() {
@@ -113,7 +154,6 @@ export function SectionPager({ pages, answers, onAnswerChange, onSubmit, submitt
           {/* Domain accent rail — colored top bar (neutral when no domain). */}
           <div className="su-intro-rail" aria-hidden="true" />
           <div className="su-intro-kicker">
-            <span className="su-intro-num" aria-hidden="true">{String(sectionIndex + 1).padStart(2, "0")}</span>
             <span className="su-intro-stepblock">
               {stepLabel ? <span className="su-intro-label">{stepLabel}</span> : null}
               <h2
@@ -163,11 +203,11 @@ export function SectionPager({ pages, answers, onAnswerChange, onSubmit, submitt
                   {q.label}{q.isRequired ? <span className="survey-required" aria-hidden="true"> *</span> : null}
                 </label>
                 {q.helpText ? <p className="survey-question-help">{q.helpText}</p> : null}
-                <QuestionInput question={q} value={answers[q.stableKey]} onChange={handleAnswerChange} disabled={submitting} />
+                <QuestionInput question={q} value={answers[q.stableKey]} onChange={handleAnswerChange} disabled={submitting} invalid={invalidKeys.has(q.stableKey)} />
               </li>
             ))}
           </ul>
-          {showGateError ? <p role="alert" className="survey-error">Please answer all required questions before continuing.</p> : null}
+          {showGateError ? <p role="alert" className="survey-error">{gateMessage}</p> : null}
           <div className="survey-nav">
             <button type="button" className="wf-btn wf-btn-secondary" onClick={handleBack}>Back</button>
             <button type="button" className="wf-btn wf-btn-primary" onClick={handleNext} disabled={submitting}>{isLast ? "Submit" : "Next"}</button>

--- a/src/src/components/assessments/section-pager.tsx
+++ b/src/src/components/assessments/section-pager.tsx
@@ -140,10 +140,9 @@ export function SectionPager({ pages, answers, onAnswerChange, onSubmit, submitt
         totalSections={pages.length}
         assessmentName={assessmentName}
         companyName={companyName}
+        answeredCount={answeredCount}
+        totalQuestions={total}
       />
-      <div role="progressbar" aria-label="Progress" aria-valuemin={0} aria-valuemax={total} aria-valuenow={answeredCount} className="survey-progress">
-        <div className="survey-progress-fill" style={{ width: total ? `${(answeredCount / total) * 100}%` : "0%" }} />
-      </div>
 
       {view === "intro" ? (
         <section

--- a/src/src/lib/assessments/answer-limits.ts
+++ b/src/src/lib/assessments/answer-limits.ts
@@ -1,0 +1,6 @@
+/**
+ * Client-safe answer-length limits. NO Zod / server imports — safe to import
+ * from participant client components without bundling the scoring module.
+ */
+/** Maximum character length accepted for a TEXT answer. */
+export const MAX_TEXT_ANSWER_LENGTH = 10_000;

--- a/src/src/lib/assessments/prune-answers.ts
+++ b/src/src/lib/assessments/prune-answers.ts
@@ -1,0 +1,15 @@
+// src/src/lib/assessments/prune-answers.ts
+
+type AnswersMap = Record<string, number | string | string[]>;
+
+/** Drop any answer whose stableKey isn't a currently-rendered question (Wave C R3-M2). */
+export function pruneAnswersToQuestions(
+  answers: AnswersMap,
+  knownStableKeys: Set<string>,
+): AnswersMap {
+  const keys = Object.keys(answers);
+  if (keys.every((k) => knownStableKeys.has(k))) return answers; // unchanged → same ref
+  const next: AnswersMap = {};
+  for (const k of keys) if (knownStableKeys.has(k)) next[k] = answers[k];
+  return next;
+}

--- a/src/src/lib/assessments/scoring.ts
+++ b/src/src/lib/assessments/scoring.ts
@@ -23,6 +23,7 @@
  */
 
 import { z } from "zod";
+import { MAX_TEXT_ANSWER_LENGTH } from "./answer-limits";
 
 // ─── Zod schemas (input validation) ──────────────────────────────────────
 
@@ -487,7 +488,7 @@ export class ScoringValidationError extends Error {
 // ─── Answer value validation ──────────────────────────────────────────────
 
 /** Maximum character length accepted for a TEXT answer. */
-export const MAX_TEXT_ANSWER_LENGTH = 10_000;
+export { MAX_TEXT_ANSWER_LENGTH } from "./answer-limits";
 
 /**
  * Validates the runtime value of a single answer against its question's type

--- a/src/src/styles/wireframes-scoped.css
+++ b/src/src/styles/wireframes-scoped.css
@@ -1182,23 +1182,47 @@
   /* Firefox track override */
   -moz-range-track: none;
 }
-/* WebKit: track */
+/* WebKit: track — unanswered: flat grey; answered: purple fill to --pct */
+.su-assessment-brand .survey-slider-wrap.is-unanswered .survey-slider::-webkit-slider-runnable-track {
+  background: #e4e4e4;
+}
+.su-assessment-brand .survey-slider-wrap:not(.is-unanswered) .survey-slider::-webkit-slider-runnable-track {
+  background: linear-gradient(to right, #522583 0%, #522583 var(--pct, 0%), #e4e4e4 var(--pct, 0%), #e4e4e4 100%);
+}
+/* WebKit: track (base, overridden by unanswered/answered rules above) */
 .su-assessment-brand .survey-slider::-webkit-slider-runnable-track {
   height: 6px;
   border-radius: 3px;
   background: linear-gradient(to right, #522583 0%, #522583 var(--pct, 0%), #e4e4e4 var(--pct, 0%), #e4e4e4 100%);
 }
+/* WebKit: thumb — unanswered: invisible; answered: visible purple */
+.su-assessment-brand .survey-slider-wrap.is-unanswered .survey-slider::-webkit-slider-thumb {
+  opacity: 0;
+  box-shadow: none;
+}
+/* Unanswered: show focus ring on the track area instead of invisible thumb */
+.su-assessment-brand .survey-slider-wrap.is-unanswered .survey-slider:focus-visible {
+  outline: 2px solid #522583;
+  outline-offset: 4px;
+  border-radius: 6px;
+}
+/* Firefox: thumb — unanswered: invisible */
+.su-assessment-brand .survey-slider-wrap.is-unanswered .survey-slider::-moz-range-thumb {
+  opacity: 0;
+  box-shadow: none;
+  border-color: transparent;
+}
 /* WebKit: thumb */
 .su-assessment-brand .survey-slider::-webkit-slider-thumb {
   -webkit-appearance: none;
-  width: 22px;
-  height: 22px;
+  width: 30px;
+  height: 30px;
   border-radius: 50%;
   background: #522583;
   border: 3px solid #fff;
   box-shadow: 0 2px 8px rgba(82, 37, 131, 0.35);
   cursor: pointer;
-  margin-top: -8px; /* vertically centre on the 6px track */
+  margin-top: -12px; /* vertically centre on the 6px track (30px thumb) */
   transition: box-shadow 0.12s, transform 0.1s;
 }
 .su-assessment-brand .survey-slider::-webkit-slider-thumb:hover,
@@ -1219,8 +1243,8 @@
 }
 /* Firefox: thumb */
 .su-assessment-brand .survey-slider::-moz-range-thumb {
-  width: 22px;
-  height: 22px;
+  width: 30px;
+  height: 30px;
   border-radius: 50%;
   background: #522583;
   border: 3px solid #fff;
@@ -1306,6 +1330,27 @@
   border-color: #b9a9d6;
   box-shadow: 0 4px 18px rgba(82, 37, 131, 0.13);
 }
+/* Invalid question card border — focus-independent (R1-M3 / #13 / G6) */
+.su-assessment-brand .survey-question.is-invalid {
+  border-color: hsl(var(--destructive));
+}
+/* Also catch when is-invalid lands on the control inside the card */
+.su-assessment-brand .survey-question:has(.is-invalid) {
+  border-color: hsl(var(--destructive));
+}
+/* Invalid slider track */
+.su-assessment-brand .survey-slider.is-invalid::-webkit-slider-runnable-track {
+  background: hsl(var(--destructive) / 0.25);
+}
+.su-assessment-brand .survey-slider.is-invalid::-moz-range-track {
+  background: hsl(var(--destructive) / 0.25);
+}
+/* Invalid text inputs and checkbox group */
+.su-assessment-brand .survey-textarea.is-invalid,
+.su-assessment-brand .survey-input-number.is-invalid,
+.su-assessment-brand .survey-checkbox-group.is-invalid {
+  border-color: hsl(var(--destructive));
+}
 .su-assessment-brand .survey-question-label {
   display: block;
   font-size: 1rem;
@@ -1315,6 +1360,27 @@
   margin-bottom: 1rem;
 }
 .su-assessment-brand .survey-question-help { margin: -0.5rem 0 0.75rem; font-size: 0.875rem; color: #6b6480; }
+
+/* ---- Brand-styled text inputs (#11) ---- */
+.su-assessment-brand .survey-textarea,
+.su-assessment-brand .survey-input-number {
+  border: 1px solid #cbb8e6;
+  border-radius: 10px;
+  padding: 0.65rem 0.8rem;
+}
+.su-assessment-brand .survey-textarea:focus-visible,
+.su-assessment-brand .survey-input-number:focus-visible {
+  outline: 2px solid #522583;
+  outline-offset: 1px;
+}
+/* Char counter (#12) */
+.su-assessment-brand .survey-char-counter {
+  display: block;
+  margin-top: 0.3rem;
+  font-size: 0.75rem;
+  color: #6b6480;
+  text-align: right;
+}
 
 /* Participant app-shell header (AssessmentShellHeader) — purple appbar + white
    logo + Four-Decisions segmented progress strip. Matches the approved
@@ -1341,6 +1407,20 @@
 @media (max-width: 640px) {
   .su-assessment-brand .su-shell-seg-item { width: 16px; }
   .su-assessment-brand .su-shell-where { white-space: normal; }
+}
+/* Progress bar inside the purple card (#6) — relocated INTO .su-shell-header */
+.su-assessment-brand .su-shell-progress {
+  width: 100%;
+  height: 6px;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.25);
+  margin-top: 0.6rem;
+  overflow: hidden;
+}
+.su-assessment-brand .su-shell-progress .survey-progress-fill {
+  height: 100%;
+  background: #fff;
+  border-radius: 9999px;
 }
 
 /* ===========================================================
@@ -1377,31 +1457,12 @@
   background: var(--su-section-accent);
 }
 
-/* Number badge + step label + section name row */
+/* Step label + section name row (su-intro-num "01" badge removed from JSX — Task 3) */
 .su-assessment-brand .su-intro-kicker {
   display: flex;
   align-items: center;
-  gap: 0.875rem;
+  gap: 0;
   margin: 0.5rem 0 0.25rem;
-}
-.su-assessment-brand .su-intro-num {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex: 0 0 auto;
-  width: 46px;
-  height: 46px;
-  border-radius: 14px;
-  background: color-mix(in srgb, var(--su-section-accent) 14%, #fff);
-  border: 1.5px solid color-mix(in srgb, var(--su-section-accent) 35%, #fff);
-  /* Darken the digit toward black so it stays legible on the light tint for
-     light-luminance domains (People/Cash) — WCAG-AA large text across domains. */
-  color: color-mix(in srgb, var(--su-section-accent) 64%, #000);
-  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-  font-weight: 800;
-  font-size: 1.25rem;
-  line-height: 1;
-  letter-spacing: -0.02em;
 }
 .su-assessment-brand .su-intro-stepblock {
   display: flex;


### PR DESCRIPTION
## Wave C — Assessment Survey Participant UX (Spec 17 #6–#14)

Polishes the participant survey UI across **all** assessments (invited + public; shared `SectionPager` / `QuestionInput` / `AssessmentShellHeader`). Additive, **no migration, no feature flag**.

- **#6/#10** Unified purple card: logo → campaign-name caption → "Section N of M" → one linear progress bar. White header bar + repeating title card removed; segmented strip dropped.
- **#7** Removed the orange "01" section-number badge.
- **#8** Slider thumb hidden + flat empty rail until tapped (no false pre-selection); the minimum is selectable. ← fixes the long-standing stuck-at-min bug for every assessment.
- **#9** Bigger 30px handle.
- **#11/#12** Bordered text/number inputs + placeholders; surfaced the 10k char counter.
- **#13** Per-question red validation — focus-independent red card border, focus jumps to the first miss, per-type contract incl. MULTI_CHOICE; clears per-question on answer.
- **#14** Verify-only (section intro renders).

**Process:** brainstorm → `/grill-with-docs` (G1–G5) → `/grill-me` (G6–G7) → `/claudex:plan` 3-round (16 findings) → `/frontend-design` mockup (approved) → subagent-driven build (8 TDD tasks, each implementer + spec + code-quality review) → whole-branch review (MERGE-READY) + 2 fixes.

**Verification:** build clean (`CI=true next build --turbopack`); ESLint 0/0 on changed files; full suite 3360+ pass (~10 pre-existing/environmental failures only). Preview-smoked live on the public Quick Assessment (blank slider, descriptions, results) — same shared components as the invited flows. Specs: `docs/specs/v7.6/17c-*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)